### PR TITLE
Add 'nocgo' tag to remove cgo dependency on build

### DIFF
--- a/prometheus/process_collector_procfs.go
+++ b/prometheus/process_collector_procfs.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux plan9 solaris
+// +build linux,cgo plan9,cgo solaris,cgo
 
 package prometheus
 

--- a/prometheus/process_collector_rest.go
+++ b/prometheus/process_collector_rest.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux,!plan9,!solaris
+// +build !linux,!plan9,!solaris !cgo
 
 package prometheus
 


### PR DESCRIPTION
This makes it possible to explicitly disable the CGO dependency.

Right now I need this to cross-compile prometheus for raspberry pi. Go disables CGO by default if doing cross compiles. With this change you can cross compile prometheus as easy as:

    GOARCH=arm go build -tags nocgo

/cc @grobie 