### PR TITLE
Missing alignment issue for 32bit machines.

### DIFF
--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -216,11 +216,12 @@ func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogr
 
 type histogram struct {
 	// sumBits contains the bits of the float64 representing the sum of all
-	// observations. sumBits and count have to go first in the struct to
-	// guarantee alignment for atomic operations.
+	// observations. sumBits, count, and counts have to go first in the struct
+	// to guarantee alignment for atomic operations.
 	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	sumBits uint64
 	count   uint64
+	counts  []uint64
 
 	SelfCollector
 	// Note that there is no mutex required.
@@ -228,7 +229,6 @@ type histogram struct {
 	desc *Desc
 
 	upperBounds []float64
-	counts      []uint64
 
 	labelPairs []*dto.LabelPair
 }


### PR DESCRIPTION
I found this issue as I audited an older version included in coreos/etcd.  The background here is that if you don't take care with the alignment of 64bit fields in structs you can't safely use sync/atomic primitives on them on 32bit architectures.  The comments in the struct look like at some point there care was taken to address this alignment.  Perhaps counts[] was added at a later time?