### PR TITLE
Register copies the provided baseLabels

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -172,17 +172,21 @@ func (r *registry) Register(name, docstring string, baseLabels map[string]string
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	if baseLabels == nil {
-		baseLabels = map[string]string{}
+	labels := map[string]string{}
+
+	if baseLabels != nil {
+		for k, v := range baseLabels {
+			labels[k] = v
+		}
 	}
 
-	signature, err := r.isValidCandidate(name, baseLabels)
+	signature, err := r.isValidCandidate(name, labels)
 	if err != nil {
 		return err
 	}
 
 	r.signatureContainers[signature] = &container{
-		BaseLabels: baseLabels,
+		BaseLabels: labels,
 		Docstring:  docstring,
 		Metric:     metric,
 		name:       name,

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -38,6 +38,8 @@ func testRegister(t tester) {
 		baseLabels map[string]string
 	}
 
+	validLabels := map[string]string{"label": "value"}
+
 	var scenarios = []struct {
 		inputs  []input
 		outputs []bool
@@ -116,6 +118,22 @@ func testRegister(t tester) {
 			outputs: []bool{
 				true,
 				false,
+			},
+		},
+		{
+			inputs: []input{
+				{
+					name:       "metric_1_with_identical_labels",
+					baseLabels: validLabels,
+				},
+				{
+					name:       "metric_2_with_identical_labels",
+					baseLabels: validLabels,
+				},
+			},
+			outputs: []bool{
+				true,
+				true,
 			},
 		},
 		{


### PR DESCRIPTION
This ensures that you can pass the same base label set into multiple
Register() calls, e.g.:

```
labels := map[string]string{"key": "value"}
prometheus.Register("metric_1", "", labels, ...)
prometheus.Register("metric_2", "", labels, ...)
```
