### PR TITLE
Unify fingerprinting aka signature calculation.

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -14,10 +14,8 @@
 package model
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"strings"
 )
@@ -66,37 +64,7 @@ func (m Metric) String() string {
 
 // Fingerprint returns a Metric's Fingerprint.
 func (m Metric) Fingerprint() Fingerprint {
-	labelNames := make([]string, 0, len(m))
-	maxLength := 0
-
-	for labelName, labelValue := range m {
-		labelNames = append(labelNames, string(labelName))
-		if len(labelName) > maxLength {
-			maxLength = len(labelName)
-		}
-		if len(labelValue) > maxLength {
-			maxLength = len(labelValue)
-		}
-	}
-
-	sort.Strings(labelNames)
-
-	summer := fnv.New64a()
-	buf := make([]byte, maxLength)
-
-	for _, labelName := range labelNames {
-		labelValue := m[LabelName(labelName)]
-
-		copy(buf, labelName)
-		summer.Write(buf[:len(labelName)])
-
-		summer.Write(separator)
-
-		copy(buf, labelValue)
-		summer.Write(buf[:len(labelValue)])
-	}
-
-	return Fingerprint(binary.LittleEndian.Uint64(summer.Sum(nil)))
+	return metricToFingerprint(m)
 }
 
 // Clone returns a copy of the Metric.

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -22,7 +22,7 @@ func testMetric(t testing.TB) {
 	}{
 		{
 			input:       Metric{},
-			fingerprint: 2676020557754725067,
+			fingerprint: 14695981039346656037,
 		},
 		{
 			input: Metric{
@@ -30,31 +30,27 @@ func testMetric(t testing.TB) {
 				"occupation":   "robot",
 				"manufacturer": "westinghouse",
 			},
-			fingerprint: 13260944541294022935,
+			fingerprint: 11310079640881077873,
 		},
 		{
 			input: Metric{
 				"x": "y",
 			},
-			fingerprint: 1470933794305433534,
+			fingerprint: 13948396922932177635,
 		},
-		// The following two demonstrate a bug in fingerprinting. They
-		// should not have the same fingerprint with a sane
-		// fingerprinting function. See
-		// https://github.com/prometheus/client_golang/issues/74 .
 		{
 			input: Metric{
 				"a": "bb",
 				"b": "c",
 			},
-			fingerprint: 3734646176939799877,
+			fingerprint: 3198632812309449502,
 		},
 		{
 			input: Metric{
 				"a":  "b",
 				"bb": "c",
 			},
-			fingerprint: 3734646176939799877,
+			fingerprint: 5774953389407657638,
 		},
 	}
 

--- a/model/signature.go
+++ b/model/signature.go
@@ -63,10 +63,10 @@ func LabelsToSignature(labels map[string]string) uint64 {
 	hb := getHashAndBuf()
 	defer putHashAndBuf(hb)
 
-	for k, v := range labels {
-		hb.b.WriteString(k)
+	for labelName, labelValue := range labels {
+		hb.b.WriteString(labelName)
 		hb.b.WriteByte(SeparatorByte)
-		hb.b.WriteString(v)
+		hb.b.WriteString(labelValue)
 		hb.h.Write(hb.b.Bytes())
 		result ^= hb.h.Sum64()
 		hb.h.Reset()
@@ -75,10 +75,34 @@ func LabelsToSignature(labels map[string]string) uint64 {
 	return result
 }
 
-// LabelValuesToSignature returns a unique signature (i.e., fingerprint) for the
-// values of a given label set.
-func LabelValuesToSignature(labels map[string]string) uint64 {
-	if len(labels) == 0 {
+// metricToFingerprint works exactly as LabelsToSignature but takes a Metric as
+// parameter (rather than a label map) and returns a Fingerprint.
+func metricToFingerprint(m Metric) Fingerprint {
+	if len(m) == 0 {
+		return Fingerprint(emptyLabelSignature)
+	}
+
+	var result uint64
+	hb := getHashAndBuf()
+	defer putHashAndBuf(hb)
+
+	for labelName, labelValue := range m {
+		hb.b.WriteString(string(labelName))
+		hb.b.WriteByte(SeparatorByte)
+		hb.b.WriteString(string(labelValue))
+		hb.h.Write(hb.b.Bytes())
+		result ^= hb.h.Sum64()
+		hb.h.Reset()
+		hb.b.Reset()
+	}
+	return Fingerprint(result)
+}
+
+// SignatureForLabels works like LabelsToSignature but takes a Metric as
+// parameter (rather than a label map) and only includes the labels with the
+// specified LabelNames into the signature calculation.
+func SignatureForLabels(m Metric, labels LabelNames) uint64 {
+	if len(m) == 0 || len(labels) == 0 {
 		return emptyLabelSignature
 	}
 
@@ -86,12 +110,44 @@ func LabelValuesToSignature(labels map[string]string) uint64 {
 	hb := getHashAndBuf()
 	defer putHashAndBuf(hb)
 
-	for _, v := range labels {
-		hb.b.WriteString(v)
+	for _, label := range labels {
+		hb.b.WriteString(string(label))
+		hb.b.WriteByte(SeparatorByte)
+		hb.b.WriteString(string(m[label]))
 		hb.h.Write(hb.b.Bytes())
 		result ^= hb.h.Sum64()
 		hb.h.Reset()
 		hb.b.Reset()
+	}
+	return result
+}
+
+// SignatureWithoutLabels works like LabelsToSignature but takes a Metric as
+// parameter (rather than a label map) and excludes the labels with any of the
+// specified LabelNames from the signature calculation.
+func SignatureWithoutLabels(m Metric, labels map[LabelName]struct{}) uint64 {
+	if len(m) == 0 {
+		return emptyLabelSignature
+	}
+
+	var result uint64
+	hb := getHashAndBuf()
+	defer putHashAndBuf(hb)
+
+	for labelName, labelValue := range m {
+		if _, exclude := labels[labelName]; exclude {
+			continue
+		}
+		hb.b.WriteString(string(labelName))
+		hb.b.WriteByte(SeparatorByte)
+		hb.b.WriteString(string(labelValue))
+		hb.h.Write(hb.b.Bytes())
+		result ^= hb.h.Sum64()
+		hb.h.Reset()
+		hb.b.Reset()
+	}
+	if result == 0 {
+		return emptyLabelSignature
 	}
 	return result
 }

--- a/model/timestamp.go
+++ b/model/timestamp.go
@@ -88,6 +88,7 @@ func (t Timestamp) String() string {
 	return strconv.FormatFloat(float64(t)/float64(second), 'f', -1, 64)
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (t Timestamp) MarshalJSON() ([]byte, error) {
 	return []byte(t.String()), nil
 }


### PR DESCRIPTION
This fixes https://github.com/prometheus/client_golang/issues/74 .

IT CHANGES THE FINGERPRINTING AND THEREFORE INVALIDATES EACH AND EVERY
PERSISTED FINGERPRINT (I.E. YOU HAVE TO WIPE THE STORAGE TO USE THIS).

This commit removes the LabelValuesToSignature function as it is used
nowhere (and broken in the way it is implemented right now).

Also, remove one more golint warning.

@juliusv 