### PR TITLE
Add support for Beaer Token Authorization

### DIFF
--- a/api/examples/instance/instance.go
+++ b/api/examples/instance/instance.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A simple example exposing the usage of Range Vector Selectors.
+
+package instance
+
+import (
+	"time"
+
+	"github.com/oscarzhao/client_golang/api/prometheus" // need to update when pull request
+	prometheusModel "github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+)
+
+// Query executes a  query to Prometheus Server
+func Query(addr, token, queryString string, ts time.Time) (prometheusModel.Value, error) {
+	// create configuration
+	c := prometheus.Config{
+		Address: addr,
+	}
+	pClient, err := prometheus.New(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a query api client
+	queryAPI := prometheus.NewQueryAPI(pClient)
+
+	rawResults, err := queryAPI.Query(context.WithValue(context.Background(), prometheus.ContextBearerTokenKey, token), queryString, ts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rawResults, nil
+}

--- a/api/examples/instance/instance_test.go
+++ b/api/examples/instance/instance_test.go
@@ -1,0 +1,46 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A test case exposing how to send a instance query (with beaer token)
+
+package instance
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestGetNodeMemoryUsage(t *testing.T) {
+	// Range Vector Selectors
+	queryString := `container_memory_usage_bytes
+    {
+        instance="192.168.1.25",job="kubernetes-nodes",kubernetes_io_hostname="192.168.1.25",id="/"
+    }[5m]
+  `
+	// url is proxied by kubernetes API Server, and verified by API Server
+	addr := "https://192.168.1.24:6443/api/v1/proxy/namespaces/kube-system/services/prometheus-monitor:9090/"
+	token := "z7jCgNcP4oNIqXJhA2IJPRD4DrTJ6jhN" // ignore if addr is http
+	ts := time.Now()
+
+	results, err := Query(addr, token, queryString, ts)
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok {
+			t.Fatalf("query node cpu/usage_rate fails, url error:%#v\n", urlErr.Err.Error())
+		} else {
+			t.Fatalf("query node cpu/usage_rate fails, error:%#v\n", err)
+		}
+
+	}
+	t.Logf("type:%s\n data: %s\n", results.Type(), results.String())
+}

--- a/api/examples/ranges/vector.go
+++ b/api/examples/ranges/vector.go
@@ -1,0 +1,51 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A simple example exposing the usage of Range Vector Selectors.
+
+package ranges
+
+import (
+	"time"
+
+	"github.com/oscarzhao/client_golang/api/prometheus" // need to update when pull request
+	prometheusModel "github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+)
+
+// QueryRange executes a range vector query to Prometheus Server
+func QueryRange(addr, token, queryString string, start, end time.Time) (prometheusModel.Value, error) {
+	// create configuration
+	c := prometheus.Config{
+		Address: addr,
+	}
+	pClient, err := prometheus.New(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a query api client
+	queryAPI := prometheus.NewQueryAPI(pClient)
+
+	rawResults, err := queryAPI.QueryRange(context.WithValue(context.Background(), prometheus.ContextBearerTokenKey, token), queryString, prometheus.Range{
+		Start: start,
+		End:   end,
+		Step:  time.Minute,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rawResults, nil
+}

--- a/api/examples/ranges/vector_test.go
+++ b/api/examples/ranges/vector_test.go
@@ -1,0 +1,52 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A test case exposing how to send a Range Selector query (with beaer token)
+
+package ranges
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestGetNodeCPU(t *testing.T) {
+	// Range Vector Selectors
+	queryString := `delta(
+container_cpu_usage_seconds_total
+    {
+        instance="192.168.1.25",
+        job="kubernetes-nodes",
+        kubernetes_io_hostname="192.168.1.25",
+        id="/"
+    }[5m]
+)
+  `
+	// url is proxied by kubernetes API Server, and verified by API Server
+	addr := "https://192.168.1.24:6443/api/v1/proxy/namespaces/kube-system/services/prometheus-monitor:9090/"
+	token := "z7jCgNcP4oNIqXJhA2IJPRD4DrTJ6jhN" // ignore if addr is http
+	start := time.Now().Add(-time.Hour)
+	end := time.Now()
+
+	results, err := QueryRange(addr, token, queryString, start, end)
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok {
+			t.Fatalf("query node cpu/usage_rate fails, url error:%#v\n", urlErr.Err.Error())
+		} else {
+			t.Fatalf("query node cpu/usage_rate fails, error:%#v\n", err)
+		}
+
+	}
+	t.Logf("type:%s\n data: %s\n", results.Type(), results.String())
+}

--- a/api/prometheus/api.go
+++ b/api/prometheus/api.go
@@ -161,6 +161,11 @@ func (c *httpClient) url(ep string, args map[string]string) *url.URL {
 }
 
 func (c *httpClient) do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	if beaerToken, ok := ctx.Value(ContextBearerTokenKey).(string); ok {
+		if len(beaerToken) > 0 {
+			req.Header.Set("Authorization", "Bearer "+beaerToken)
+		}
+	}
 	resp, err := ctxhttp.Do(ctx, &http.Client{Transport: c.transport}, req)
 
 	defer func() {
@@ -356,12 +361,6 @@ func (h *httpQueryAPI) QueryRange(ctx context.Context, query string, r Range) (m
 	u.RawQuery = q.Encode()
 
 	req, _ := http.NewRequest("GET", u.String(), nil)
-
-	if beaerToken, ok := ctx.Value(ContextBearerTokenKey).(string); ok {
-		if len(beaerToken) > 0 {
-			req.Header.Set("Authorization", "Bearer "+beaerToken)
-		}
-	}
 
 	_, body, err := h.client.do(ctx, req)
 	if err != nil {

--- a/api/prometheus/api_test.go
+++ b/api/prometheus/api_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestConfig(t *testing.T) {
 	c := Config{}
-	if c.transport() != DefaultTransport {
+	if c.transport() != DefaultHTTPTransport {
 		t.Fatalf("expected default transport for nil Transport field")
 	}
 }
@@ -108,7 +108,7 @@ func TestClientURL(t *testing.T) {
 
 		hclient := &httpClient{
 			endpoint:  ep,
-			transport: DefaultTransport,
+			transport: DefaultHTTPTransport,
 		}
 
 		u := hclient.url(test.endpoint, test.args)


### PR DESCRIPTION
Default Prometheus Server is visited with no authorization. In kubernetes, we can use API Server to proxy requests to prometheus service, API Server often has a token, so I add support to token authorization to the client
