### PR TITLE
Add *RegisterAll functions with variadic args

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -115,11 +115,13 @@ func Register(m Collector) error {
 }
 
 // MustRegister works like Register but panics where Register would have
-// returned an error.
-func MustRegister(m Collector) {
-	err := Register(m)
-	if err != nil {
-		panic(err)
+// returned an error. MustRegister is also Variadic, where Register only
+// accepts a single Collector to register.
+func MustRegister(m ...Collector) {
+	for i := range m {
+		if err := Register(m[i]); err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This enables a little bit more flexibility and less boilerplate for registering many Collectors.

- One-liner `MustRegisterAll(coll1, coll2, coll3, coll4)`
- Spread a slice `MustRegisterAll(collectors...)`