### PR TITLE
goCollector: add thread count gauge in goCollector

### DIFF
--- a/prometheus/go_collector_test.go
+++ b/prometheus/go_collector_test.go
@@ -33,6 +33,9 @@ func TestGoCollector(t *testing.T) {
 			switch m := metric.(type) {
 			// Attention, this also catches Counter...
 			case Gauge:
+				if m.Desc().fqName != "go_goroutines" {
+					continue
+				}
 				pb := &dto.Metric{}
 				m.Write(pb)
 				if pb.GetGauge() == nil {
@@ -50,9 +53,10 @@ func TestGoCollector(t *testing.T) {
 					t.Errorf("want 1 new goroutine, got %d", diff)
 				}
 
-				// GoCollector performs two sends per call.
+				// GoCollector performs three sends per call.
 				// On line 27 we need to receive the second send
 				// to shut down cleanly.
+				<-ch
 				<-ch
 				return
 			}

--- a/prometheus/go_collector_test.go
+++ b/prometheus/go_collector_test.go
@@ -29,37 +29,36 @@ func TestGoCollector(t *testing.T) {
 
 	for {
 		select {
-		case metric := <-ch:
-			switch m := metric.(type) {
-			// Attention, this also catches Counter...
-			case Gauge:
-				if m.Desc().fqName != "go_goroutines" {
-					continue
-				}
-				pb := &dto.Metric{}
-				m.Write(pb)
-				if pb.GetGauge() == nil {
-					continue
-				}
-
-				if old == -1 {
-					old = int(pb.GetGauge().GetValue())
-					close(waitc)
-					continue
-				}
-
-				if diff := int(pb.GetGauge().GetValue()) - old; diff != 1 {
-					// TODO: This is flaky in highly concurrent situations.
-					t.Errorf("want 1 new goroutine, got %d", diff)
-				}
-
-				// GoCollector performs three sends per call.
-				// On line 27 we need to receive the second send
-				// to shut down cleanly.
-				<-ch
-				<-ch
-				return
+		case m := <-ch:
+			// m can be Gauge or Counter,
+			// currently just test the go_goroutines Gauge
+			// and ignore others.
+			if m.Desc().fqName != "go_goroutines" {
+				continue
 			}
+			pb := &dto.Metric{}
+			m.Write(pb)
+			if pb.GetGauge() == nil {
+				continue
+			}
+
+			if old == -1 {
+				old = int(pb.GetGauge().GetValue())
+				close(waitc)
+				continue
+			}
+
+			if diff := int(pb.GetGauge().GetValue()) - old; diff != 1 {
+				// TODO: This is flaky in highly concurrent situations.
+				t.Errorf("want 1 new goroutine, got %d", diff)
+			}
+
+			// GoCollector performs three sends per call.
+			// On line 27 we need to receive the second send
+			// to shut down cleanly.
+			<-ch
+			<-ch
+			return
 		case <-time.After(1 * time.Second):
 			t.Fatalf("expected collect timed out")
 		}


### PR DESCRIPTION
@beorn7 I want to add a threads count gauge in the default go collector, but I just make a workaround to pass the unit test, and I am thinking a way to test it.
Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>