### PR TITLE
Make metric sort stable and sort by timestamp

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/expfmt"
@@ -722,5 +723,26 @@ func (s metricSorter) Less(i, j int) bool {
 			return vi < vj
 		}
 	}
-	return true
+	if s[i].GetTimestampMs() != s[j].GetTimestampMs() {
+		// While this is not strictly supported, until we have
+		// an import API some people are having some success
+		// getting data imported by supplying the same metric
+		// with different timestamps.  At the very least we
+		// shouldn't make things more difficult, so ensure that
+		// metrics get ordered by timestamp to make it possible
+		// for Prometheus to import them.
+		ti, tj := s[i].GetTimestampMs(), s[j].GetTimestampMs()
+		if ti == 0 {
+			ti = nowMillis()
+		} else if tj == 0 {
+			tj = nowMillis()
+		}
+		return ti < tj
+	}
+	return false
+}
+
+func nowMillis() int64 {
+	now := time.Now()
+	return now.Unix()*1000 + int64(now.Nanosecond())/1000000
 }


### PR DESCRIPTION
Presently metricSorter is unstable because Less returns "true" instead of "false" when two metrics compare the same.  This means when Collectors emit timestamped metrics in order, this sort will perturb the ordering and result in metrics delivered out-of-order to Prometheus.  This PR fixes the return value for Less.

Since we're going through the trouble of reordering metrics here anyway, explicitly sort by TimestampMs as well.