### PR TITLE
Update histogram_test.go

### DIFF
--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -124,6 +124,10 @@ func BenchmarkHistogramWrite8(b *testing.B) {
 var testBuckets = []float64{-2, -1, -0.5, 0, 0.5, 1, 2, math.Inf(+1)}
 
 func TestHistogramConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+	
 	rand.Seed(42)
 
 	it := func(n uint32) bool {
@@ -198,6 +202,10 @@ func TestHistogramConcurrency(t *testing.T) {
 }
 
 func TestHistogramVecConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
 	rand.Seed(42)
 
 	objectives := make([]float64, 0, len(DefObjectives))


### PR DESCRIPTION
These tests are always timing out in our Jenkins CI environment. We have moved our timeout to 2 minutes and it still timed out. I have studies the code and can't find any reason for this. There does not appear to be a deadlock at all. The stack traces for the time out change a bit with just the slightest changes in the test code. I have added a check for the short flag so other can skip these tests as we are until this can be identified.