### PR TITLE
new handler instrumentation

### DIFF
--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -313,7 +313,7 @@ func NewHistogramVec(opts HistogramOpts, labelNames []string) *HistogramVec {
 func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
-		return metric.(Histogram), err
+		return metric.(Observer), err
 	}
 	return nil, err
 }
@@ -324,7 +324,7 @@ func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error)
 func (m *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)
 	if metric != nil {
-		return metric.(Histogram), err
+		return metric.(Observer), err
 	}
 	return nil, err
 }
@@ -334,14 +334,14 @@ func (m *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
 // error, WithLabelValues allows shortcuts like
 //     myVec.WithLabelValues("404", "GET").Observe(42.21)
 func (m *HistogramVec) WithLabelValues(lvs ...string) Observer {
-	return m.MetricVec.WithLabelValues(lvs...).(Histogram)
+	return m.MetricVec.WithLabelValues(lvs...).(Observer)
 }
 
 // With works as GetMetricWith, but panics where GetMetricWithLabels would have
 // returned an error. By not returning an error, With allows shortcuts like
 //     myVec.With(Labels{"code": "404", "method": "GET"}).Observe(42.21)
 func (m *HistogramVec) With(labels Labels) Observer {
-	return m.MetricVec.With(labels).(Histogram)
+	return m.MetricVec.With(labels).(Observer)
 }
 
 type constHistogram struct {

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -308,7 +308,7 @@ func NewHistogramVec(opts HistogramOpts, labelNames []string) *HistogramVec {
 }
 
 // GetMetricWithLabelValues replaces the method of the same name in
-// MetricVec. The difference is that this method returns a Observer and not a
+// MetricVec. The difference is that this method returns an Observer and not a
 // Metric so that no type conversion is required.
 func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
@@ -319,7 +319,7 @@ func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error)
 }
 
 // GetMetricWith replaces the method of the same name in MetricVec. The
-// difference is that this method returns a Observer and not a Metric so that no
+// difference is that this method returns an Observer and not a Metric so that no
 // type conversion is required.
 func (m *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -309,7 +309,7 @@ func NewHistogramVec(opts HistogramOpts, labelNames []string) *HistogramVec {
 
 // GetMetricWithLabelValues replaces the method of the same name in
 // MetricVec. The difference is that this method returns an Observer and not a
-// Metric so that no type conversion is required.
+// Metric so that no type conversion to an Observer is required.
 func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
@@ -320,7 +320,7 @@ func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error)
 
 // GetMetricWith replaces the method of the same name in MetricVec. The
 // difference is that this method returns an Observer and not a Metric so that no
-// type conversion is required.
+// type conversion to an Observer is required.
 func (m *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)
 	if metric != nil {

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -308,9 +308,9 @@ func NewHistogramVec(opts HistogramOpts, labelNames []string) *HistogramVec {
 }
 
 // GetMetricWithLabelValues replaces the method of the same name in
-// MetricVec. The difference is that this method returns a Histogram and not a
+// MetricVec. The difference is that this method returns a Observer and not a
 // Metric so that no type conversion is required.
-func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Histogram, error) {
+func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
 		return metric.(Histogram), err
@@ -319,9 +319,9 @@ func (m *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Histogram, error
 }
 
 // GetMetricWith replaces the method of the same name in MetricVec. The
-// difference is that this method returns a Histogram and not a Metric so that no
+// difference is that this method returns a Observer and not a Metric so that no
 // type conversion is required.
-func (m *HistogramVec) GetMetricWith(labels Labels) (Histogram, error) {
+func (m *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)
 	if metric != nil {
 		return metric.(Histogram), err
@@ -333,14 +333,14 @@ func (m *HistogramVec) GetMetricWith(labels Labels) (Histogram, error) {
 // GetMetricWithLabelValues would have returned an error. By not returning an
 // error, WithLabelValues allows shortcuts like
 //     myVec.WithLabelValues("404", "GET").Observe(42.21)
-func (m *HistogramVec) WithLabelValues(lvs ...string) Histogram {
+func (m *HistogramVec) WithLabelValues(lvs ...string) Observer {
 	return m.MetricVec.WithLabelValues(lvs...).(Histogram)
 }
 
 // With works as GetMetricWith, but panics where GetMetricWithLabels would have
 // returned an error. By not returning an error, With allows shortcuts like
 //     myVec.With(Labels{"code": "404", "method": "GET"}).Observe(42.21)
-func (m *HistogramVec) With(labels Labels) Histogram {
+func (m *HistogramVec) With(labels Labels) Observer {
 	return m.MetricVec.With(labels).(Histogram)
 }
 

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -286,7 +286,7 @@ func TestHistogramVecConcurrency(t *testing.T) {
 		for i := 0; i < vecLength; i++ {
 			m := &dto.Metric{}
 			s := his.WithLabelValues(string('A' + i))
-			s.Write(m)
+			s.(Histogram).Write(m)
 
 			if got, want := len(m.Histogram.Bucket), len(testBuckets)-1; got != want {
 				t.Errorf("got %d buckets in protobuf, want %d", got, want)

--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -1,3 +1,16 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package prometheus
 
 // Observer is the interface that wraps the Observe method, which is used by

--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -1,0 +1,71 @@
+package prometheus
+
+// Observer is the interface that wraps the Observe method, which is used by
+// Histogram and Summary to add observations.
+type Observer interface {
+	Observe(float64)
+}
+
+// The ObserverFunc type is an adapter to allow the use of ordinary
+// functions as Observers. If f is a function with the appropriate
+// signature, ObserverFunc(f) is an Observer that calls f.
+//
+// This adapter is usually used in connection with the Timer type, and there are
+// two general use cases:
+//
+// The most common one is to use a Gauge as the Observer for a Timer.
+// See the "Gauge" Timer example.
+//
+// The more advanced use case is to create a function that dynamically decides
+// which Observer to use for observing the duration. See the "Complex" Timer
+// example.
+type ObserverFunc func(float64)
+
+// Observe calls f(value). It implements Observer.
+func (f ObserverFunc) Observe(value float64) {
+	f(value)
+}
+
+// ObserverVec implements MetricVec for the purpose of using instance labels
+// for an Observer.
+type ObserverVec struct {
+	*MetricVec
+	Observer
+}
+
+// GetMetricWithLabelValues replaces the method of the same name in
+// MetricVec. The difference is that this method returns a Summary and not a
+// Metric so that no type conversion is required.
+func (m *ObserverVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
+	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
+	if metric != nil {
+		return metric.(Observer), err
+	}
+	return nil, err
+}
+
+// GetMetricWith replaces the method of the same name in MetricVec. The
+// difference is that this method returns a Observer and not a Metric so that no
+// type conversion is required.
+func (m *ObserverVec) GetMetricWith(labels Labels) (Observer, error) {
+	metric, err := m.MetricVec.GetMetricWith(labels)
+	if metric != nil {
+		return metric.(Observer), err
+	}
+	return nil, err
+}
+
+// WithLabelValues works as GetMetricWithLabelValues, but panics where
+// GetMetricWithLabelValues would have returned an error. By not returning an
+// error, WithLabelValues allows shortcuts like
+//     myVec.WithLabelValues("404", "GET").Observe(42.21)
+func (m *ObserverVec) WithLabelValues(lvs ...string) Observer {
+	return m.MetricVec.WithLabelValues(lvs...).(Observer)
+}
+
+// With works as GetMetricWith, but panics where GetMetricWithLabels would have
+// returned an error. By not returning an error, With allows shortcuts like
+//     myVec.With(Labels{"code": "404", "method": "GET"}).Observe(42.21)
+func (m *ObserverVec) With(labels Labels) Observer {
+	return m.MetricVec.With(labels).(Observer)
+}

--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -28,44 +28,9 @@ func (f ObserverFunc) Observe(value float64) {
 
 // ObserverVec implements MetricVec for the purpose of using instance labels
 // for an Observer.
-type ObserverVec struct {
-	*MetricVec
-	Observer
-}
-
-// GetMetricWithLabelValues replaces the method of the same name in
-// MetricVec. The difference is that this method returns a Summary and not a
-// Metric so that no type conversion is required.
-func (m *ObserverVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
-	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
-	if metric != nil {
-		return metric.(Observer), err
-	}
-	return nil, err
-}
-
-// GetMetricWith replaces the method of the same name in MetricVec. The
-// difference is that this method returns a Observer and not a Metric so that no
-// type conversion is required.
-func (m *ObserverVec) GetMetricWith(labels Labels) (Observer, error) {
-	metric, err := m.MetricVec.GetMetricWith(labels)
-	if metric != nil {
-		return metric.(Observer), err
-	}
-	return nil, err
-}
-
-// WithLabelValues works as GetMetricWithLabelValues, but panics where
-// GetMetricWithLabelValues would have returned an error. By not returning an
-// error, WithLabelValues allows shortcuts like
-//     myVec.WithLabelValues("404", "GET").Observe(42.21)
-func (m *ObserverVec) WithLabelValues(lvs ...string) Observer {
-	return m.MetricVec.WithLabelValues(lvs...).(Observer)
-}
-
-// With works as GetMetricWith, but panics where GetMetricWithLabels would have
-// returned an error. By not returning an error, With allows shortcuts like
-//     myVec.With(Labels{"code": "404", "method": "GET"}).Observe(42.21)
-func (m *ObserverVec) With(labels Labels) Observer {
-	return m.MetricVec.With(labels).(Observer)
+type ObserverVec interface {
+	GetMetricWith(Labels) (Observer, error)
+	GetMetricWithLabelValues(lvs ...string) (Observer, error)
+	With(Labels) Observer
+	WithLabelValues(...string) Observer
 }

--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -26,11 +26,12 @@ func (f ObserverFunc) Observe(value float64) {
 	f(value)
 }
 
-// ObserverVec implements MetricVec for the purpose of using instance labels
-// for an Observer.
+// ObserverVec is an interface implemented by `HistogramVec` and `SummaryVec`.
 type ObserverVec interface {
 	GetMetricWith(Labels) (Observer, error)
 	GetMetricWithLabelValues(lvs ...string) (Observer, error)
 	With(Labels) Observer
 	WithLabelValues(...string) Observer
+
+	Collector
 }

--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -28,7 +28,7 @@ func newDelegator(w http.ResponseWriter) delegator {
 	_, hj := w.(http.Hijacker)
 	_, rf := w.(io.ReaderFrom)
 	if cn && fl && hj && rf {
-		return &classicFancyResponseWriterDelegator{d}
+		return &fancyDelegator{d}
 	}
 
 	return d

--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -13,9 +13,6 @@
 
 // Copyright (c) 2013, The Prometheus Authors
 // All rights reserved.
-//
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
 
 // +build !go1.8
 

--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2013, The Prometheus Authors
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+// +build !go1.8
+
+package promhttp
+
+import (
+	"io"
+	"net/http"
+)
+
+func newDelegator(w http.ResponseWriter) delegator {
+	d := &responseWriterDelegator{ResponseWriter: w}
+
+	_, cn := w.(http.CloseNotifier)
+	_, fl := w.(http.Flusher)
+	_, hj := w.(http.Hijacker)
+	_, rf := w.(io.ReaderFrom)
+	if cn && fl && hj && rf {
+		return &fancyResponseWriterDelegator{d}
+	}
+
+	return d
+}

--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2013, The Prometheus Authors
-// All rights reserved.
-
 // +build !go1.8
 
 package promhttp

--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -28,7 +28,7 @@ func newDelegator(w http.ResponseWriter) delegator {
 	_, hj := w.(http.Hijacker)
 	_, rf := w.(io.ReaderFrom)
 	if cn && fl && hj && rf {
-		return &fancyResponseWriterDelegator{d}
+		return &classicFancyResponseWriterDelegator{d}
 	}
 
 	return d

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2013, The Prometheus Authors
-// All rights reserved.
-//
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
@@ -26,6 +23,7 @@ import (
 	"net/http"
 )
 
+// Do the four different methods of all + pusher, pusher, nothing, all - pusher
 func newDelegator(w http.ResponseWriter) delegator {
 	d := &responseWriterDelegator{ResponseWriter: w}
 

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -32,7 +32,17 @@ func newDelegator(w http.ResponseWriter) delegator {
 	_, hj := w.(http.Hijacker)
 	_, ps := w.(http.Pusher)
 	_, rf := w.(io.ReaderFrom)
+
+	// Check for different possible interfaces that the http.ResponseWriter
+	// could implement.
 	if cn && fl && hj && rf && ps {
+		// All interfaces.
+		return &fancyResponseWriterDelegator{d}
+	} else if cn && fl && hj && rf {
+		// All interfaces, except http.Pusher.
+		return &fancyResponseWriterDelegator{d}
+	} else if ps {
+		// All just http.Pusher.
 		return &fancyResponseWriterDelegator{d}
 	}
 

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2013, The Prometheus Authors
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+// +build go1.8
+
+package promhttp
+
+import (
+	"io"
+	"net/http"
+)
+
+func newDelegator(w http.ResponseWriter) delegator {
+	d := &responseWriterDelegator{ResponseWriter: w}
+
+	_, cn := w.(http.CloseNotifier)
+	_, fl := w.(http.Flusher)
+	_, hj := w.(http.Hijacker)
+	_, ps := w.(http.Pusher)
+	_, rf := w.(io.ReaderFrom)
+	if cn && fl && hj && rf && ps {
+		return &fancyResponseWriterDelegator{d}
+	}
+
+	return d
+}
+
+func (f *fancyResponseWriterDelegator) Push(target string, opts *http.PushOptions) error {
+	return f.ResponseWriter.(http.Pusher).Push(target, opts)
+}

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -36,13 +36,13 @@ func newDelegator(w http.ResponseWriter) delegator {
 	switch {
 	case cn && fl && hj && rf && ps:
 		// All interfaces.
-		return &fancyResponseWriterDelegator{
-			classicFancyResponseWriterDelegator: &classicFancyResponseWriterDelegator{d},
-			p: &pushDelegator{d},
+		return &fancyPushDelegator{
+			fancyDelegator: &fancyDelegator{d},
+			p:              &pushDelegator{d},
 		}
 	case cn && fl && hj && rf:
 		// All interfaces, except http.Pusher.
-		return &classicFancyResponseWriterDelegator{d}
+		return &fancyDelegator{d}
 	case ps:
 		// Just http.Pusher.
 		return &pushDelegator{d}
@@ -51,13 +51,13 @@ func newDelegator(w http.ResponseWriter) delegator {
 	return d
 }
 
-type fancyResponseWriterDelegator struct {
+type fancyPushDelegator struct {
 	p *pushDelegator
 
-	*classicFancyResponseWriterDelegator
+	*fancyDelegator
 }
 
-func (f *fancyResponseWriterDelegator) Push(target string, opts *http.PushOptions) error {
+func (f *fancyPushDelegator) Push(target string, opts *http.PushOptions) error {
 	return f.p.Push(target, opts)
 }
 

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
-
 // +build go1.8
 
 package promhttp
@@ -23,7 +20,8 @@ import (
 	"net/http"
 )
 
-// Do the four different methods of all + pusher, pusher, nothing, all - pusher
+// newDelegator handles the four different methods of upgrading a
+// http.ResponseWriter to delegator.
 func newDelegator(w http.ResponseWriter) delegator {
 	d := &responseWriterDelegator{ResponseWriter: w}
 

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -11,17 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package promhttp provides new functions for instrumenting go code.
-// promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
-// you can create a handler for a custom registry or anything that implements
-// the Gatherer interface. It also allows to create handlers that act
-// differently on errors or allow to log errors.
+// Package promhttp provides functions to create http.Handler instances to
+// expose Prometheus metrics via HTTP. It also provides middleware to
+// instrument HTTP handlers in general.
 //
-// The package also contains functions to create http.Handler instances to
-// expose Prometheus metrics via HTTP. It contains tooling to instrument
-// instances of http.Handler via middleware. Middleware wrappers follow the
-// naming scheme InstrumentHandlerX, where X describes the intended use of the
-// middleware. Specific details are listed by their respective functions.
+// The package also contains tooling to instrument instances of http.Handler
+// via middleware. Middleware wrappers follow the naming scheme
+// InstrumentHandlerX, where X describes the intended use of the middleware.
+// Specific details are listed by their respective functions.
 package promhttp
 
 import (

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -11,12 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2013, The Prometheus Authors
-// All rights reserved.
-//
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
-
 // Package promhttp contains functions to create http.Handler instances to
 // expose Prometheus metrics via HTTP. It contains tooling to instrument
 // instances of http.Handler via Middleware. Currently available middleware
@@ -26,10 +20,10 @@
 // - Instrumenting in flight requests
 // - Instrumenting incoming request size
 // - Instrumenting outgoing response size
-//
-//Note that instrumenting latency with a histogram is rather expensive, and
-//cardinality on the supplied histogram should be kept to a minimum.
-//
+
+// Note that instrumenting latency with a histogram is rather expensive, and
+// cardinality on the supplied histogram should be kept to a minimum.
+
 // promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
 // you can create a handler for a custom registry or anything that implements
 // the Gatherer interface. It also allows to create handlers that act

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -15,7 +15,7 @@
 // expose Prometheus metrics via HTTP. It contains tooling to instrument
 // instances of http.Handler via Middleware. Currently available middleware
 // wrappers support:
-// - Instrumenting latency
+// - Instrumenting duration
 // - Instrumenting handler requests
 // - Instrumenting in flight requests
 // - Instrumenting incoming request size
@@ -24,6 +24,7 @@
 // Note that instrumenting latency with a histogram is rather expensive, and
 // cardinality on the supplied histogram should be kept to a minimum.
 
+// Package promhttp provides new functions for instrumenting go code.
 // promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
 // you can create a handler for a custom registry or anything that implements
 // the Gatherer interface. It also allows to create handlers that act

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -11,24 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package promhttp contains functions to create http.Handler instances to
-// expose Prometheus metrics via HTTP. It contains tooling to instrument
-// instances of http.Handler via Middleware. Currently available middleware
-// wrappers support:
-// - Instrumenting duration
-// - Instrumenting handler requests
-// - Instrumenting in flight requests
-// - Instrumenting incoming request size
-// - Instrumenting outgoing response size
-
-// Note that instrumenting latency with a histogram is rather expensive, and
-// cardinality on the supplied histogram should be kept to a minimum.
-
 // Package promhttp provides new functions for instrumenting go code.
 // promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
 // you can create a handler for a custom registry or anything that implements
 // the Gatherer interface. It also allows to create handlers that act
 // differently on errors or allow to log errors.
+//
+// The package also contains functions to create http.Handler instances to
+// expose Prometheus metrics via HTTP. It contains tooling to instrument
+// instances of http.Handler via middleware. Middleware wrappers follow the
+// naming scheme InstrumentHandlerX, where X describes the intended use of the
+// middleware. Specific details are listed by their respective functions.
 package promhttp
 
 import (

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -18,9 +18,17 @@
 // in the LICENSE file.
 
 // Package promhttp contains functions to create http.Handler instances to
-// expose Prometheus metrics via HTTP. In later versions of this package, it
-// will also contain tooling to instrument instances of http.Handler and
-// http.RoundTripper.
+// expose Prometheus metrics via HTTP. It contains tooling to instrument
+// instances of http.Handler via Middleware. Currently available middleware
+// wrappers support:
+// - Instrumenting latency
+// - Instrumenting handler requests
+// - Instrumenting in flight requests
+// - Instrumenting incoming request size
+// - Instrumenting outgoing response size
+//
+//Note that instrumenting latency with a histogram is rather expensive, and
+//cardinality on the supplied histogram should be kept to a minimum.
 //
 // promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
 // you can create a handler for a custom registry or anything that implements

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
 // Package promhttp provides tooling around HTTP servers and clients.
 //
 // First, the package allows the creation of http.Handler instances to expose

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -10,15 +10,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// Package promhttp provides functions to create http.Handler instances to
-// expose Prometheus metrics via HTTP. It also provides middleware to
-// instrument HTTP handlers in general.
 //
-// The package also contains tooling to instrument instances of http.Handler
+// Package promhttp provides tooling around HTTP servers and clients.
+//
+// First, the package allows the creation of http.Handler instances to expose
+// Prometheus metrics via HTTP. promhttp.Handler acts on the
+// prometheus.DefaultGatherer. With HandlerFor, you can create a handler for a
+// custom registry or anything that implements the Gatherer interface. It also
+// allows the creation of handlers that act differently on errors or allow to
+// log errors.
+//
+// Second, the package provides tooling to instrument instances of http.Handler
 // via middleware. Middleware wrappers follow the naming scheme
 // InstrumentHandlerX, where X describes the intended use of the middleware.
-// Specific details are listed by their respective functions.
+// See each function's doc comment for specific details.
 package promhttp
 
 import (

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -13,9 +13,6 @@
 
 // Copyright (c) 2013, The Prometheus Authors
 // All rights reserved.
-//
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
 
 package promhttp
 

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2013, The Prometheus Authors
-// All rights reserved.
-
 package promhttp
 
 import (

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -450,6 +450,7 @@ func (r *fancyDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 func (r *fancyDelegator) Flush() {
 	r.ResponseWriter.(http.Flusher).Flush()
 }
+
 func (r *fancyDelegator) ReadFrom(re io.Reader) (int64, error) {
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -1,0 +1,400 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2013, The Prometheus Authors
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+// Package promhttp contains functions to create http.Handler instances to
+// expose Prometheus metrics via HTTP. In later versions of this package, it
+// will also contain tooling to instrument instances of http.Handler and
+// http.RoundTripper.
+//
+// promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
+// you can create a handler for a custom registry or anything that implements
+// the Gatherer interface. It also allows to create handlers that act
+// differently on errors or allow to log errors.
+package promhttp
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Server struct {
+	mw  http.Handler
+	end http.Handler
+}
+
+type Middleware func(http.Handler) http.Handler
+
+type ConfigFunc func(*Server) error
+
+func InFlight(opts prometheus.GaugeOpts) Middleware {
+	ifg := prometheus.NewGauge(opts)
+	prometheus.MustRegister(ifg)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ifg.Inc()
+
+			next.ServeHTTP(w, r)
+
+			ifg.Dec()
+		})
+	}
+}
+
+var (
+	instLabels = []string{"method", "code"}
+
+	defaultGaugeOpts = prometheus.GaugeOpts{Name: "requests_in_flight", Help: "The number of requests currently in flight."}
+
+	defaultMiddleware = []Middleware{InFlight(defaultGaugeOpts)}
+)
+
+func NewDefaultServer(handlerName string, handler http.Handler) http.HandlerFunc {
+	return NewServer(handlerName, handler, SetMiddleware(defaultMiddleware...))
+}
+
+func NewServer(handlerName string, handler http.Handler, configFuncs ...ConfigFunc) http.HandlerFunc {
+	s := &Server{
+		end: handler,
+	}
+
+	for _, fn := range configFuncs {
+		fn(s)
+	}
+
+	return instrumentHandlerFunc(handlerName, s.mw.ServeHTTP)
+}
+
+func SetMiddleware(middleware ...Middleware) ConfigFunc {
+	return func(s *Server) error {
+		s.mw = s.chain(middleware...)
+		return nil
+	}
+}
+
+func (s *Server) chain(middlewares ...Middleware) http.Handler {
+	if len(middlewares) == 0 {
+		return s.end
+	}
+
+	next := s.chain(middlewares[1:]...)
+
+	return middlewares[0](next)
+}
+
+func instrumentHandlerFunc(handlerName string, handlerFunc http.HandlerFunc) http.HandlerFunc {
+	return instrumentHandlerFuncWithOpts(
+		prometheus.HistogramOpts{
+			Subsystem:   "http",
+			ConstLabels: prometheus.Labels{"handler": handlerName},
+			Buckets:     prometheus.DefBuckets,
+		},
+		handlerFunc,
+	)
+}
+
+func instrumentHandlerFuncWithOpts(opts prometheus.HistogramOpts, handlerFunc http.HandlerFunc) http.HandlerFunc {
+	reqCnt := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   opts.Namespace,
+			Subsystem:   opts.Subsystem,
+			Name:        "requests_total",
+			Help:        "Total number of HTTP requests made.",
+			ConstLabels: opts.ConstLabels,
+		},
+		instLabels,
+	)
+	if err := prometheus.Register(reqCnt); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			reqCnt = are.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			panic(err)
+		}
+	}
+
+	opts.Name = "request_duration_seconds"
+	opts.Help = "The HTTP request latencies in seconds."
+	reqDur := prometheus.NewHistogram(opts)
+	if err := prometheus.Register(reqDur); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			reqDur = are.ExistingCollector.(prometheus.Histogram)
+		} else {
+			panic(err)
+		}
+	}
+
+	opts.Name = "request_size_bytes"
+	opts.Help = "The HTTP request sizes in bytes."
+	reqSz := prometheus.NewHistogram(opts)
+	if err := prometheus.Register(reqSz); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			reqSz = are.ExistingCollector.(prometheus.Histogram)
+		} else {
+			panic(err)
+		}
+	}
+
+	opts.Name = "response_size_bytes"
+	opts.Help = "The HTTP response sizes in bytes."
+	resSz := prometheus.NewHistogram(opts)
+	if err := prometheus.Register(resSz); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			resSz = are.ExistingCollector.(prometheus.Histogram)
+		} else {
+			panic(err)
+		}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		now := time.Now()
+
+		delegate := &responseWriterDelegator{ResponseWriter: w}
+
+		_, cn := w.(http.CloseNotifier)
+		_, fl := w.(http.Flusher)
+		_, hj := w.(http.Hijacker)
+		_, rf := w.(io.ReaderFrom)
+		var rw http.ResponseWriter
+		if cn && fl && hj && rf {
+			rw = &fancyResponseWriterDelegator{delegate}
+		} else {
+			rw = delegate
+		}
+		handlerFunc(rw, r)
+
+		// TODO: Do we want to calculate this at the end in case the
+		// user modifies the request? Or do we want to ignore this?
+		size := computeApproximateRequestSize(r)
+
+		elapsed := time.Since(now).Seconds()
+
+		method := sanitizeMethod(r.Method)
+		code := sanitizeCode(delegate.status)
+		reqCnt.WithLabelValues(method, code).Inc()
+		reqDur.Observe(elapsed)
+		resSz.Observe(float64(delegate.written))
+		reqSz.Observe(float64(size))
+	})
+}
+
+func computeApproximateRequestSize(r *http.Request) int {
+	// Get URL length in current go routine for avoiding a race condition.
+	// HandlerFunc that runs in parallel may modify the URL.
+	s := 0
+	if r.URL != nil {
+		s += len(r.URL.String())
+	}
+
+	s += len(r.Method)
+	s += len(r.Proto)
+	for name, values := range r.Header {
+		s += len(name)
+		for _, value := range values {
+			s += len(value)
+		}
+	}
+	s += len(r.Host)
+
+	// N.B. r.Form and r.MultipartForm are assumed to be included in r.URL.
+
+	if r.ContentLength != -1 {
+		s += int(r.ContentLength)
+	}
+	return s
+}
+
+func sanitizeMethod(m string) string {
+	switch m {
+	case "GET", "get":
+		return "get"
+	case "PUT", "put":
+		return "put"
+	case "HEAD", "head":
+		return "head"
+	case "POST", "post":
+		return "post"
+	case "DELETE", "delete":
+		return "delete"
+	case "CONNECT", "connect":
+		return "connect"
+	case "OPTIONS", "options":
+		return "options"
+	case "NOTIFY", "notify":
+		return "notify"
+	default:
+		return strings.ToLower(m)
+	}
+}
+
+func sanitizeCode(s int) string {
+	switch s {
+	case 100:
+		return "100"
+	case 101:
+		return "101"
+
+	case 200:
+		return "200"
+	case 201:
+		return "201"
+	case 202:
+		return "202"
+	case 203:
+		return "203"
+	case 204:
+		return "204"
+	case 205:
+		return "205"
+	case 206:
+		return "206"
+
+	case 300:
+		return "300"
+	case 301:
+		return "301"
+	case 302:
+		return "302"
+	case 304:
+		return "304"
+	case 305:
+		return "305"
+	case 307:
+		return "307"
+
+	case 400:
+		return "400"
+	case 401:
+		return "401"
+	case 402:
+		return "402"
+	case 403:
+		return "403"
+	case 404:
+		return "404"
+	case 405:
+		return "405"
+	case 406:
+		return "406"
+	case 407:
+		return "407"
+	case 408:
+		return "408"
+	case 409:
+		return "409"
+	case 410:
+		return "410"
+	case 411:
+		return "411"
+	case 412:
+		return "412"
+	case 413:
+		return "413"
+	case 414:
+		return "414"
+	case 415:
+		return "415"
+	case 416:
+		return "416"
+	case 417:
+		return "417"
+	case 418:
+		return "418"
+
+	case 500:
+		return "500"
+	case 501:
+		return "501"
+	case 502:
+		return "502"
+	case 503:
+		return "503"
+	case 504:
+		return "504"
+	case 505:
+		return "505"
+
+	case 428:
+		return "428"
+	case 429:
+		return "429"
+	case 431:
+		return "431"
+	case 511:
+		return "511"
+
+	default:
+		return strconv.Itoa(s)
+	}
+}
+
+type responseWriterDelegator struct {
+	http.ResponseWriter
+
+	handler, method string
+	status          int
+	written         int64
+	wroteHeader     bool
+}
+
+func (r *responseWriterDelegator) WriteHeader(code int) {
+	r.status = code
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseWriterDelegator) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.written += int64(n)
+	return n, err
+}
+
+type fancyResponseWriterDelegator struct {
+	*responseWriterDelegator
+}
+
+func (f *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
+	return f.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+func (f *fancyResponseWriterDelegator) Flush() {
+	f.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return f.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+func (f *fancyResponseWriterDelegator) ReadFrom(r io.Reader) (int64, error) {
+	if !f.wroteHeader {
+		f.WriteHeader(http.StatusOK)
+	}
+	n, err := f.ResponseWriter.(io.ReaderFrom).ReadFrom(r)
+	f.written += n
+	return n, err
+}

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -70,21 +70,6 @@ func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	})
 }
 
-func newDelegator(w http.ResponseWriter) delegator {
-	d := &responseWriterDelegator{ResponseWriter: w}
-
-	_, cn := w.(http.CloseNotifier)
-	_, fl := w.(http.Flusher)
-	_, hj := w.(http.Hijacker)
-	_, ps := w.(http.Pusher)
-	_, rf := w.(io.ReaderFrom)
-	if cn && fl && hj && rf && ps {
-		return &fancyResponseWriterDelegator{d}
-	}
-
-	return d
-}
-
 // Counter accepts an CounterVec interface and an http.Handler, returning a new
 // http.Handler that wraps the supplied http.Handler. The provided CounterVec
 // must be registered in a registry in order to be used.  If the wrapped
@@ -372,6 +357,21 @@ type delegator interface {
 	Written() int64
 
 	http.ResponseWriter
+}
+
+func newDelegator(w http.ResponseWriter) delegator {
+	d := &responseWriterDelegator{ResponseWriter: w}
+
+	_, cn := w.(http.CloseNotifier)
+	_, fl := w.(http.Flusher)
+	_, hj := w.(http.Hijacker)
+	_, ps := w.(http.Pusher)
+	_, rf := w.(io.ReaderFrom)
+	if cn && fl && hj && rf && ps {
+		return &fancyResponseWriterDelegator{d}
+	}
+
+	return d
 }
 
 type responseWriterDelegator struct {

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -233,7 +233,7 @@ func checkLabels(c prometheus.Collector) (code bool, method bool) {
 var emptyLabels = prometheus.Labels{}
 
 func labels(code, method bool, reqMethod string, status int) prometheus.Labels {
-	if !(code && method) {
+	if !(code || method) {
 		return emptyLabels
 	}
 	labels := prometheus.Labels{}

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -435,30 +435,30 @@ func (r *responseWriterDelegator) Write(b []byte) (int, error) {
 	return n, err
 }
 
-type classicFancyResponseWriterDelegator struct {
+type fancyDelegator struct {
 	*responseWriterDelegator
 }
 
-func (r *classicFancyResponseWriterDelegator) Status() int {
+func (r *fancyDelegator) Status() int {
 	return r.status
 }
 
-func (r *classicFancyResponseWriterDelegator) Written() int64 {
+func (r *fancyDelegator) Written() int64 {
 	return r.written
 }
 
-func (r *classicFancyResponseWriterDelegator) CloseNotify() <-chan bool {
+func (r *fancyDelegator) CloseNotify() <-chan bool {
 	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
-func (r *classicFancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (r *fancyDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return r.ResponseWriter.(http.Hijacker).Hijack()
 }
 
-func (r *classicFancyResponseWriterDelegator) Flush() {
+func (r *fancyDelegator) Flush() {
 	r.ResponseWriter.(http.Flusher).Flush()
 }
-func (r *classicFancyResponseWriterDelegator) ReadFrom(re io.Reader) (int64, error) {
+func (r *fancyDelegator) ReadFrom(re io.Reader) (int64, error) {
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)
 	}

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -60,7 +60,7 @@ func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 		now := time.Now()
 		delegate := &responseWriterDelegator{ResponseWriter: w}
 
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(delegate, r)
 
 		if _, prs := labels["code"]; prs {
 			labels["code"] = sanitizeCode(delegate.status)
@@ -93,7 +93,7 @@ func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		delegate := &responseWriterDelegator{ResponseWriter: w}
 
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(delegate, r)
 
 		if _, prs := labels["code"]; prs {
 			labels["code"] = sanitizeCode(delegate.status)

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -435,30 +435,30 @@ func (r *responseWriterDelegator) Write(b []byte) (int, error) {
 	return n, err
 }
 
-type fancyResponseWriterDelegator struct {
+type classicFancyResponseWriterDelegator struct {
 	*responseWriterDelegator
 }
 
-func (r *fancyResponseWriterDelegator) Status() int {
+func (r *classicFancyResponseWriterDelegator) Status() int {
 	return r.status
 }
 
-func (r *fancyResponseWriterDelegator) Written() int64 {
+func (r *classicFancyResponseWriterDelegator) Written() int64 {
 	return r.written
 }
 
-func (r *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
+func (r *classicFancyResponseWriterDelegator) CloseNotify() <-chan bool {
 	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
-func (r *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (r *classicFancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return r.ResponseWriter.(http.Hijacker).Hijack()
 }
 
-func (r *fancyResponseWriterDelegator) Flush() {
+func (r *classicFancyResponseWriterDelegator) Flush() {
 	r.ResponseWriter.(http.Flusher).Flush()
 }
-func (r *fancyResponseWriterDelegator) ReadFrom(re io.Reader) (int64, error) {
+func (r *classicFancyResponseWriterDelegator) ReadFrom(re io.Reader) (int64, error) {
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)
 	}

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -49,10 +49,9 @@ func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 }
 
 func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
-	// Include code
 	// Maybe include path? Tell people to use a const label for now.
 	labels := prometheus.Labels{}
-	if _, err := obs.GetMetricWith(prometheus.Labels{"code": "200"}); err == nil {
+	if _, err := obs.GetMetricWith(prometheus.Labels{"code": ""}); err == nil {
 		labels = prometheus.Labels{"code": ""}
 	}
 	// TODO: How to delete these labels?

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -51,7 +51,7 @@ func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	// Maybe include path? Tell people to use a const label for now.
 	labels := prometheus.Labels{}
-	if _, err := obs.GetMetricWith(prometheus.Labels{"code": ""}); err == nil {
+	if _, err := obs.GetMetricWith(prometheus.Labels{"code": "0"}); err == nil {
 		labels = prometheus.Labels{"code": ""}
 	}
 	// TODO: How to delete these labels?
@@ -77,12 +77,12 @@ func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 
 	// TODO(beorn7): Remove this hacky way to check for instance labels
 	// once Descriptors can have their dimensionality queried.
-	if _, err = counter.GetMetricWith(prometheus.Labels{"code": "", "method": ""}); err == nil {
+	if _, err = counter.GetMetricWith(prometheus.Labels{"code": "0", "method": "get"}); err == nil {
 		labels["code"] = ""
 		labels["method"] = ""
-	} else if _, err = counter.GetMetricWith(prometheus.Labels{"method": ""}); err == nil {
+	} else if _, err = counter.GetMetricWith(prometheus.Labels{"method": "get"}); err == nil {
 		labels["method"] = ""
-	} else if _, err = counter.GetMetricWith(prometheus.Labels{"code": ""}); err == nil {
+	} else if _, err = counter.GetMetricWith(prometheus.Labels{"code": "0"}); err == nil {
 		labels["code"] = ""
 	} else if _, err = counter.GetMetricWith(labels); err != nil {
 		panic(`counter middleware requires instance labels "code", "method", or both "code" and "label".`)

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -46,7 +46,7 @@ func InstrumentHandlerInFlight(g prometheus.Gauge, next http.Handler) http.Handl
 // InstrumentHandlerDuration accepts an ObserverVec interface and an
 // http.Handler, returning a new http.Handler that wraps the supplied
 // http.Handler. The provided ObserverVec must be registered in a registry in
-// order to be used.  If the wrapped http.Handler has not set a status code,
+// order to be used. If the wrapped http.Handler has not set a status code,
 // i.e. the value is currently 0, the supplied ObserverVec will report a 200.
 // The instance labels "code" and "method" are supported on the provided
 // ObserverVec.  Note: Partitioning histograms is expensive.
@@ -73,7 +73,7 @@ func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler) ht
 // InstrumentHandlerCounter accepts an CounterVec interface and an
 // http.Handler, returning a new http.Handler that wraps the supplied
 // http.Handler. The provided CounterVec must be registered in a registry in
-// order to be used.  If the wrapped http.Handler has not set a status code,
+// order to be used. If the wrapped http.Handler has not set a status code,
 // i.e. the value is currently 0, the supplied counter will report a 200. The
 // instance labels "code" and "method" are supported on the provided
 // CounterVec.
@@ -97,7 +97,7 @@ func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler)
 // InstrumentHandlerRequestSize accepts an ObserverVec interface and an
 // http.Handler, returning a new http.Handler that wraps the supplied
 // http.Handler. The provided ObserverVec must be registered in a registry in
-// order to be used.  If the wrapped http.Handler has not set a status code,
+// order to be used. If the wrapped http.Handler has not set a status code,
 // i.e. the value is currently 0, the supplied ObserverVec will report a 200.
 // The instance labels "code" and "method" are supported on the provided
 // ObserverVec.  Note: Partitioning histograms is expensive.
@@ -123,10 +123,11 @@ func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler)
 // InstrumentHandlerResponseSize accepts an ObserverVec interface and an
 // http.Handler, returning a new http.Handler that wraps the supplied
 // http.Handler. The provided ObserverVec must be registered in a registry in
-// order to be used.  If the wrapped http.Handler has not set a status code,
+// order to be used. If the wrapped http.Handler has not set a status code,
 // i.e. the value is currently 0, the supplied ObserverVec will report a 200.
 // The instance labels "code" and "method" are supported on the provided
-// ObserverVec.  Note: Partitioning histograms is expensive.
+// ObserverVec.
+// Note: Partitioning histograms is expensive.
 func InstrumentHandlerResponseSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	code, method := checkLabels(obs)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -439,14 +439,6 @@ type fancyDelegator struct {
 	*responseWriterDelegator
 }
 
-func (r *fancyDelegator) Status() int {
-	return r.status
-}
-
-func (r *fancyDelegator) Written() int64 {
-	return r.written
-}
-
 func (r *fancyDelegator) CloseNotify() <-chan bool {
 	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -48,8 +48,12 @@ func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 	})
 }
 
+// Latency accepts an ObserverVec interface and an http.Handler, returning a
+// new http.Handler that wraps the supplied http.Handler. The provided
+// ObserverVec must be registered in a registry in order to be used.
 // If the wrapped http.Handler has not set a status code, i.e. the value is
-// currently 0, it will report a 200.
+// currently 0, the supplied ObserverVec will report a 200.
+// The instance labels "code" and are supported on the provided ObserverVec.
 func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	// Maybe include path? Tell people to use a const label for now.
 	var code bool
@@ -72,8 +76,13 @@ func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	})
 }
 
+// Latency accepts an ObserverVec interface and an http.Handler, returning a
+// new http.Handler that wraps the supplied http.Handler. The provided
+// CounterVec must be registered in a registry in order to be used.
 // If the wrapped http.Handler has not set a status code, i.e. the value is
-// currently 0, it will report a 200.
+// currently 0, the supplied counter will report a 200.
+// The instance labels "code" and "method" are supported on the provided
+// CounterVec.
 func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	var (
 		code   bool
@@ -112,6 +121,9 @@ func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	})
 }
 
+// RequestSize accepts an Observer interface and an http.Handler, returning a
+// new http.Handler that wraps the supplied http.Handler. The provided Observer
+// must be registered in a registry in order to be used.
 func RequestSize(obs prometheus.Observer, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(w, r)
@@ -120,6 +132,9 @@ func RequestSize(obs prometheus.Observer, next http.Handler) http.Handler {
 	})
 }
 
+// ResponseSize accepts an Observer interface and an http.Handler, returning a
+// new http.Handler that wraps the supplied http.Handler. The provided Observer
+// must be registered in a registry in order to be used.
 func ResponseSize(obs prometheus.Observer, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		delegate := &responseWriterDelegator{ResponseWriter: w}

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -32,10 +32,10 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-// InFlight accepts a Gauge and an http.Handler, returning a new http.Handler
-// that wraps the supplied http.Handler. The provided Gauge must be registered
-// in a registry in order to be used.
-func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
+// InstrumentHandlerInFlight accepts a Gauge and an http.Handler, returning a
+// new http.Handler that wraps the supplied http.Handler. The provided Gauge
+// must be registered in a registry in order to be used.
+func InstrumentHandlerInFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		g.Inc()
 		next.ServeHTTP(w, r)
@@ -43,14 +43,14 @@ func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 	})
 }
 
-// Latency accepts an ObserverVec interface and an http.Handler, returning a
-// new http.Handler that wraps the supplied http.Handler. The provided
-// ObserverVec must be registered in a registry in order to be used.
-// If the wrapped http.Handler has not set a status code, i.e. the value is
-// currently 0, the supplied ObserverVec will report a 200.  The instance
-// labels "code" and "method" are supported on the provided ObserverVec.
-// Note: Partitioning histograms is expensive.
-func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
+// InstrumentHandlerDuration accepts an ObserverVec interface and an
+// http.Handler, returning a new http.Handler that wraps the supplied
+// http.Handler. The provided ObserverVec must be registered in a registry in
+// order to be used.  If the wrapped http.Handler has not set a status code,
+// i.e. the value is currently 0, the supplied ObserverVec will report a 200.
+// The instance labels "code" and "method" are supported on the provided
+// ObserverVec.  Note: Partitioning histograms is expensive.
+func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler) http.HandlerFunc {
 	code, method := checkLabels(obs)
 
 	if code {
@@ -70,13 +70,14 @@ func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	})
 }
 
-// Counter accepts an CounterVec interface and an http.Handler, returning a new
-// http.Handler that wraps the supplied http.Handler. The provided CounterVec
-// must be registered in a registry in order to be used.  If the wrapped
-// http.Handler has not set a status code, i.e. the value is currently 0, the
-// supplied counter will report a 200. The instance labels "code" and "method"
-// are supported on the provided CounterVec.
-func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
+// InstrumentHandlerCounter accepts an CounterVec interface and an
+// http.Handler, returning a new http.Handler that wraps the supplied
+// http.Handler. The provided CounterVec must be registered in a registry in
+// order to be used.  If the wrapped http.Handler has not set a status code,
+// i.e. the value is currently 0, the supplied counter will report a 200. The
+// instance labels "code" and "method" are supported on the provided
+// CounterVec.
+func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler) http.HandlerFunc {
 	code, method := checkLabels(counter)
 
 	if code {
@@ -93,14 +94,14 @@ func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	})
 }
 
-// RequestSize accepts an ObserverVec interface and an http.Handler, returning a
-// new http.Handler that wraps the supplied http.Handler. The provided
-// ObserverVec must be registered in a registry in order to be used.
-// If the wrapped http.Handler has not set a status code, i.e. the value is
-// currently 0, the supplied ObserverVec will report a 200.  The instance
-// labels "code" and "method" are supported on the provided ObserverVec.
-// Note: Partitioning histograms is expensive.
-func RequestSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
+// InstrumentHandlerRequestSize accepts an ObserverVec interface and an
+// http.Handler, returning a new http.Handler that wraps the supplied
+// http.Handler. The provided ObserverVec must be registered in a registry in
+// order to be used.  If the wrapped http.Handler has not set a status code,
+// i.e. the value is currently 0, the supplied ObserverVec will report a 200.
+// The instance labels "code" and "method" are supported on the provided
+// ObserverVec.  Note: Partitioning histograms is expensive.
+func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler) http.HandlerFunc {
 	code, method := checkLabels(obs)
 
 	if code {
@@ -119,14 +120,14 @@ func RequestSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	})
 }
 
-// ResponseSize accepts an ObserverVec interface and an http.Handler, returning a
-// new http.Handler that wraps the supplied http.Handler. The provided
-// ObserverVec must be registered in a registry in order to be used.
-// If the wrapped http.Handler has not set a status code, i.e. the value is
-// currently 0, the supplied ObserverVec will report a 200.  The instance
-// labels "code" and "method" are supported on the provided ObserverVec.
-// Note: Partitioning histograms is expensive.
-func ResponseSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
+// InstrumentHandlerResponseSize accepts an ObserverVec interface and an
+// http.Handler, returning a new http.Handler that wraps the supplied
+// http.Handler. The provided ObserverVec must be registered in a registry in
+// order to be used.  If the wrapped http.Handler has not set a status code,
+// i.e. the value is currently 0, the supplied ObserverVec will report a 200.
+// The instance labels "code" and "method" are supported on the provided
+// ObserverVec.  Note: Partitioning histograms is expensive.
+func InstrumentHandlerResponseSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	code, method := checkLabels(obs)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		d := newDelegator(w)

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -49,6 +49,7 @@ func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 // If the wrapped http.Handler has not set a status code, i.e. the value is
 // currently 0, the supplied ObserverVec will report a 200.  The instance
 // labels "code" and "method" are supported on the provided ObserverVec.
+// Note: Partitioning histograms is expensive.
 func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	code, method := checkLabels(obs)
 
@@ -98,6 +99,7 @@ func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 // If the wrapped http.Handler has not set a status code, i.e. the value is
 // currently 0, the supplied ObserverVec will report a 200.  The instance
 // labels "code" and "method" are supported on the provided ObserverVec.
+// Note: Partitioning histograms is expensive.
 func RequestSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	code, method := checkLabels(obs)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +123,7 @@ func RequestSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 // If the wrapped http.Handler has not set a status code, i.e. the value is
 // currently 0, the supplied ObserverVec will report a 200.  The instance
 // labels "code" and "method" are supported on the provided ObserverVec.
+// Note: Partitioning histograms is expensive.
 func ResponseSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	code, method := checkLabels(obs)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -48,6 +48,8 @@ func InFlight(g prometheus.Gauge, next http.Handler) http.Handler {
 	})
 }
 
+// If the wrapped http.Handler has not set a status code, i.e. the value is
+// currently 0, it will report a 200.
 func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	// Maybe include path? Tell people to use a const label for now.
 	var code bool
@@ -70,6 +72,8 @@ func Latency(obs prometheus.ObserverVec, next http.Handler) http.Handler {
 	})
 }
 
+// If the wrapped http.Handler has not set a status code, i.e. the value is
+// currently 0, it will report a 200.
 func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	var (
 		code   bool
@@ -186,6 +190,9 @@ func sanitizeMethod(m string) string {
 	}
 }
 
+// If the wrapped http.Handler has not set a status code, i.e. the value is
+// currently 0, santizeCode will return 200, for consistency with behavior in
+// the stdlib.
 func sanitizeCode(s int) string {
 	switch s {
 	case 100:
@@ -193,7 +200,7 @@ func sanitizeCode(s int) string {
 	case 101:
 		return "101"
 
-	case 200:
+	case 200, 0:
 		return "200"
 	case 201:
 		return "201"

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -85,7 +85,7 @@ func Counter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	} else if _, err = counter.GetMetricWith(prometheus.Labels{"code": ""}); err == nil {
 		labels["code"] = ""
 	} else if _, err = counter.GetMetricWith(labels); err != nil {
-		panic(`counter middleware requires "code", "method", or both.`)
+		panic(`counter middleware requires instance labels "code", "method", or both "code" and "label".`)
 	}
 	// TODO: There is no delete exposed on interface Counter.
 	// c.Delete(labels)

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2013, The Prometheus Authors
-// All rights reserved.
-
 package promhttp
 
 import (

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -27,25 +27,25 @@ import (
 
 func TestMiddlewareAPI(t *testing.T) {
 	inFlightGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "inFlight",
-		Help: "Gauge.",
+		Name: "in_flight_requests",
+		Help: "A gauge of requests currently being served by the wrapped handler.",
 	})
 
 	counter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "test_counter",
-			Help: "Counter.",
+			Name: "api_requests_total",
+			Help: "A counter for requests to the wrapped handler.",
 		},
 		[]string{"code", "method"},
 	)
 
 	histVec := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "latency",
-			Help:    "Histogram.",
+			Name:    "response_duration_seconds",
+			Help:    "A histogram of request latencies.",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"code"},
+		[]string{"method"},
 	)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +67,7 @@ func TestMiddlewareAPI(t *testing.T) {
 
 func ExampleInstrumentHandlerDuration() {
 	inFlightGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "in_flight",
+		Name: "in_flight_requests",
 		Help: "A gauge of requests currently being served by the wrapped handler.",
 	})
 

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -110,6 +110,7 @@ func ExampleInstrumentHandlerDuration() {
 			Help:    "A histogram of request sizes for requests.",
 			Buckets: []float64{200, 500, 900, 1500},
 		},
+		[]string{},
 	)
 
 	// Create the handlers that will be wrapped by the middleware.
@@ -138,7 +139,7 @@ func ExampleInstrumentHandlerDuration() {
 	pullChain := InstrumentHandlerInFlight(inFlightGauge,
 		InstrumentHandlerCounter(counter,
 			InstrumentHandlerDuration(pullVec,
-				InstrumentHandlerResponseSize(responseSize, pushHandler),
+				InstrumentHandlerResponseSize(responseSize, pullHandler),
 			),
 		),
 	)

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -28,58 +28,7 @@
 // differently on errors or allow to log errors.
 package promhttp
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-)
+import "testing"
 
 func TestMiddlewareWrapsFirstToLast(t *testing.T) {
-	order := []int{}
-	first := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			order = append(order, 0)
-
-			next.ServeHTTP(w, r)
-
-			order = append(order, 6)
-		})
-	}
-
-	second := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			order = append(order, 1)
-
-			next.ServeHTTP(w, r)
-
-			order = append(order, 5)
-		})
-	}
-
-	third := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			order = append(order, 2)
-
-			next.ServeHTTP(w, r)
-
-			order = append(order, 4)
-		})
-	}
-
-	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		order = append(order, 3)
-	})
-
-	handler := NewServer("testHandler", wrapped, SetMiddleware(first, second, third))
-
-	rec := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
-
-	handler.ServeHTTP(rec, req)
-
-	for want, got := range order {
-		if want != got {
-			t.Fatalf("wanted %d, got %d", want, got)
-		}
-	}
 }

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -17,15 +17,6 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-// Package promhttp contains functions to create http.Handler instances to
-// expose Prometheus metrics via HTTP. In later versions of this package, it
-// will also contain tooling to instrument instances of http.Handler and
-// http.RoundTripper.
-//
-// promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
-// you can create a handler for a custom registry or anything that implements
-// the Gatherer interface. It also allows to create handlers that act
-// differently on errors or allow to log errors.
 package promhttp
 
 import (

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -87,11 +87,12 @@ func ExampleInstrumentHandlerDuration() {
 		[]string{"code", "method"},
 	)
 
-	// pushVec is partitioned with custom buckets based on expected request
-	// duration.
+	// pushVec is partitioned by the HTTP method and uses custom buckets based on
+	// the expected request duration. It uses ConstLabels to set a handler label
+	// marking pushVec as tracking the durations for pushes.
 	pushVec := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:        "push_duration_seconds",
+			Name:        "request_duration_seconds",
 			Help:        "A histogram of latencies for requests to the push handler.",
 			Buckets:     []float64{.25, .5, 1, 2.5, 5, 10},
 			ConstLabels: prometheus.Labels{"handler": "push"},
@@ -99,11 +100,12 @@ func ExampleInstrumentHandlerDuration() {
 		[]string{"method"},
 	)
 
-	// pullVec is partitioned with custom buckets based on expected request
-	// duration, which differ from those defined in pushVec.
+	// pullVec is also partitioned by the HTTP method but uses custom buckets
+	// different from those for pushVec. It also has a different value for the
+	// constant "handler" label.
 	pullVec := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:        "pull_duration_seconds",
+			Name:        "request_duration_seconds",
 			Help:        "A histogram of latencies for requests to the pull handler.",
 			Buckets:     []float64{.005, .01, .025, .05},
 			ConstLabels: prometheus.Labels{"handler": "pull"},
@@ -111,11 +113,12 @@ func ExampleInstrumentHandlerDuration() {
 		[]string{"method"},
 	)
 
-	// responseSize is an ObserverVec partitioned with no instance labels.
+	// responseSize has no labels, making it a zero-dimensional
+	// ObserverVec.
 	responseSize := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "push_request_size_bytes",
-			Help:    "A histogram of request sizes for requests.",
+			Name:    "response_size_bytes",
+			Help:    "A histogram of response sizes for requests.",
 			Buckets: []float64{200, 500, 900, 1500},
 		},
 		[]string{},

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2013, The Prometheus Authors
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+// Package promhttp contains functions to create http.Handler instances to
+// expose Prometheus metrics via HTTP. In later versions of this package, it
+// will also contain tooling to instrument instances of http.Handler and
+// http.RoundTripper.
+//
+// promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
+// you can create a handler for a custom registry or anything that implements
+// the Gatherer interface. It also allows to create handlers that act
+// differently on errors or allow to log errors.
+package promhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMiddlewareWrapsFirstToLast(t *testing.T) {
+	order := []int{}
+	first := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, 0)
+
+			next.ServeHTTP(w, r)
+
+			order = append(order, 6)
+		})
+	}
+
+	second := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, 1)
+
+			next.ServeHTTP(w, r)
+
+			order = append(order, 5)
+		})
+	}
+
+	third := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, 2)
+
+			next.ServeHTTP(w, r)
+
+			order = append(order, 4)
+		})
+	}
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		order = append(order, 3)
+	})
+
+	handler := NewServer("testHandler", wrapped, SetMiddleware(first, second, third))
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	handler.ServeHTTP(rec, req)
+
+	for want, got := range order {
+		if want != got {
+			t.Fatalf("wanted %d, got %d", want, got)
+		}
+	}
+}

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2013, The Prometheus Authors
-// All rights reserved.
-
 package promhttp
 
 import (

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -419,9 +419,9 @@ func NewSummaryVec(opts SummaryOpts, labelNames []string) *SummaryVec {
 	}
 }
 
-// GetMetricWithLabelValues replaces the method of the same name in
-// MetricVec. The difference is that this method returns an Observer and not a
-// Metric so that no type conversion is required.
+// GetMetricWithLabelValues replaces the method of the same name in MetricVec.
+// The difference is that this method returns an Observer and not a Metric so
+// that no type conversion to an Observer is required.
 func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
@@ -431,8 +431,8 @@ func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 }
 
 // GetMetricWith replaces the method of the same name in MetricVec. The
-// difference is that this method returns an Observer and not a Metric so that no
-// type conversion is required.
+// difference is that this method returns an Observer and not a Metric so that
+// no type conversion to an Observer is required.
 func (m *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)
 	if metric != nil {

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -425,7 +425,7 @@ func NewSummaryVec(opts SummaryOpts, labelNames []string) *SummaryVec {
 func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
-		return metric.(Summary), err
+		return metric.(Observer), err
 	}
 	return nil, err
 }
@@ -436,7 +436,7 @@ func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 func (m *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)
 	if metric != nil {
-		return metric.(Summary), err
+		return metric.(Observer), err
 	}
 	return nil, err
 }
@@ -446,14 +446,14 @@ func (m *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
 // error, WithLabelValues allows shortcuts like
 //     myVec.WithLabelValues("404", "GET").Observe(42.21)
 func (m *SummaryVec) WithLabelValues(lvs ...string) Observer {
-	return m.MetricVec.WithLabelValues(lvs...).(Summary)
+	return m.MetricVec.WithLabelValues(lvs...).(Observer)
 }
 
 // With works as GetMetricWith, but panics where GetMetricWithLabels would have
 // returned an error. By not returning an error, With allows shortcuts like
 //     myVec.With(Labels{"code": "404", "method": "GET"}).Observe(42.21)
 func (m *SummaryVec) With(labels Labels) Observer {
-	return m.MetricVec.With(labels).(Summary)
+	return m.MetricVec.With(labels).(Observer)
 }
 
 type constSummary struct {

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -420,7 +420,7 @@ func NewSummaryVec(opts SummaryOpts, labelNames []string) *SummaryVec {
 }
 
 // GetMetricWithLabelValues replaces the method of the same name in
-// MetricVec. The difference is that this method returns a Observer and not a
+// MetricVec. The difference is that this method returns an Observer and not a
 // Metric so that no type conversion is required.
 func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
@@ -431,7 +431,7 @@ func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 }
 
 // GetMetricWith replaces the method of the same name in MetricVec. The
-// difference is that this method returns a Observer and not a Metric so that no
+// difference is that this method returns an Observer and not a Metric so that no
 // type conversion is required.
 func (m *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -420,9 +420,9 @@ func NewSummaryVec(opts SummaryOpts, labelNames []string) *SummaryVec {
 }
 
 // GetMetricWithLabelValues replaces the method of the same name in
-// MetricVec. The difference is that this method returns a Summary and not a
+// MetricVec. The difference is that this method returns a Observer and not a
 // Metric so that no type conversion is required.
-func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Summary, error) {
+func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
 		return metric.(Summary), err
@@ -431,9 +431,9 @@ func (m *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Summary, error) {
 }
 
 // GetMetricWith replaces the method of the same name in MetricVec. The
-// difference is that this method returns a Summary and not a Metric so that no
+// difference is that this method returns a Observer and not a Metric so that no
 // type conversion is required.
-func (m *SummaryVec) GetMetricWith(labels Labels) (Summary, error) {
+func (m *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
 	metric, err := m.MetricVec.GetMetricWith(labels)
 	if metric != nil {
 		return metric.(Summary), err
@@ -445,14 +445,14 @@ func (m *SummaryVec) GetMetricWith(labels Labels) (Summary, error) {
 // GetMetricWithLabelValues would have returned an error. By not returning an
 // error, WithLabelValues allows shortcuts like
 //     myVec.WithLabelValues("404", "GET").Observe(42.21)
-func (m *SummaryVec) WithLabelValues(lvs ...string) Summary {
+func (m *SummaryVec) WithLabelValues(lvs ...string) Observer {
 	return m.MetricVec.WithLabelValues(lvs...).(Summary)
 }
 
 // With works as GetMetricWith, but panics where GetMetricWithLabels would have
 // returned an error. By not returning an error, With allows shortcuts like
 //     myVec.With(Labels{"code": "404", "method": "GET"}).Observe(42.21)
-func (m *SummaryVec) With(labels Labels) Summary {
+func (m *SummaryVec) With(labels Labels) Observer {
 	return m.MetricVec.With(labels).(Summary)
 }
 

--- a/prometheus/summary_test.go
+++ b/prometheus/summary_test.go
@@ -301,7 +301,7 @@ func TestSummaryVecConcurrency(t *testing.T) {
 		for i := 0; i < vecLength; i++ {
 			m := &dto.Metric{}
 			s := sum.WithLabelValues(string('A' + i))
-			s.Write(m)
+			s.(Summary).Write(m)
 			if got, want := int(*m.Summary.SampleCount), len(allVars[i]); got != want {
 				t.Errorf("got sample count %d for label %c, want %d", got, 'A'+i, want)
 			}

--- a/prometheus/timer.go
+++ b/prometheus/timer.go
@@ -15,32 +15,6 @@ package prometheus
 
 import "time"
 
-// Observer is the interface that wraps the Observe method, which is used by
-// Histogram and Summary to add observations.
-type Observer interface {
-	Observe(float64)
-}
-
-// The ObserverFunc type is an adapter to allow the use of ordinary
-// functions as Observers. If f is a function with the appropriate
-// signature, ObserverFunc(f) is an Observer that calls f.
-//
-// This adapter is usually used in connection with the Timer type, and there are
-// two general use cases:
-//
-// The most common one is to use a Gauge as the Observer for a Timer.
-// See the "Gauge" Timer example.
-//
-// The more advanced use case is to create a function that dynamically decides
-// which Observer to use for observing the duration. See the "Complex" Timer
-// example.
-type ObserverFunc func(float64)
-
-// Observe calls f(value). It implements Observer.
-func (f ObserverFunc) Observe(value float64) {
-	f(value)
-}
-
 // Timer is a helper type to time functions. Use NewTimer to create new
 // instances.
 type Timer struct {

--- a/prometheus/timer_test.go
+++ b/prometheus/timer_test.go
@@ -115,36 +115,36 @@ func TestTimerByOutcome(t *testing.T) {
 	}
 
 	timedFunc()
-	his.WithLabelValues("foo").Write(m)
+	his.WithLabelValues("foo").(Histogram).Write(m)
 	if want, got := uint64(0), m.GetHistogram().GetSampleCount(); want != got {
 		t.Errorf("want %d observations for 'foo' histogram, got %d", want, got)
 	}
 	m.Reset()
-	his.WithLabelValues("bar").Write(m)
+	his.WithLabelValues("bar").(Histogram).Write(m)
 	if want, got := uint64(1), m.GetHistogram().GetSampleCount(); want != got {
 		t.Errorf("want %d observations for 'bar' histogram, got %d", want, got)
 	}
 
 	timedFunc()
 	m.Reset()
-	his.WithLabelValues("foo").Write(m)
+	his.WithLabelValues("foo").(Histogram).Write(m)
 	if want, got := uint64(1), m.GetHistogram().GetSampleCount(); want != got {
 		t.Errorf("want %d observations for 'foo' histogram, got %d", want, got)
 	}
 	m.Reset()
-	his.WithLabelValues("bar").Write(m)
+	his.WithLabelValues("bar").(Histogram).Write(m)
 	if want, got := uint64(1), m.GetHistogram().GetSampleCount(); want != got {
 		t.Errorf("want %d observations for 'bar' histogram, got %d", want, got)
 	}
 
 	timedFunc()
 	m.Reset()
-	his.WithLabelValues("foo").Write(m)
+	his.WithLabelValues("foo").(Histogram).Write(m)
 	if want, got := uint64(1), m.GetHistogram().GetSampleCount(); want != got {
 		t.Errorf("want %d observations for 'foo' histogram, got %d", want, got)
 	}
 	m.Reset()
-	his.WithLabelValues("bar").Write(m)
+	his.WithLabelValues("bar").(Histogram).Write(m)
 	if want, got := uint64(2), m.GetHistogram().GetSampleCount(); want != got {
 		t.Errorf("want %d observations for 'bar' histogram, got %d", want, got)
 	}


### PR DESCRIPTION
The main premise is to provide some middleware that a user can compose as s/he wishes, instead of the "all or nothing" approach of the current `InstrumentHandler()` approach.

Things to note:

- This pr makes use of the `Observer` interface, and additionally adds an `ObserverVec` interface.
- The `ObserverVec` interface was discussed with @beorn7 and necessitated a breaking change to `SummaryVec` and `HistogramVec` by changing the return types of their methods for interacting with labels. @beorn7 scanned code usage for this library and saw that while it is a breaking change, in practice he didn't find anyone using methods other than `Observe()` on the return type, which will not break based on this change. @beorn7 can you confirm this?
- The tests fail because we are compiling against go-1.6 and go-1.7, while the code requires go-1.8 because of its use of `http.Pusher`.
- Additional work needs to be done to check that this works with http/2.
- The middleware **does not** register the collectors passed to them. This allows the user to a custom registery, as opposed to the default registry. This is decision is up for discussion.
- If a user doesn't write an http status in their wrapped handler, our middleware will report the default value (`0`). If no status is written, go doesn't add a status until all handlers have been executed: https://golang.org/src/net/http/server.go#L1830
