### PR TITLE
s/ext/pbutil/g

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -20,7 +20,11 @@
 		},
 		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/ext",
-			"Rev": "ba7d65ac66e9da93a714ca18f6d1bc7a0c09100c"
+			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
+		},
+		{
+			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_model/go",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,10 +19,6 @@
 			"Rev": "c22ae3cf020a21ebb7ae566dccbe90fc8ea4f9ea"
 		},
 		{
-			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/ext",
-			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
-		},
-		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
 			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
 		},

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/all_test.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/all_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ext
+package pbutil
 
 import (
 	"bytes"
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 	"testing/quick"
+
+	"github.com/matttproud/golang_protobuf_extensions/pbtest"
 
 	. "github.com/golang/protobuf/proto"
 	. "github.com/golang/protobuf/proto/testdata"
@@ -138,10 +140,10 @@ I expect it may.  Let's hope you enjoy testing as much as we do.`),
 
 func TestEndToEndValid(t *testing.T) {
 	for _, test := range [][]Message{
-		[]Message{&Empty{}},
-		[]Message{&GoEnum{Foo: FOO_FOO1.Enum()}, &Empty{}, &GoEnum{Foo: FOO_FOO1.Enum()}},
-		[]Message{&GoEnum{Foo: FOO_FOO1.Enum()}},
-		[]Message{&Strings{
+		{&Empty{}},
+		{&GoEnum{Foo: FOO_FOO1.Enum()}, &Empty{}, &GoEnum{Foo: FOO_FOO1.Enum()}},
+		{&GoEnum{Foo: FOO_FOO1.Enum()}},
+		{&Strings{
 			StringField: String(`This is my gigantic, unhappy string.  It exceeds
 the encoding size of a single byte varint.  We are using it to fuzz test the
 correctness of the header decoding mechanisms, which may prove problematic.
@@ -173,45 +175,6 @@ I expect it may.  Let's hope you enjoy testing as much as we do.`),
 		if read != written {
 			t.Fatalf("%v read = %d; want %d", test, read, written)
 		}
-	}
-}
-
-// visitMessage empties the private state fields of the quick.Value()-generated
-// Protocol Buffer messages, for they cause an inordinate amount of problems.
-// This is because we are using an automated fuzz generator on a type with
-// private fields.
-func visitMessage(m Message) {
-	t := reflect.TypeOf(m)
-	if t.Kind() != reflect.Ptr {
-		return
-	}
-	derefed := t.Elem()
-	if derefed.Kind() != reflect.Struct {
-		return
-	}
-	v := reflect.ValueOf(m)
-	elem := v.Elem()
-	for i := 0; i < elem.NumField(); i++ {
-		field := elem.FieldByIndex([]int{i})
-		fieldType := field.Type()
-		if fieldType.Implements(reflect.TypeOf((*Message)(nil)).Elem()) {
-			visitMessage(field.Interface().(Message))
-		}
-		if field.Kind() == reflect.Slice {
-			for i := 0; i < field.Len(); i++ {
-				elem := field.Index(i)
-				elemType := elem.Type()
-				if elemType.Implements(reflect.TypeOf((*Message)(nil)).Elem()) {
-					visitMessage(elem.Interface().(Message))
-				}
-			}
-		}
-	}
-	if field := elem.FieldByName("XXX_unrecognized"); field.IsValid() {
-		field.Set(reflect.ValueOf([]byte{}))
-	}
-	if field := elem.FieldByName("XXX_extensions"); field.IsValid() {
-		field.Set(reflect.ValueOf(nil))
 	}
 }
 
@@ -307,7 +270,9 @@ func rndMessage(r *rand.Rand) Message {
 	if !ok {
 		panic("attempt to generate illegal item; consult item 11")
 	}
-	visitMessage(v.Interface().(Message))
+	if err := pbtest.SanitizeGenerated(v.Interface().(Message)); err != nil {
+		panic(err)
+	}
 	return v.Interface().(Message)
 }
 

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/decode.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/decode.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ext
+package pbutil
 
 import (
 	"encoding/binary"

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/doc.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ext enables record length-delimited Protocol Buffer streaming.
-package ext
+// Package pbutil provides record length-delimited Protocol Buffer streaming.
+package pbutil

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/encode.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/encode.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ext
+package pbutil
 
 import (
 	"encoding/binary"

--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/fixtures_test.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/fixtures_test.go
@@ -27,7 +27,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-package ext
+package pbutil
 
 import (
 	. "github.com/golang/protobuf/proto"

--- a/extraction/metricfamilyprocessor.go
+++ b/extraction/metricfamilyprocessor.go
@@ -20,7 +20,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/matttproud/golang_protobuf_extensions/ext"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 
 	"github.com/prometheus/client_golang/model"
 )
@@ -40,7 +40,7 @@ func (m *metricFamilyProcessor) ProcessSingle(i io.Reader, out Ingester, o *Proc
 	for {
 		family.Reset()
 
-		if _, err := ext.ReadDelimited(i, family); err != nil {
+		if _, err := pbutil.ReadDelimited(i, family); err != nil {
 			if err == io.EOF {
 				return nil
 			}

--- a/text/bench_test.go
+++ b/text/bench_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/matttproud/golang_protobuf_extensions/ext"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 )
 
 // Benchmarks to show how much penalty text format parsing actually inflicts.
@@ -101,7 +101,7 @@ func BenchmarkParseProto(b *testing.B) {
 		in := bytes.NewReader(data)
 		for {
 			family.Reset()
-			if _, err := ext.ReadDelimited(in, family); err != nil {
+			if _, err := pbutil.ReadDelimited(in, family); err != nil {
 				if err == io.EOF {
 					break
 				}
@@ -129,7 +129,7 @@ func BenchmarkParseProtoGzip(b *testing.B) {
 		}
 		for {
 			family.Reset()
-			if _, err := ext.ReadDelimited(in, family); err != nil {
+			if _, err := pbutil.ReadDelimited(in, family); err != nil {
 				if err == io.EOF {
 					break
 				}
@@ -156,7 +156,7 @@ func BenchmarkParseProtoMap(b *testing.B) {
 		in := bytes.NewReader(data)
 		for {
 			family := &dto.MetricFamily{}
-			if _, err := ext.ReadDelimited(in, family); err != nil {
+			if _, err := pbutil.ReadDelimited(in, family); err != nil {
 				if err == io.EOF {
 					break
 				}

--- a/text/proto.go
+++ b/text/proto.go
@@ -18,7 +18,7 @@ import (
 	"io"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/matttproud/golang_protobuf_extensions/ext"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -27,7 +27,7 @@ import (
 // protobuf format and returns the number of bytes written and any error
 // encountered.
 func WriteProtoDelimited(w io.Writer, p *dto.MetricFamily) (int, error) {
-	return ext.WriteDelimited(w, p)
+	return pbutil.WriteDelimited(w, p)
 }
 
 // WriteProtoText writes the MetricFamily to the writer in text format and


### PR DESCRIPTION
The dependency matttproud/golang_protobuf_extensions changed its package layout [with this commit](https://github.com/matttproud/golang_protobuf_extensions/commit/d23aa0353c6500a97c053615ebd6dcb694d56cc1) and thereby broke the Prometheus client_golang build. This fixes it.