### PR TITLE
Remove local REs for label and metric names and use fast checks

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -16,18 +16,13 @@ package prometheus
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/common/model"
 
 	dto "github.com/prometheus/client_model/go"
-)
-
-var (
-	metricNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_:]*$`)
-	labelNameRE  = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 )
 
 // reservedLabelPrefix is a prefix which is not legal in user-supplied
@@ -103,7 +98,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 		d.err = errors.New("empty help string")
 		return d
 	}
-	if !metricNameRE.MatchString(fqName) {
+	if !model.IsValidMetricName(model.LabelValue(fqName)) {
 		d.err = fmt.Errorf("%q is not a valid metric name", fqName)
 		return d
 	}
@@ -200,6 +195,6 @@ func (d *Desc) String() string {
 }
 
 func checkLabelName(l string) bool {
-	return labelNameRE.MatchString(l) &&
+	return model.LabelName(l).IsValid() &&
 		!strings.HasPrefix(l, reservedLabelPrefix)
 }

--- a/prometheus/push/push.go
+++ b/prometheus/push/push.go
@@ -84,7 +84,7 @@ func push(job string, grouping map[string]string, pushURL string, g prometheus.G
 	}
 	urlComponents := []string{url.QueryEscape(job)}
 	for ln, lv := range grouping {
-		if !model.LabelNameRE.MatchString(ln) {
+		if !model.LabelName(ln).IsValid() {
 			return fmt.Errorf("grouping label has invalid name: %s", ln)
 		}
 		if strings.Contains(lv, "/") {


### PR DESCRIPTION
All was a mess, we had duplicates of the REs for label name and metric
names here, and we sometimes used them, sometimes we used those from
common/model.

Now we are consistently using the fast checking functions from common/model.

(Tests for leading colons are included there, see
https://github.com/prometheus/common/pull/66 .)

@stuartnelson3 @grobie @kamalmarhubi