### PR TITLE
Add method to merge a LabelSet into a Metric with collision avoidance.

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -63,3 +63,18 @@ func (m Metric) String() string {
 		return fmt.Sprintf("%s{%s}", metricName, strings.Join(labelStrings, ", "))
 	}
 }
+
+func (m Metric) MergeFromLabelSet(labels LabelSet, collisionPrefix LabelName) {
+	for k, v := range labels {
+		if collisionPrefix != "" {
+			for {
+				if _, exists := m[k]; !exists {
+					break
+				}
+				k = collisionPrefix + k
+			}
+		}
+
+		m[k] = v
+	}
+}


### PR DESCRIPTION
Colliding labels can happen e.g. when an exporter job is scraped and already
includes "job" labels for its samples in /metrics. In this case, a
collisionPrefix of "exporter_" is added to the colliding target labels, but the
specifics (the collision prefix) are managed by Prometheus, not the client
library.
