### PR TITLE
Adhere to telemetry schema 0.0.2

### DIFF
--- a/prometheus/constants.go
+++ b/prometheus/constants.go
@@ -24,12 +24,10 @@ const (
 
 	// The format of the exported data.  This will match this library's version,
 	// which subscribes to the Semantic Versioning scheme.
-	APIVersion = "0.0.1"
+	APIVersion = "0.0.2"
 
-	// When reporting telemetric data over the HTTP web services interface, a web
-	// services interface shall include this header along with APIVersion as its
-	// value.
-	ProtocolVersionHeader = "X-Prometheus-API-Version"
+	// The content type and schema information set on telemetry data responses.
+	TelemetryContentType = `application/json; schema="prometheus/telemetry"; version=` + APIVersion
 
 	// The customary web services endpoint on which telemetric data is exposed.
 	ExpositionResource = "/metrics.json"

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -240,8 +240,7 @@ func (registry registry) Handler() http.HandlerFunc {
 
 		if strings.HasSuffix(url.Path, jsonSuffix) {
 			header := w.Header()
-			header.Set(ProtocolVersionHeader, APIVersion)
-			header.Set(contentTypeHeader, jsonContentType)
+			header.Set(contentTypeHeader, TelemetryContentType)
 
 			writer := decorateWriter(r, w)
 


### PR DESCRIPTION
- The schema and version of telemetry data is exposed through the
  Content-Type header instead of through a custom HTTP Header.

See [Prometheus Client Data Exposition Format](https://docs.google.com/a/soundcloud.com/document/d/1ZjyKiKxZV83VI9ZKAXRGKaUKK2BIWCT7oiGBKDBpjEY/edit#heading=h.wnviarbnyxcj) for more details.

This is dependent on prometheus/prometheus#192
