### PR TITLE
Less locking for metric vectors.

### DIFF
--- a/prometheus/benchmark_test.go
+++ b/prometheus/benchmark_test.go
@@ -14,6 +14,7 @@
 package prometheus
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -30,6 +31,29 @@ func BenchmarkCounterWithLabelValues(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m.WithLabelValues("eins", "zwei", "drei").Inc()
 	}
+}
+
+func BenchmarkCounterWithLabelValuesConcurrent(b *testing.B) {
+	m := NewCounterVec(
+		CounterOpts{
+			Name: "benchmark_counter",
+			Help: "A counter to benchmark it.",
+		},
+		[]string{"one", "two", "three"},
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < b.N/10; j++ {
+				m.WithLabelValues("eins", "zwei", "drei").Inc()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 func BenchmarkCounterWithMappedLabels(b *testing.B) {

--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -15,7 +15,6 @@ package prometheus
 
 import (
 	"errors"
-	"hash/fnv"
 )
 
 // Counter is a Metric that represents a single numerical value that only ever
@@ -97,7 +96,6 @@ func NewCounterVec(opts CounterOpts, labelNames []string) *CounterVec {
 		MetricVec: MetricVec{
 			children: map[uint64]Metric{},
 			desc:     desc,
-			hash:     fnv.New64a(),
 			newMetric: func(lvs ...string) Metric {
 				result := &counter{value: value{
 					desc:       desc,

--- a/prometheus/fnv.go
+++ b/prometheus/fnv.go
@@ -1,0 +1,22 @@
+package prometheus
+
+// Inline and byte-free variant of hash/fnv's fnv64a.
+
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
+// hashNew initializies a new fnv64a hash value.
+func hashNew() uint64 {
+	return offset64
+}
+
+// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
+func hashAdd(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
+}

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -13,8 +13,6 @@
 
 package prometheus
 
-import "hash/fnv"
-
 // Gauge is a Metric that represents a single numerical value that can
 // arbitrarily go up and down.
 //
@@ -77,7 +75,6 @@ func NewGaugeVec(opts GaugeOpts, labelNames []string) *GaugeVec {
 		MetricVec: MetricVec{
 			children: map[uint64]Metric{},
 			desc:     desc,
-			hash:     fnv.New64a(),
 			newMetric: func(lvs ...string) Metric {
 				return newValue(desc, GaugeValue, 0, lvs...)
 			},

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -15,7 +15,6 @@ package prometheus
 
 import (
 	"fmt"
-	"hash/fnv"
 	"math"
 	"sort"
 	"sync/atomic"
@@ -305,7 +304,6 @@ func NewHistogramVec(opts HistogramOpts, labelNames []string) *HistogramVec {
 		MetricVec: MetricVec{
 			children: map[uint64]Metric{},
 			desc:     desc,
-			hash:     fnv.New64a(),
 			newMetric: func(lvs ...string) Metric {
 				return newHistogram(desc, opts, lvs...)
 			},

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -127,7 +127,7 @@ func TestHistogramConcurrency(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
-	
+
 	rand.Seed(42)
 
 	it := func(n uint32) bool {

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -15,7 +15,6 @@ package prometheus
 
 import (
 	"fmt"
-	"hash/fnv"
 	"math"
 	"sort"
 	"sync"
@@ -408,7 +407,6 @@ func NewSummaryVec(opts SummaryOpts, labelNames []string) *SummaryVec {
 		MetricVec: MetricVec{
 			children: map[uint64]Metric{},
 			desc:     desc,
-			hash:     fnv.New64a(),
 			newMetric: func(lvs ...string) Metric {
 				return newSummary(desc, opts, lvs...)
 			},

--- a/prometheus/untyped.go
+++ b/prometheus/untyped.go
@@ -13,8 +13,6 @@
 
 package prometheus
 
-import "hash/fnv"
-
 // Untyped is a Metric that represents a single numerical value that can
 // arbitrarily go up and down.
 //
@@ -75,7 +73,6 @@ func NewUntypedVec(opts UntypedOpts, labelNames []string) *UntypedVec {
 		MetricVec: MetricVec{
 			children: map[uint64]Metric{},
 			desc:     desc,
-			hash:     fnv.New64a(),
 			newMetric: func(lvs ...string) Metric {
 				return newValue(desc, UntypedValue, 0, lvs...)
 			},

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -154,7 +154,7 @@ func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 	if err != nil {
 		return false
 	}
-	if _, has := m.children[h]; !has {
+	if _, ok := m.children[h]; !ok {
 		return false
 	}
 	delete(m.children, h)
@@ -179,7 +179,7 @@ func (m *MetricVec) Delete(labels Labels) bool {
 	if err != nil {
 		return false
 	}
-	if _, has := m.children[h]; !has {
+	if _, ok := m.children[h]; !ok {
 		return false
 	}
 	delete(m.children, h)

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -14,7 +14,6 @@
 package prometheus
 
 import (
-	"hash/fnv"
 	"testing"
 )
 
@@ -23,7 +22,6 @@ func TestDelete(t *testing.T) {
 	vec := MetricVec{
 		children: map[uint64]Metric{},
 		desc:     desc,
-		hash:     fnv.New64a(),
 		newMetric: func(lvs ...string) Metric {
 			return newValue(desc, UntypedValue, 0, lvs...)
 		},
@@ -63,7 +61,6 @@ func TestDeleteLabelValues(t *testing.T) {
 	vec := MetricVec{
 		children: map[uint64]Metric{},
 		desc:     desc,
-		hash:     fnv.New64a(),
 		newMetric: func(lvs ...string) Metric {
 			return newValue(desc, UntypedValue, 0, lvs...)
 		},


### PR DESCRIPTION
Joint work with @alicebob. @beorn7, you seem to know the vector stuff well?

* Inline the label hashing to remove the need to keep around and lock a shared buffer and hash.
* Try looking up metrics with a read lock before falling back to a write-locked "get or create".

This should improve lock contention issues when using variable labels in a concurrent setting. (We're currently using the hacky https://github.com/realzeitmedia/promvec, which avoids locking altogether.)

The benchmark results look quite good. BenchmarkHandler varies a lot between runs, that delta is not always positive.

```
$ benchcmp old.txt new.txt 
benchmark                                       old ns/op     new ns/op     delta
BenchmarkCounterWithLabelValues-4               462           144           -68.83%
BenchmarkCounterWithLabelValuesConcurrent-4     561           91.7          -83.65%
BenchmarkCounterWithMappedLabels-4              2360          760           -67.80%
BenchmarkCounterWithPreparedMappedLabels-4      763           178           -76.67%
BenchmarkCounterNoLabels-4                      26.7          22.8          -14.61%
BenchmarkGaugeWithLabelValues-4                 407           129           -68.30%
BenchmarkGaugeNoLabels-4                        15.7          13.7          -12.74%
BenchmarkSummaryWithLabelValues-4               1672          1550          -7.30%
BenchmarkSummaryNoLabels-4                      1671          1408          -15.74%
BenchmarkHistogramWithLabelValues-4             550           191           -65.27%
BenchmarkHistogramNoLabels-4                    72.5          62.4          -13.93%
BenchmarkHistogramObserve1-4                    53.3          45.7          -14.26%
BenchmarkHistogramObserve2-4                    171           200           +16.96%
BenchmarkHistogramObserve4-4                    433           530           +22.40%
BenchmarkHistogramObserve8-4                    987           1070          +8.41%
BenchmarkHistogramWrite1-4                      5718          4103          -28.24%
BenchmarkHistogramWrite2-4                      6783          5710          -15.82%
BenchmarkHistogramWrite4-4                      12864         12178         -5.33%
BenchmarkHistogramWrite8-4                      25073         22742         -9.30%
BenchmarkHandler-4                              12246782      20103907      +64.16%
BenchmarkSummaryObserve1-4                      1917          1950          +1.72%
BenchmarkSummaryObserve2-4                      5591          4818          -13.83%
BenchmarkSummaryObserve4-4                      12727         12346         -2.99%
BenchmarkSummaryObserve8-4                      26542         25127         -5.33%
BenchmarkSummaryWrite1-4                        23767         20058         -15.61%
BenchmarkSummaryWrite2-4                        48698         46691         -4.12%
BenchmarkSummaryWrite4-4                        92121         92998         +0.95%
BenchmarkSummaryWrite8-4                        196476        182895        -6.91%

benchmark                                       old allocs     new allocs     delta
BenchmarkCounterWithLabelValues-4               0              0              +0.00%
BenchmarkCounterWithLabelValuesConcurrent-4     0              0              +0.00%
BenchmarkCounterWithMappedLabels-4              3              2              -33.33%
BenchmarkCounterWithPreparedMappedLabels-4      1              0              -100.00%
BenchmarkCounterNoLabels-4                      0              0              +0.00%
BenchmarkGaugeWithLabelValues-4                 0              0              +0.00%
BenchmarkGaugeNoLabels-4                        0              0              +0.00%
BenchmarkSummaryWithLabelValues-4               0              0              +0.00%
BenchmarkSummaryNoLabels-4                      0              0              +0.00%
BenchmarkHistogramWithLabelValues-4             0              0              +0.00%
BenchmarkHistogramNoLabels-4                    0              0              +0.00%

benchmark                                       old bytes     new bytes     delta
BenchmarkCounterWithLabelValues-4               0             0             +0.00%
BenchmarkCounterWithLabelValuesConcurrent-4     0             0             +0.00%
BenchmarkCounterWithMappedLabels-4              384           336           -12.50%
BenchmarkCounterWithPreparedMappedLabels-4      48            0             -100.00%
BenchmarkCounterNoLabels-4                      0             0             +0.00%
BenchmarkGaugeWithLabelValues-4                 0             0             +0.00%
BenchmarkGaugeNoLabels-4                        0             0             +0.00%
BenchmarkSummaryWithLabelValues-4               0             0             +0.00%
BenchmarkSummaryNoLabels-4                      0             0             +0.00%
BenchmarkHistogramWithLabelValues-4             0             0             +0.00%
BenchmarkHistogramNoLabels-4                    0             0             +0.00%
```
