### PR TITLE
Rename process_goroutines to go_goroutines

### DIFF
--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -16,7 +16,7 @@ type goCollector struct {
 func NewGoCollector() *goCollector {
 	return &goCollector{
 		goroutines: NewGauge(GaugeOpts{
-			Name: "process_goroutines",
+			Name: "go_goroutines",
 			Help: "Number of goroutines that currently exist.",
 		}),
 		gcDesc: NewDesc(

--- a/text/testdata/text
+++ b/text/testdata/text
@@ -175,9 +175,9 @@ http_response_size_bytes_count{handler="prometheus"} 119
 # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
 # TYPE process_cpu_seconds_total counter
 process_cpu_seconds_total 0.55
-# HELP process_goroutines Number of goroutines that currently exist.
-# TYPE process_goroutines gauge
-process_goroutines 70
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 70
 # HELP process_max_fds Maximum number of open file descriptors.
 # TYPE process_max_fds gauge
 process_max_fds 8192


### PR DESCRIPTION
The decision was made to use the language name for language specific
metrics, so go_goroutines is the right names similar to
go_gc_duration_seconds.

Fixes #121.