### PR TITLE
Turn allocation test into a benchmark.

### DIFF
--- a/model/signature_test.go
+++ b/model/signature_test.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"runtime"
 	"sync"
 	"testing"
 )
@@ -244,6 +245,26 @@ func BenchmarkMetricToFastFingerprintDouble(b *testing.B) {
 
 func BenchmarkMetricToFastFingerprintTriple(b *testing.B) {
 	benchmarkMetricToFastFingerprint(b, Metric{"first-label": "first-label-value", "second-label": "second-label-value", "third-label": "third-label-value"}, 15738406913934009676)
+}
+
+func BenchmarkEmptyLabelSignature(b *testing.B) {
+	b.StopTimer()
+	input := []map[string]string{nil, {}}
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	alloc := ms.Alloc
+
+	for _, labels := range input {
+		LabelsToSignature(labels)
+	}
+
+	runtime.ReadMemStats(&ms)
+
+	if got := ms.Alloc; alloc != got {
+		b.Error("expected LabelsToSignature with empty labels not to perform allocations")
+	}
 }
 
 func benchmarkMetricToFastFingerprintConc(b *testing.B, m Metric, e Fingerprint, concLevel int) {


### PR DESCRIPTION
It even stays at logging an error. But now it is not in the testing path which should succeed without exception if the code compiles.

@grobie 