### PR TITLE
desc: Allow initial colon in metric name

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	metricNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_:]*$`)
+	metricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 	labelNameRE  = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 )
 


### PR DESCRIPTION
Match the documented regex:
    https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

The Java and Python first-party libraries allow the initial colon:
- java: https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Collector.java#L142
- python: https://github.com/prometheus/client_python/blob/master/prometheus_client/core.py#L26

The Ruby library requires that the name be a symbol, which is less restrictive:
  https://github.com/prometheus/client_ruby/blob/master/lib/prometheus/client/metric.rb#L49