### PR TITLE
Remove client_golang/model dependency from text package

### DIFF
--- a/text/create.go
+++ b/text/create.go
@@ -27,7 +27,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/prometheus/client_golang/model"
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -118,7 +117,7 @@ func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (int, error) {
 			for _, q := range metric.Summary.Quantile {
 				n, err = writeSample(
 					name, metric,
-					model.QuantileLabel, fmt.Sprint(q.GetQuantile()),
+					quantileLabel, fmt.Sprint(q.GetQuantile()),
 					q.GetValue(),
 					out,
 				)
@@ -151,7 +150,7 @@ func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (int, error) {
 			for _, q := range metric.Histogram.Bucket {
 				n, err = writeSample(
 					name+"_bucket", metric,
-					model.BucketLabel, fmt.Sprint(q.GetUpperBound()),
+					bucketLabel, fmt.Sprint(q.GetUpperBound()),
 					float64(q.GetCumulativeCount()),
 					out,
 				)
@@ -166,7 +165,7 @@ func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (int, error) {
 			if !infSeen {
 				n, err = writeSample(
 					name+"_bucket", metric,
-					model.BucketLabel, "+Inf",
+					bucketLabel, "+Inf",
 					float64(metric.Histogram.GetSampleCount()),
 					out,
 				)

--- a/text/parse_test.go
+++ b/text/parse_test.go
@@ -586,3 +586,27 @@ func BenchmarkParseError(b *testing.B) {
 		testParseError(b)
 	}
 }
+
+func TestLabelsToSignature(t *testing.T) {
+	var scenarios = []struct {
+		in  map[string]string
+		out uint64
+	}{
+		{
+			in:  map[string]string{},
+			out: 14695981039346656037,
+		},
+		{
+			in:  map[string]string{"name": "garland, briggs", "fear": "love is not enough"},
+			out: 5799056148416392346,
+		},
+	}
+
+	for i, scenario := range scenarios {
+		actual := labelsToSignature(scenario.in)
+
+		if actual != scenario.out {
+			t.Errorf("%d. expected %d, got %d", i, scenario.out, actual)
+		}
+	}
+}


### PR DESCRIPTION
@brian-brazil @juliusv @beorn7 

As for the instrumentation package the constants are well defined and stable, so replicating is fine. The label set hashing is internal to the package, so it doesn't have to be identical with anything else. Thus, replicating the hashing code is worth dropping the dependency.

With that the instrumentation package no longer depends on client_golang/model at all. Neither does the Prometheus server.

Is there any other place using it? Otherwise we should delete it soon.