### PR TITLE
Remove a Go 1.4ism to allow compilation under Go 1.3.

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -427,7 +427,7 @@ func (r *registry) writePB(w io.Writer, writeEncoded encoder) (int, error) {
 
 	// Drain metricChan in case of premature return.
 	defer func() {
-		for range metricChan {
+		for _ = range metricChan {
 		}
 	}()
 


### PR DESCRIPTION
One line syntactic change with no semantic effects.