### PR TITLE
Allow error reporting during metrics collection and simplify Register().

### DIFF
--- a/prometheus/collector.go
+++ b/prometheus/collector.go
@@ -33,8 +33,9 @@ type Collector interface {
 	// duplicate descriptors. Those duplicates are simply ignored. However,
 	// two different Collectors must not send duplicate descriptors.) This
 	// method idempotently sends the same descriptors throughout the
-	// lifetime of the Collector. A Collector unable to describe itself must
-	// send an invalid descriptor (created with NewInvalidDesc).
+	// lifetime of the Collector. If a Collector encounters an error while
+	// executing this method, it must send an invalid descriptor (created
+	// with NewInvalidDesc) to signal the error to the registry.
 	Describe(chan<- *Desc)
 	// Collect is called by Prometheus when collecting metrics. The
 	// implementation sends each collected metric via the provided channel

--- a/prometheus/collector.go
+++ b/prometheus/collector.go
@@ -33,7 +33,8 @@ type Collector interface {
 	// duplicate descriptors. Those duplicates are simply ignored. However,
 	// two different Collectors must not send duplicate descriptors.) This
 	// method idempotently sends the same descriptors throughout the
-	// lifetime of the Collector.
+	// lifetime of the Collector. A Collector unable to describe itself must
+	// send an invalid descriptor (created with NewInvalidDesc).
 	Describe(chan<- *Desc)
 	// Collect is called by Prometheus when collecting metrics. The
 	// implementation sends each collected metric via the provided channel

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -166,6 +166,16 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	return d
 }
 
+// NewInvalidDesc returns an invalid descriptor, i.e. a descriptor with the
+// provided error set. If a collector returning such a descriptor is registered,
+// registration will fail with the provided error. NewInvalidDesc can be used by
+// a Collector to signal inability to describe itself.
+func NewInvalidDesc(err error) *Desc {
+	return &Desc{
+		err: err,
+	}
+}
+
 func (d *Desc) String() string {
 	lpStrings := make([]string, 0, len(d.constLabelPairs))
 	for _, lp := range d.constLabelPairs {

--- a/prometheus/example_selfcollector_test.go
+++ b/prometheus/example_selfcollector_test.go
@@ -49,8 +49,9 @@ func (cm *CallbackMetric) Desc() *prometheus.Desc {
 	return cm.desc
 }
 
-func (cm *CallbackMetric) Write(m *dto.Metric) {
+func (cm *CallbackMetric) Write(m *dto.Metric) error {
 	m.Untyped = &dto.Untyped{Value: proto.Float64(cm.callback())}
+	return nil
 }
 
 func ExampleSelfCollector() {

--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -74,7 +74,7 @@ func ExampleGaugeVec() {
 }
 
 func ExampleGaugeFunc() {
-	if _, err := prometheus.Register(prometheus.NewGaugeFunc(
+	if err := prometheus.Register(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Subsystem: "runtime",
 			Name:      "goroutines_count",
@@ -95,7 +95,7 @@ func ExampleCounter() {
 	pushCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "repository_pushes", // Note: No help string...
 	})
-	_, err := prometheus.Register(pushCounter) // ... so this will return an error.
+	err := prometheus.Register(pushCounter) // ... so this will return an error.
 	if err != nil {
 		fmt.Println("Push counter couldn't be registered, no counting will happen:", err)
 		return
@@ -106,7 +106,7 @@ func ExampleCounter() {
 		Name: "repository_pushes",
 		Help: "Number of pushes to external repository.",
 	})
-	_, err = prometheus.Register(pushCounter)
+	err = prometheus.Register(pushCounter)
 	if err != nil {
 		fmt.Println("Push counter couldn't be registered AGAIN, no counting will happen:", err)
 		return
@@ -194,7 +194,7 @@ func ExampleRegister() {
 		Help:      "Total number of tasks completed.",
 	})
 	// This will register fine.
-	if _, err := prometheus.Register(taskCounter); err != nil {
+	if err := prometheus.Register(taskCounter); err != nil {
 		fmt.Println(err)
 	} else {
 		fmt.Println("taskCounter registered.")
@@ -219,7 +219,7 @@ func ExampleRegister() {
 	)
 
 	// Registering will fail because we already have a metric of that name.
-	if _, err := prometheus.Register(taskCounterVec); err != nil {
+	if err := prometheus.Register(taskCounterVec); err != nil {
 		fmt.Println("taskCounterVec not registered:", err)
 	} else {
 		fmt.Println("taskCounterVec registered.")
@@ -231,7 +231,7 @@ func ExampleRegister() {
 	}
 
 	// Try registering taskCounterVec again.
-	if _, err := prometheus.Register(taskCounterVec); err != nil {
+	if err := prometheus.Register(taskCounterVec); err != nil {
 		fmt.Println("taskCounterVec not registered:", err)
 	} else {
 		fmt.Println("taskCounterVec registered.")
@@ -253,7 +253,7 @@ func ExampleRegister() {
 		},
 		[]string{"worker_id"},
 	)
-	if _, err := prometheus.Register(taskCounterVec); err != nil {
+	if err := prometheus.Register(taskCounterVec); err != nil {
 		fmt.Println("taskCounterVec not registered:", err)
 	} else {
 		fmt.Println("taskCounterVec registered.")
@@ -299,7 +299,7 @@ func ExampleRegister() {
 		ConstLabels: prometheus.Labels{"worker_id": "42"},
 	}
 	taskCounterForWorker42 := prometheus.NewCounter(counterOpts)
-	if _, err := prometheus.Register(taskCounterForWorker42); err != nil {
+	if err := prometheus.Register(taskCounterForWorker42); err != nil {
 		fmt.Println("taskCounterVForWorker42 not registered:", err)
 	} else {
 		fmt.Println("taskCounterForWorker42 registered.")
@@ -313,7 +313,7 @@ func ExampleRegister() {
 	// counterOpts. Just change the ConstLabels.
 	counterOpts.ConstLabels = prometheus.Labels{"worker_id": "2001"}
 	taskCounterForWorker2001 := prometheus.NewCounter(counterOpts)
-	if _, err := prometheus.Register(taskCounterForWorker2001); err != nil {
+	if err := prometheus.Register(taskCounterForWorker2001); err != nil {
 		fmt.Println("taskCounterVForWorker2001 not registered:", err)
 	} else {
 		fmt.Println("taskCounterForWorker2001 registered.")

--- a/prometheus/expvar.go
+++ b/prometheus/expvar.go
@@ -82,36 +82,38 @@ func (e *ExpvarCollector) Collect(ch chan<- Metric) {
 		}
 		var v interface{}
 		labels := make([]string, len(desc.variableLabels))
-		if err := json.Unmarshal([]byte(expVar.String()), &v); err == nil {
-			var processValue func(v interface{}, i int)
-			processValue = func(v interface{}, i int) {
-				if i >= len(labels) {
-					copiedLabels := append(make([]string, 0, len(labels)), labels...)
-					switch v := v.(type) {
-					case float64:
-						m = MustNewConstMetric(desc, UntypedValue, v, copiedLabels...)
-					case bool:
-						if v {
-							m = MustNewConstMetric(desc, UntypedValue, 1, copiedLabels...)
-						} else {
-							m = MustNewConstMetric(desc, UntypedValue, 0, copiedLabels...)
-						}
-					default:
-						return
-					}
-					ch <- m
-					return
-				}
-				vm, ok := v.(map[string]interface{})
-				if !ok {
-					return
-				}
-				for lv, val := range vm {
-					labels[i] = lv
-					processValue(val, i+1)
-				}
-			}
-			processValue(v, 0)
+		if err := json.Unmarshal([]byte(expVar.String()), &v); err != nil {
+			ch <- NewInvalidMetric(desc, err)
+			continue
 		}
+		var processValue func(v interface{}, i int)
+		processValue = func(v interface{}, i int) {
+			if i >= len(labels) {
+				copiedLabels := append(make([]string, 0, len(labels)), labels...)
+				switch v := v.(type) {
+				case float64:
+					m = MustNewConstMetric(desc, UntypedValue, v, copiedLabels...)
+				case bool:
+					if v {
+						m = MustNewConstMetric(desc, UntypedValue, 1, copiedLabels...)
+					} else {
+						m = MustNewConstMetric(desc, UntypedValue, 0, copiedLabels...)
+					}
+				default:
+					return
+				}
+				ch <- m
+				return
+			}
+			vm, ok := v.(map[string]interface{})
+			if !ok {
+				return
+			}
+			for lv, val := range vm {
+				labels[i] = lv
+				processValue(val, i+1)
+			}
+		}
+		processValue(v, 0)
 	}
 }

--- a/prometheus/go_collector_test.go
+++ b/prometheus/go_collector_test.go
@@ -31,7 +31,7 @@ func TestGoCollector(t *testing.T) {
 		select {
 		case metric := <-ch:
 			switch m := metric.(type) {
-			// Attention, this als catches Counter ...
+			// Attention, this also catches Counter...
 			case Gauge:
 				pb := &dto.Metric{}
 				m.Write(pb)
@@ -43,7 +43,7 @@ func TestGoCollector(t *testing.T) {
 				}
 
 				if diff := int(pb.GetGauge().GetValue()) - old; diff != 1 {
-					t.Errorf("want 1 new goroutine, got %f", diff)
+					t.Errorf("want 1 new goroutine, got %d", diff)
 				}
 
 				return

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -242,7 +242,7 @@ func (s *summary) Observe(v float64) {
 	}
 }
 
-func (s *summary) Write(out *dto.Metric) {
+func (s *summary) Write(out *dto.Metric) error {
 	sum := &dto.Summary{}
 	qs := make([]*dto.Quantile, 0, len(s.objectives))
 
@@ -277,6 +277,7 @@ func (s *summary) Write(out *dto.Metric) {
 
 	out.Summary = sum
 	out.Label = s.labelPairs
+	return nil
 }
 
 func (s *summary) newStream() *quantile.Stream {


### PR DESCRIPTION
@juliusv @grobie @xla 

Both are interface changes I want to get in before public
announcement. They only break rare usage cases, and are always easy to
fix, but still we want to avoid breaking changes after a wider
announcement of the project.

The change of Register() simply removes the return of the Collector,
which nobody was using in practice. It was just bloating the call
syntax. Note that this is different from RegisterOrGet(), which is
used at various occasions where you want to register something that
might or might not be registered already, but if it is, you want the
previously registered Collector back (because that's the relevant
one).

WRT error reporting: I first tried the obvious way of letting the
Collector methods Describe() and Collect() return error. However, I
had to conclude that that bloated _many_ calls and their handling in
very obnoxious ways. On the other hand, the case where you actually
want to report errors during registration or collection is very
rare. Hence, this approach has the wrong trade-off. The approach taken
here might at first appear clunky but is in practice quite handy,
mostly because there is almost no change for the "normal" case of "no
special error handling", but also because it plays well with the way
descriptors and metrics are handled (via channels).

Explaining the approach in more detail:

- During registration / describe: Error handling was actually already
  in place (for invalid descriptors, which carry an error anyway). I
  only added a convenience function to create an invalid descriptor
  with a given error on purpose.

- Metrics are now treated in a similar way. The Write method returns
  an error now (the only change in interface). An "invalid metric" is
  provided that can be sent via the channel to signal that that metric
  could not be collected. It alse transports an error.

NON-GOALS OF THIS COMMIT:

This is NOT yet the major improvement of the whole registry part,
where we want a public Registry interface and plenty of modular
configurations (for error handling, various auto-metrics, http
instrumentation, testing, ...). However, we can do that whole thing
without breaking existing interfaces. For now (which is a significant
issue) any error during collection will either cause a 500 HTTP
response or a panic (depending on registry config). Later, we
definitely want to have a possibility to skip (and only report
somehow) non-collectible metrics instead of aborting the whole scrape.