### PR TITLE
prometheus/docs: Added a link to the metric types page

### DIFF
--- a/prometheus/doc.go
+++ b/prometheus/doc.go
@@ -61,7 +61,9 @@
 // It also exports some stats about the HTTP usage of the /metrics
 // endpoint. (See the Handler function for more detail.)
 //
-// Two more advanced metric types are the Summary and Histogram.
+// Two more advanced metric types are the Summary and Histogram. A more
+// thorough description of metric types can be found in the prometheus docs:
+// https://prometheus.io/docs/concepts/metric_types/
 //
 // In addition to the fundamental metric types Gauge, Counter, Summary, and
 // Histogram, a very important part of the Prometheus data model is the


### PR DESCRIPTION
Sorry to driveby like this. Thought it might be useful to link to the metric types doc somewhere