### PR TITLE
Fix max_fds process collector test

### DIFF
--- a/prometheus/process_collector_test.go
+++ b/prometheus/process_collector_test.go
@@ -35,13 +35,13 @@ func TestProcessCollector(t *testing.T) {
 
 	for _, re := range []*regexp.Regexp{
 		regexp.MustCompile("process_cpu_seconds_total [0-9]"),
-		regexp.MustCompile("process_max_fds [0-9]{2,}"),
+		regexp.MustCompile("process_max_fds [1-9]"),
 		regexp.MustCompile("process_open_fds [1-9]"),
 		regexp.MustCompile("process_virtual_memory_bytes [1-9]"),
 		regexp.MustCompile("process_resident_memory_bytes [1-9]"),
 		regexp.MustCompile("process_start_time_seconds [0-9.]{10,}"),
 		regexp.MustCompile("foobar_process_cpu_seconds_total [0-9]"),
-		regexp.MustCompile("foobar_process_max_fds [0-9]{2,}"),
+		regexp.MustCompile("foobar_process_max_fds [1-9]"),
 		regexp.MustCompile("foobar_process_open_fds [1-9]"),
 		regexp.MustCompile("foobar_process_virtual_memory_bytes [1-9]"),
 		regexp.MustCompile("foobar_process_resident_memory_bytes [1-9]"),


### PR DESCRIPTION
This test fails when max_fds is a large value; say 4.5e+06, for example. Change it to match virtual_memory_bytes, which also has to handle large values.