### PR TITLE
http.go: incorrect error message displayed when no metrics encoded error

### DIFF
--- a/prometheus/http.go
+++ b/prometheus/http.go
@@ -96,7 +96,7 @@ func UninstrumentedHandler() http.Handler {
 			closer.Close()
 		}
 		if lastErr != nil && buf.Len() == 0 {
-			http.Error(w, "No metrics encoded, last error:\n\n"+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "No metrics encoded, last error:\n\n"+lastErr.Error(), http.StatusInternalServerError)
 			return
 		}
 		header := w.Header()


### PR DESCRIPTION
The "No metrics encoded" error was erroneously displayed the value of err, not lastErr.

It looks like this could potentially have caused a panic in this error condition, since `err` is never set in scope.