### PR TITLE
Add time to write header handler middleware

### DIFF
--- a/prometheus/promhttp/delegator_1_7.go
+++ b/prometheus/promhttp/delegator_1_7.go
@@ -20,8 +20,11 @@ import (
 	"net/http"
 )
 
-func newDelegator(w http.ResponseWriter) delegator {
-	d := &responseWriterDelegator{ResponseWriter: w}
+func newDelegator(w http.ResponseWriter, observeWriteHeaderFunc func(int)) delegator {
+	d := &responseWriterDelegator{
+		ResponseWriter:     w,
+		observeWriteHeader: observeWriteHeaderFunc,
+	}
 
 	_, cn := w.(http.CloseNotifier)
 	_, fl := w.(http.Flusher)

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -22,8 +22,11 @@ import (
 
 // newDelegator handles the four different methods of upgrading a
 // http.ResponseWriter to delegator.
-func newDelegator(w http.ResponseWriter) delegator {
-	d := &responseWriterDelegator{ResponseWriter: w}
+func newDelegator(w http.ResponseWriter, observeWriteHeaderFunc func(int)) delegator {
+	d := &responseWriterDelegator{
+		ResponseWriter:     w,
+		observeWriteHeader: observeWriteHeaderFunc,
+	}
 
 	_, cn := w.(http.CloseNotifier)
 	_, fl := w.(http.Flusher)

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -120,9 +120,6 @@ func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler)
 // labels. Note that partitioning of Histograms is expensive and should be used
 // judiciously.
 //
-// If the wrapped Handler does not set a status code via WriteHeader, no value
-// is reported.
-//
 // If the wrapped Handler panics before calling WriteHeader, no value is
 // reported.
 //

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -88,6 +88,23 @@ func TestMiddlewareAPI(t *testing.T) {
 	chain.ServeHTTP(w, r)
 }
 
+func TestInstrumentTimeToFirstWrite(t *testing.T) {
+	var i int
+	dobs := &responseWriterDelegator{
+		ResponseWriter: httptest.NewRecorder(),
+		observeWriteHeader: func(status int) {
+			i = status
+		},
+	}
+	d := newDelegator(dobs)
+
+	d.WriteHeader(http.StatusOK)
+
+	if i != http.StatusOK {
+		t.Fatalf("failed to execute observeWriteHeader")
+	}
+}
+
 func ExampleInstrumentHandlerDuration() {
 	inFlightGauge := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "in_flight_requests",

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -96,7 +96,7 @@ func TestInstrumentTimeToFirstWrite(t *testing.T) {
 			i = status
 		},
 	}
-	d := newDelegator(dobs)
+	d := newDelegator(dobs, nil)
 
 	d.WriteHeader(http.StatusOK)
 


### PR DESCRIPTION
@beorn7 first stab at writing the "time to writing header" middleware.

Things to note are:

- I've forgone branching between "has the code label" and "doesn't have the code label". They paths are too similar to warrant it IMO.
- As mentioned, this is just based off what I saw in https://github.com/mwitkow/go-httpwares/pull/12. No strong opinions one way or another, but this seemed like a simple way to implement it. I didn't think it necessary to generalize quite like that PR did with a slice of callback functions.