### PR TITLE
add a Registry interface and NewRegistry

### DIFF
--- a/prometheus/process_collector_test.go
+++ b/prometheus/process_collector_test.go
@@ -16,7 +16,7 @@ func TestProcessCollector(t *testing.T) {
 		t.Skipf("skipping TestProcessCollector, procfs not available: %s", err)
 	}
 
-	registry := newRegistry()
+	registry := NewRegistry()
 	registry.Register(NewProcessCollector(os.Getpid(), ""))
 	registry.Register(NewProcessCollectorPIDFn(
 		func() (int, error) { return os.Getpid(), nil }, "foobar"))

--- a/prometheus/push.go
+++ b/prometheus/push.go
@@ -55,7 +55,7 @@ func PushAddCollectors(job, instance, url string, collectors ...Collector) error
 }
 
 func pushCollectors(job, instance, url, method string, collectors ...Collector) error {
-	r := newRegistry()
+	r := NewRegistry()
 	for _, collector := range collectors {
 		if _, err := r.Register(collector); err != nil {
 			return err

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -95,6 +95,7 @@ type Registry interface {
 	RegisterOrGet(c Collector) (Collector, error)
 	Unregister(c Collector) bool
 	Push(job, instance, pushURL, method string) error
+	ServeHTTP(w http.ResponseWriter, req *http.Request)
 }
 
 // UninstrumentedHandler works in the same way as Handler, but the returned HTTP

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -88,6 +88,15 @@ func Handler() http.Handler {
 	return InstrumentHandler("prometheus", defRegistry)
 }
 
+// A Registry holds collected metric data, and knows how to publish that
+// data to a Prometheus server.
+type Registry interface {
+	Register(c Collector) (Collector, error)
+	RegisterOrGet(c Collector) (Collector, error)
+	Unregister(c Collector) bool
+	Push(job, instance, pushURL, method string) error
+}
+
 // UninstrumentedHandler works in the same way as Handler, but the returned HTTP
 // handler is not instrumented. This is useful if no instrumentation is desired
 // (for whatever reason) or if the instrumentation has to happen with a
@@ -211,6 +220,8 @@ type registry struct {
 
 	panicOnCollectError, collectChecksEnabled bool
 }
+
+var _ Registry = (*registry)(nil)
 
 func (r *registry) Register(c Collector) (Collector, error) {
 	descChan := make(chan *Desc, capDescChan)
@@ -659,7 +670,8 @@ func (r *registry) giveMetric(m *dto.Metric) {
 	}
 }
 
-func newRegistry() *registry {
+// NewRegistry creates a new blank registry.
+func NewRegistry() *registry {
 	return &registry{
 		collectorsByID:   map[uint64]Collector{},
 		descIDs:          map[uint64]struct{}{},
@@ -671,7 +683,7 @@ func newRegistry() *registry {
 }
 
 func newDefaultRegistry() *registry {
-	r := newRegistry()
+	r := NewRegistry()
 	r.Register(NewProcessCollector(os.Getpid(), ""))
 	r.Register(NewGoCollector())
 	return r

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -485,7 +485,7 @@ metric: <
 		},
 	}
 	for i, scenario := range scenarios {
-		registry := newRegistry()
+		registry := NewRegistry()
 		registry.collectChecksEnabled = true
 
 		if scenario.collector != nil {


### PR DESCRIPTION
For testing purposes, it would be convenient to create a new
registry that is unrelated to the default registry. For example,
this allows running tests in parallel that update and verify metrics.

@beorn7 