### PR TITLE
api: added go1.8 build tag

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build go1.7
+// +build go1.7 go1.8
 
 // Package api provides clients for the HTTP APIs.
 package api

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build go1.7
+// +build go1.7 go1.8
 
 package api
 

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build go1.7
+// +build go1.7 go1.8
 
 // Package v1 provides bindings to the Prometheus HTTP API v1:
 // http://prometheus.io/docs/querying/api/

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build go1.7
+// +build go1.7 go1.8
 
 package v1
 


### PR DESCRIPTION
Otherwise the api package works with go 1.7 only.