### PR TITLE
Switch to sync.Pool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MAC_OS_X_VERSION ?= 10.8
 
 BUILD_PATH = $(PWD)/.build
 
-export GO_VERSION = 1.4
+export GO_VERSION = 1.4.2
 export GOOS       = $(subst Darwin,darwin,$(subst Linux,linux,$(subst FreeBSD,freebsd,$(OS))))
 
 ifeq ($(GOOS),darwin)


### PR DESCRIPTION
sync.Pool is after all faster than the home-made free list. Especially
under contention. To prove that, this commit also adds a benchmark for
concurrent fingerprint calculation.

Benchmark results:
(Run with -cpu=1,2,4. x-y -> x goroutines with GOMAXPROCS=y.)

benchmark                                     old ns/op     new ns/op     delta
BenchmarkMetricToFingerprintTripleConc4-4     320           138           -56.88%
BenchmarkMetricToFingerprintTripleConc8-4     314           141           -55.10%
BenchmarkMetricToFingerprintTripleConc4-2     344           264           -23.26%
BenchmarkMetricToFingerprintTripleConc2-4     331           256           -22.66%
BenchmarkMetricToFingerprintTripleConc8-2     338           263           -22.19%
BenchmarkMetricToFingerprintTripleConc1-4     599           505           -15.69%
BenchmarkMetricToFingerprintTripleConc4       553           493           -10.85%
BenchmarkMetricToFingerprintTripleConc2-2     327           292           -10.70%
BenchmarkMetricToFingerprintTripleConc8       554           496           -10.47%
BenchmarkMetricToFingerprintTripleConc2       555           501           -9.73%
BenchmarkMetricToFingerprintTripleConc1       554           509           -8.12%
BenchmarkMetricToFingerprintTripleConc1-2     551           513           -6.90%

@juliusv 

![bench-client-golang](https://cloud.githubusercontent.com/assets/5609886/6482903/817ee592-c26b-11e4-80cd-ded55c309d88.png)
