### PR TITLE
Remove client_golang/model als direct dependency

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -12,13 +12,16 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
-
-	"github.com/prometheus/client_golang/model"
 )
 
 var (
 	metricNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_:]*$`)
+	labelNameRE  = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 )
+
+// reservedLabelPrefix is a prefix which is not legal in user-supplied
+// label names.
+const reservedLabelPrefix = "__"
 
 // Labels represents a collection of label name -> value mappings. This type is
 // commonly used with the With(Labels) and GetMetricWith(Labels) methods of
@@ -133,7 +136,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	for _, val := range labelValues {
 		b.Reset()
 		b.WriteString(val)
-		b.WriteByte(model.SeparatorByte)
+		b.WriteByte(separatorByte)
 		h.Write(b.Bytes())
 	}
 	d.id = h.Sum64()
@@ -144,12 +147,12 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	h.Reset()
 	b.Reset()
 	b.WriteString(help)
-	b.WriteByte(model.SeparatorByte)
+	b.WriteByte(separatorByte)
 	h.Write(b.Bytes())
 	for _, labelName := range labelNames {
 		b.Reset()
 		b.WriteString(labelName)
-		b.WriteByte(model.SeparatorByte)
+		b.WriteByte(separatorByte)
 		h.Write(b.Bytes())
 	}
 	d.dimHash = h.Sum64()
@@ -193,6 +196,6 @@ func (d *Desc) String() string {
 }
 
 func checkLabelName(l string) bool {
-	return model.LabelNameRE.MatchString(l) &&
-		!strings.HasPrefix(l, model.ReservedLabelPrefix)
+	return labelNameRE.MatchString(l) &&
+		!strings.HasPrefix(l, reservedLabelPrefix)
 }

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/prometheus/client_golang/model"
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -49,6 +48,10 @@ type Histogram interface {
 	Observe(float64)
 }
 
+// bucketLabel is used for the label that defines the upper bound of a
+// bucket of a histogram ("le" -> "less or equal").
+const bucketLabel = "le"
+
 var (
 	// DefBuckets are the default Histogram buckets. The default buckets are
 	// tailored to broadly measure the response time (in seconds) of a
@@ -57,7 +60,7 @@ var (
 	DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
 
 	errBucketLabelNotAllowed = fmt.Errorf(
-		"%q is not allowed as label name in histograms", model.BucketLabel,
+		"%q is not allowed as label name in histograms", bucketLabel,
 	)
 )
 
@@ -171,12 +174,12 @@ func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogr
 	}
 
 	for _, n := range desc.variableLabels {
-		if n == model.BucketLabel {
+		if n == bucketLabel {
 			panic(errBucketLabelNotAllowed)
 		}
 	}
 	for _, lp := range desc.constLabelPairs {
-		if lp.GetName() == model.BucketLabel {
+		if lp.GetName() == bucketLabel {
 			panic(errBucketLabelNotAllowed)
 		}
 	}

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -19,6 +19,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+const separatorByte byte = 255
+
 // A Metric models a single sample value with its meta data being exported to
 // Prometheus. Implementers of Metric in this package inclued Gauge, Counter,
 // Untyped, and Summary. Users can implement their own Metric types, but that

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -38,7 +38,6 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/prometheus/client_golang/model"
 	"github.com/prometheus/client_golang/text"
 )
 
@@ -537,7 +536,7 @@ func (r *registry) checkConsistency(metricFamily *dto.MetricFamily, dtoMetric *d
 	h := fnv.New64a()
 	var buf bytes.Buffer
 	buf.WriteString(metricFamily.GetName())
-	buf.WriteByte(model.SeparatorByte)
+	buf.WriteByte(separatorByte)
 	h.Write(buf.Bytes())
 	// Make sure label pairs are sorted. We depend on it for the consistency
 	// check. Label pairs must be sorted by contract. But the point of this
@@ -547,7 +546,7 @@ func (r *registry) checkConsistency(metricFamily *dto.MetricFamily, dtoMetric *d
 	for _, lp := range dtoMetric.Label {
 		buf.Reset()
 		buf.WriteString(lp.GetValue())
-		buf.WriteByte(model.SeparatorByte)
+		buf.WriteByte(separatorByte)
 		h.Write(buf.Bytes())
 	}
 	metricHash := h.Sum64()

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -25,9 +25,11 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
-
-	"github.com/prometheus/client_golang/model"
 )
+
+// quantileLabel is used for the label that defines the quantile in a
+// summary.
+const quantileLabel = "quantile"
 
 // A Summary captures individual observations from an event or sample stream and
 // summarizes them in a manner similar to traditional summary statistics: 1. sum
@@ -57,7 +59,7 @@ var (
 	DefObjectives = map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
 
 	errQuantileLabelNotAllowed = fmt.Errorf(
-		"%q is not allowed as label name in summaries", model.QuantileLabel,
+		"%q is not allowed as label name in summaries", quantileLabel,
 	)
 )
 
@@ -172,12 +174,12 @@ func newSummary(desc *Desc, opts SummaryOpts, labelValues ...string) Summary {
 	}
 
 	for _, n := range desc.variableLabels {
-		if n == model.QuantileLabel {
+		if n == quantileLabel {
 			panic(errQuantileLabelNotAllowed)
 		}
 	}
 	for _, lp := range desc.constLabelPairs {
-		if lp.GetName() == model.QuantileLabel {
+		if lp.GetName() == quantileLabel {
 			panic(errQuantileLabelNotAllowed)
 		}
 	}


### PR DESCRIPTION
This removes client_golang/model as a direct dependency from the instrumentation.
It's still a dependency via the text parser, however.

It was only used for constants, which are well-specified enough that replicating them is okay.

@brian-brazil @juliusv 