### PR TITLE
Remove remaining references to MetricVec from doc comments

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -70,9 +70,6 @@ func (c *counter) Add(v float64) {
 // if you want to count the same thing partitioned by various dimensions
 // (e.g. number of HTTP requests, partitioned by response code and
 // method). Create instances with NewCounterVec.
-//
-// CounterVec embeds MetricVec. See there for a full list of methods with
-// detailed documentation.
 type CounterVec struct {
 	*metricVec
 }

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -35,8 +35,7 @@ type metricVec struct {
 	hashAddByte func(h uint64, b byte) uint64
 }
 
-// newMetricVec returns an initialized MetricVec. The concrete value is
-// returned for embedding into another struct.
+// newMetricVec returns an initialized metricVec.
 func newMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) *metricVec {
 	return &metricVec{
 		children:    map[uint64][]metricWithLabelValues{},


### PR DESCRIPTION
MetricVec is un-experted by now. godoc handles that correctly by
showing the methods of the embedded un-exported metricVec with the
exported type (CounterVec, SummaryVec, ...) that embeds metricVec.

@grobie @ibigbug