### PR TITLE
Fix race conditions in metric methods

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -73,7 +73,7 @@ func (metric *counter) ResetAll() {
 	}
 }
 
-func (metric counter) String() string {
+func (metric *counter) String() string {
 	formatString := "[Counter %s]"
 
 	metric.mutex.RLock()
@@ -132,7 +132,7 @@ func (metric *counter) Decrement(labels map[string]string) float64 {
 	return metric.DecrementBy(labels, 1)
 }
 
-func (metric counter) MarshalJSON() ([]byte, error) {
+func (metric *counter) MarshalJSON() ([]byte, error) {
 	metric.mutex.RLock()
 	defer metric.mutex.RUnlock()
 

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -37,7 +37,7 @@ type gauge struct {
 	values map[string]*gaugeVector
 }
 
-func (metric gauge) String() string {
+func (metric *gauge) String() string {
 	formatString := "[Gauge %s]"
 
 	metric.mutex.RLock()
@@ -80,7 +80,7 @@ func (metric *gauge) ResetAll() {
 	}
 }
 
-func (metric gauge) MarshalJSON() ([]byte, error) {
+func (metric *gauge) MarshalJSON() ([]byte, error) {
 	metric.mutex.RLock()
 	defer metric.mutex.RUnlock()
 

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -122,7 +122,7 @@ func (h *histogram) Add(labels map[string]string, value float64) {
 	histogram.buckets[lastIndex].Add(value)
 }
 
-func (h histogram) String() string {
+func (h *histogram) String() string {
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
 
@@ -239,7 +239,7 @@ func formatFloat(value float64) string {
 	return strconv.FormatFloat(value, floatFormat, floatPrecision, floatBitCount)
 }
 
-func (h histogram) MarshalJSON() ([]byte, error) {
+func (h *histogram) MarshalJSON() ([]byte, error) {
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
 


### PR DESCRIPTION
Methods which expect to use a mutex must be defined for the pointer
value, because mutexes are not copyable.
