### PR TITLE
Adjust examples to modern usage

### DIFF
--- a/examples/random/main.go
+++ b/examples/random/main.go
@@ -25,13 +25,14 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
 	addr              = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
-	uniformDomain     = flag.Float64("uniform.domain", 200, "The domain for the uniform distribution.")
-	normDomain        = flag.Float64("normal.domain", 200, "The domain for the normal distribution.")
-	normMean          = flag.Float64("normal.mean", 10, "The mean for the normal distribution.")
+	uniformDomain     = flag.Float64("uniform.domain", 0.0002, "The domain for the uniform distribution.")
+	normDomain        = flag.Float64("normal.domain", 0.0002, "The domain for the normal distribution.")
+	normMean          = flag.Float64("normal.mean", 0.00001, "The mean for the normal distribution.")
 	oscillationPeriod = flag.Duration("oscillation-period", 10*time.Minute, "The duration of the rate oscillation period.")
 )
 
@@ -41,7 +42,7 @@ var (
 	// differentiated via a "service" label.
 	rpcDurations = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "rpc_durations_microseconds",
+			Name: "rpc_durations_seconds",
 			Help: "RPC latency distributions.",
 		},
 		[]string{"service"},
@@ -51,7 +52,7 @@ var (
 	// normal distribution, with 20 buckets centered on the mean, each
 	// half-sigma wide.
 	rpcDurationsHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "rpc_durations_histogram_microseconds",
+		Name:    "rpc_durations_histogram_seconds",
 		Help:    "RPC latency distributions.",
 		Buckets: prometheus.LinearBuckets(*normMean-5**normDomain, .5**normDomain, 20),
 	})
@@ -92,13 +93,13 @@ func main() {
 
 	go func() {
 		for {
-			v := rand.ExpFloat64()
+			v := rand.ExpFloat64() / 1e6
 			rpcDurations.WithLabelValues("exponential").Observe(v)
 			time.Sleep(time.Duration(50*oscillationFactor()) * time.Millisecond)
 		}
 	}()
 
 	// Expose the registered metrics via HTTP.
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -19,13 +19,13 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var addr = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
 
 func main() {
 	flag.Parse()
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
- Use seconds instead of microseconds.
- Use promhttp.Handler instead of prometheus.Handler

@grobie @iamjarvo