### PR TITLE
More explicit documentation of SummaryOpts.Objectives.

### DIFF
--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -112,7 +112,9 @@ type SummaryOpts struct {
 	ConstLabels Labels
 
 	// Objectives defines the quantile rank estimates with their respective
-	// absolute error. The default value is DefObjectives.
+	// absolute error. If Objectives[q] = e, then the reported q-quantile
+	// value will be the r-quantile value with r between q-e and q+e.
+	// The default value is DefObjectives.
 	Objectives map[float64]float64
 
 	// MaxAge defines the duration for which an observation stays relevant

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -112,8 +112,8 @@ type SummaryOpts struct {
 	ConstLabels Labels
 
 	// Objectives defines the quantile rank estimates with their respective
-	// absolute error. If Objectives[q] = e, then the reported q-quantile
-	// value will be the r-quantile value with r between q-e and q+e.
+	// absolute error. If Objectives[q] = e, then the value reported
+	// for q will be the φ-quantile value for some φ between q-e and q+e.
 	// The default value is DefObjectives.
 	Objectives map[float64]float64
 


### PR DESCRIPTION
I ended up following the source to the quantile package https://godoc.org/github.com/prometheus/client_golang/Godeps/_workspace/src/github.com/beorn7/perks/quantile#NewTargeted to understand the meaning of `Objectives`, so some kind of documentation change would be appreciated. Maybe this works?