### PR TITLE
Reduce allocations during fingerprinting.

### DIFF
--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -38,6 +38,24 @@ func testMetric(t testing.TB) {
 			},
 			fingerprint: 1470933794305433534,
 		},
+		// The following two demonstrate a bug in fingerprinting. They
+		// should not have the same fingerprint with a sane
+		// fingerprinting function. See
+		// https://github.com/prometheus/client_golang/issues/74 .
+		{
+			input: Metric{
+				"a": "bb",
+				"b": "c",
+			},
+			fingerprint: 3734646176939799877,
+		},
+		{
+			input: Metric{
+				"a":  "b",
+				"bb": "c",
+			},
+			fingerprint: 3734646176939799877,
+		},
 	}
 
 	for i, scenario := range scenarios {


### PR DESCRIPTION
Also, add a test to expose
https://github.com/prometheus/client_golang/issues/74 .

benchmark           old ns/op     new ns/op     delta
BenchmarkMetric     7034          6272          -10.83%

benchmark           old allocs     new allocs     delta
BenchmarkMetric     52             32             -38.46%

benchmark           old bytes     new bytes     delta
BenchmarkMetric     1976          1800          -8.91%

@juliusv 