### PR TITLE
Added support for relatetive path when Prom API is behind nginx

### DIFF
--- a/api/prometheus/api.go
+++ b/api/prometheus/api.go
@@ -107,7 +107,7 @@ func New(cfg Config) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	u.Path = apiPrefix
+	u.Path = u.Path + apiPrefix
 
 	return &httpClient{
 		endpoint:  u,


### PR DESCRIPTION
If Prometheus is behind Nginx at some path, e.g. `/prometheus`, this change will allow to pass the address along with relative URL and will not be ignored.

```
config := prometheus.Config{Address: "http://my-nginx/prometheus")}
```

Currently, `/prometheus` is ignored in this example and the path is hardcoded to `apiPrefix      = "/api/v1"`