### PR TITLE
Update protobuf library package name.

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -13,7 +13,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 var (

--- a/prometheus/example_selfcollector_test.go
+++ b/prometheus/example_selfcollector_test.go
@@ -16,7 +16,7 @@ package prometheus_test
 import (
 	"runtime"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 

--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -23,7 +23,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -35,7 +35,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/prometheus/client_golang/_vendor/goautoneg"
 	"github.com/prometheus/client_golang/model"

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
 )
 

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -22,7 +22,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // ValueType is an enumeration of metric types that represent a simple value.

--- a/text/create_test.go
+++ b/text/create_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
 )
 

--- a/text/parse.go
+++ b/text/parse.go
@@ -24,7 +24,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/model"
 )
 

--- a/text/parse_test.go
+++ b/text/parse_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
 )
 

--- a/text/proto.go
+++ b/text/proto.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/matttproud/golang_protobuf_extensions/ext"
 
 	dto "github.com/prometheus/client_model/go"


### PR DESCRIPTION
The Golang protocol buffer library has now moved to GitHub:

https://github.com/golang/protobuf

Although "go get"-ing the old package name still works, moving
everything to the new one will make vendoring cleaner.

See also https://github.com/matttproud/golang_protobuf_extensions/pull/7