### PR TITLE
Use clear error interface for process pidFn

### DIFF
--- a/prometheus/process_collector_test.go
+++ b/prometheus/process_collector_test.go
@@ -19,7 +19,7 @@ func TestProcessCollector(t *testing.T) {
 	registry := newRegistry()
 	registry.Register(NewProcessCollector(os.Getpid(), ""))
 	registry.Register(NewProcessCollectorPIDFn(
-		func() int { return os.Getpid() }, "foobar"))
+		func() (int, error) { return os.Getpid(), nil }, "foobar"))
 
 	s := httptest.NewServer(InstrumentHandler("prometheus", registry))
 	defer s.Close()


### PR DESCRIPTION
If a given pidFn for a process collector can't determine the pid, this
had to be signaled with an invalid pid so far (pid <= 0). In order to
make the error interface clearer for users, this change introduces an
explicit error parameter.

As requested by @juliusv.

@brian-brazil 

---

I'll handle any possible merge conflict errors depending whether #65 or this change will be merged first.