### PR TITLE
Strip trailing / from push URL.

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -336,6 +336,9 @@ func (r *registry) Push(job, instance, pushURL, method string) error {
 	if !strings.Contains(pushURL, "://") {
 		pushURL = "http://" + pushURL
 	}
+	if strings.HasSuffix(pushURL, "/") {
+		pushURL = pushURL[:len(pushURL)-1]
+	}
 	pushURL = fmt.Sprintf("%s/metrics/jobs/%s", pushURL, url.QueryEscape(job))
 	if instance != "" {
 		pushURL += "/instances/" + url.QueryEscape(instance)


### PR DESCRIPTION
This circumvents the following problem:
• The prometheus client library appends “/metrics/…” to the pushURL.
• When pushURL ends in a trailing slash, the URL becomes e.g.
  http://pushgateway.example.com:9091//metrics/…
• The pushgateway will reply with an HTTP 307 status code
  (temporary redirect).
• While Go’s net/http client follows redirects by default, it will only
  follow HTTP 302 (Found) and HTTP 303 (See Other) redirects for PUT and
  POST requests, which the prometheus client library uses.

Hence, when calling e.g.:

    prometheus.Push("foo", "bar", "http://pushgateway.example.com:9091/")

…your metrics would not actually get pushed successfully, but rather
you’d see the error message:

    2015/11/26 10:59:49 main.go:209: unexpected status code 307 while pushing to http://push...