### PR TITLE
Fix renamed library

### DIFF
--- a/text/proto.go
+++ b/text/proto.go
@@ -18,7 +18,7 @@ import (
 	"io"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/matttproud/golang_protobuf_extensions/ext"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -27,7 +27,7 @@ import (
 // protobuf format and returns the number of bytes written and any error
 // encountered.
 func WriteProtoDelimited(w io.Writer, p *dto.MetricFamily) (int, error) {
-	return ext.WriteDelimited(w, p)
+	return pbutil.WriteDelimited(w, p)
 }
 
 // WriteProtoText writes the MetricFamily to the writer in text format and


### PR DESCRIPTION
ext was renamed to pbutil on golang_protobuf_extensions. See https://github.com/matttproud/golang_protobuf_extensions/commit/d23aa0353c6500a97c053615ebd6dcb694d56cc1

Thanks to @brian-brazil for pointing the way.