### PR TITLE
Use spaces instead of tabs to align equals (=)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,17 @@ endif
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN
 
-export GOARCH		  = $(subst x86_64,amd64,$(patsubst i%86,386,$(ARCH)))
-export GOPKG		  = go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
-export GOURL		  = https://golang.org/dl
-export GOROOT		  = $(BUILD_PATH)/root/go
-export GOPATH		  = $(BUILD_PATH)/root/gopath
-export GOCC		  = $(GOROOT)/bin/go
-export TMPDIR		  = /tmp
-export GOENV		  = TMPDIR=$(TMPDIR) GOROOT=$(GOROOT) GOPATH=$(GOPATH)
-export GO	          = $(GOENV) $(GOCC)
-export GOFMT		  = $(GOROOT)/bin/gofmt
-export GODOC              = $(GOENV) $(GOROOT)/bin/godoc
+export GOARCH = $(subst x86_64,amd64,$(patsubst i%86,386,$(ARCH)))
+export GOPKG  = go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
+export GOURL  = https://golang.org/dl
+export GOROOT = $(BUILD_PATH)/root/go
+export GOPATH = $(BUILD_PATH)/root/gopath
+export GOCC   = $(GOROOT)/bin/go
+export TMPDIR = /tmp
+export GOENV  = TMPDIR=$(TMPDIR) GOROOT=$(GOROOT) GOPATH=$(GOPATH)
+export GO     = $(GOENV) $(GOCC)
+export GOFMT  = $(GOROOT)/bin/gofmt
+export GODOC  = $(GOENV) $(GOROOT)/bin/godoc
 
 BENCHMARK_FILTER ?= .
 


### PR DESCRIPTION
Using tabs to align things has the downside that people who have set the
tabstop to be of a different lenght than the orignial author's run the
risk of not having the alignment stay. In the current Makefile before
this change people with tabstop of 4 do not see the equals line up.

![set tabstop=4](https://cloud.githubusercontent.com/assets/970540/9044880/76f1f12e-39d4-11e5-9294-25bebffcf7a3.png)
![set tabstop=8](https://cloud.githubusercontent.com/assets/970540/9044881/76f34542-39d4-11e5-807d-c9f701ed2658.png)