### PR TITLE
Solve "The Proxy Problem" of http.InstrumentHandler

### DIFF
--- a/prometheus/http.go
+++ b/prometheus/http.go
@@ -14,6 +14,9 @@
 package prometheus
 
 import (
+	"bufio"
+	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -141,7 +144,18 @@ func InstrumentHandlerFuncWithOpts(opts SummaryOpts, handlerFunc func(http.Respo
 			urlLen = len(r.URL.String())
 		}
 		go computeApproximateRequestSize(r, out, urlLen)
-		handlerFunc(delegate, r)
+
+		_, cn := w.(http.CloseNotifier)
+		_, fl := w.(http.Flusher)
+		_, hj := w.(http.Hijacker)
+		_, rf := w.(io.ReaderFrom)
+		var rw http.ResponseWriter
+		if cn && fl && hj && rf {
+			rw = &fancyResponseWriterDelegator{delegate}
+		} else {
+			rw = delegate
+		}
+		handlerFunc(rw, r)
 
 		elapsed := float64(time.Since(now)) / float64(time.Microsecond)
 
@@ -194,6 +208,31 @@ func (r *responseWriterDelegator) Write(b []byte) (int, error) {
 	}
 	n, err := r.ResponseWriter.Write(b)
 	r.written += int64(n)
+	return n, err
+}
+
+type fancyResponseWriterDelegator struct {
+	*responseWriterDelegator
+}
+
+func (f *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
+	return f.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+func (f *fancyResponseWriterDelegator) Flush() {
+	f.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return f.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+func (f *fancyResponseWriterDelegator) ReadFrom(r io.Reader) (int64, error) {
+	if !f.wroteHeader {
+		f.WriteHeader(http.StatusOK)
+	}
+	n, err := f.ResponseWriter.(io.ReaderFrom).ReadFrom(r)
+	f.written += n
 	return n, err
 }
 

--- a/prometheus/http.go
+++ b/prometheus/http.go
@@ -178,7 +178,7 @@ type responseWriterDelegator struct {
 
 	handler, method string
 	status          int
-	written         int
+	written         int64
 	wroteHeader     bool
 }
 
@@ -193,7 +193,7 @@ func (r *responseWriterDelegator) Write(b []byte) (int, error) {
 		r.WriteHeader(http.StatusOK)
 	}
 	n, err := r.ResponseWriter.Write(b)
-	r.written += n
+	r.written += int64(n)
 	return n, err
 }
 


### PR DESCRIPTION
`InstrumentHandler` provides proxy object over given `http.ResponseWriter` - `responseWriterDelegator` that only implements the bare minimum required of an `http.ResponseWriter` and doesn’t implement any interface upgrades (`http.Flusher`, `http.Hijacker`, etc.). One example of negative side-effect of this is decreased performance of `http.FileServer` handler after instrumentation.
This PR fixes it by providing `fancyResponseWriterDelegator` with all the fancy bells and whistles if standard library `http.ResponseWriter` is detected. More info [here](https://avtok.com/2014/11/05/interface-upgrades.html#the-proxy-problem).

I also switched `responseWriterDelegator.written` to int64 (to allow responses greater than 4GB) in different commit. If you prefer two different PRs or one PR with squashed commits just let me know.