### PR TITLE
Add garbage collection stats

### DIFF
--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -2,10 +2,12 @@ package prometheus
 
 import (
 	"runtime"
+	"runtime/debug"
 )
 
 type goCollector struct {
 	goroutines Gauge
+	gcDesc     *Desc
 }
 
 // NewGoCollector returns a collector which exports metrics about the current
@@ -16,16 +18,26 @@ func NewGoCollector() *goCollector {
 			Name: "process_goroutines",
 			Help: "Number of goroutines that currently exist.",
 		}),
+		gcDesc: NewDesc(
+			"go_gc_duration_seconds",
+			"A summary of the GC invocation durations.",
+			nil, nil),
 	}
 }
 
 // Describe returns all descriptions of the collector.
 func (c *goCollector) Describe(ch chan<- *Desc) {
 	ch <- c.goroutines.Desc()
+	ch <- c.gcDesc
 }
 
 // Collect returns the current state of all metrics of the collector.
 func (c *goCollector) Collect(ch chan<- Metric) {
 	c.goroutines.Set(float64(runtime.NumGoroutine()))
 	ch <- c.goroutines
+
+	var stats debug.GCStats
+	debug.ReadGCStats(&stats)
+
+	ch <- MustNewConstSummary(c.gcDesc, uint64(stats.NumGC), float64(stats.PauseTotal.Seconds()), nil)
 }


### PR DESCRIPTION
This adds basic garbage collections stats to the metrics that are exported by default by the golang client.