### PR TITLE
fix go_memstats_last_gc_time_seconds division

### DIFF
--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -211,7 +211,7 @@ func NewGoCollector() *goCollector {
 					"Number of seconds since 1970 of last garbage collection.",
 					nil, nil,
 				),
-				eval:    func(ms *runtime.MemStats) float64 { return float64(ms.LastGC*10 ^ 9) },
+				eval:    func(ms *runtime.MemStats) float64 { return float64(ms.LastGC) / 1e9 },
 				valType: GaugeValue,
 			},
 		},


### PR DESCRIPTION
'^' is the bitwise XOR, and ms.LastGC is in nanoseconds.

For @beorn7 maybe?