### PR TITLE
Drop Go1.6 support, add test for Go1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: go
 
 go:
- - 1.6.3
- - 1.7
- - 1.8.1
+ - 1.7.x
+ - 1.8.x
+ - 1.9.x
 
 script:
  - go test -short ./...

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is the [Go](http://golang.org) client library for
 instrumenting application code, and one for creating clients that talk to the
 Prometheus HTTP API.
 
+__This library requires Go1.7 or later.__
+
 ## Instrumenting applications
 
 [![code-coverage](http://gocover.io/_badge/github.com/prometheus/client_golang/prometheus)](http://gocover.io/github.com/prometheus/client_golang/prometheus) [![go-doc](https://godoc.org/github.com/prometheus/client_golang/prometheus?status.svg)](https://godoc.org/github.com/prometheus/client_golang/prometheus)


### PR DESCRIPTION
Also, document the version requirement.

Triggered by #333 . @stuartnelson3 @grobie @fabxc any concerns about dropping 1.6 support?
I'd say support for three minor version ought to be enough for anybody. Supporting too many versions will be quite a maintenance overhead, as demonstrated in #333. (We also have separate code for 1.7 and 1.8+ right now, which can be dropped once Go1.10 is out.)