### PR TITLE
Create Docker images for the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 _obj
 _test
 
+# Examples
+/examples/simple/simple
+/examples/random/random
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/examples/random/Dockerfile
+++ b/examples/random/Dockerfile
@@ -1,0 +1,20 @@
+# This Dockerfile builds an image for a client_golang example.
+#
+# Use as (from the root for the client_golang repository):
+#    docker build -f examples/$name/Dockerfile -t prometheus/golang-example-$name .
+
+# Builder image, where we build the example.
+FROM golang:1.9.0 AS builder
+WORKDIR /go/src/github.com/prometheus/client_golang
+COPY . .
+WORKDIR /go/src/github.com/prometheus/client_golang/prometheus
+RUN go get -d
+WORKDIR /go/src/github.com/prometheus/client_golang/examples/random
+RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w'
+
+# Final image.
+FROM scratch
+LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
+COPY --from=builder /go/src/github.com/prometheus/client_golang/examples/random .
+EXPOSE 8080
+ENTRYPOINT ["/random"]

--- a/examples/simple/Dockerfile
+++ b/examples/simple/Dockerfile
@@ -1,0 +1,20 @@
+# This Dockerfile builds an image for a client_golang example.
+#
+# Use as (from the root for the client_golang repository):
+#    docker build -f examples/$name/Dockerfile -t prometheus/golang-example-$name .
+
+# Builder image, where we build the example.
+FROM golang:1.9.0 AS builder
+WORKDIR /go/src/github.com/prometheus/client_golang
+COPY . .
+WORKDIR /go/src/github.com/prometheus/client_golang/prometheus
+RUN go get -d
+WORKDIR /go/src/github.com/prometheus/client_golang/examples/simple
+RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w'
+
+# Final image.
+FROM scratch
+LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
+COPY --from=builder /go/src/github.com/prometheus/client_golang/examples/simple .
+EXPOSE 8080
+ENTRYPOINT ["/simple"]


### PR DESCRIPTION
When those are published on Dockerhub, people will be able to start those
examples in fewer steps than the current documentation:

  https://prometheus.io/docs/introduction/getting_started/#starting-up-some-sample-targets

While relying on Docker may not be always wished, giving the possibility to
quickly start a daemon that exposes metrics can be useful in many tutorials.

This commit tries really hard to limit the number of per-example maintenance
work by sharing most of the Makefile to build the Docker images. The tiny top
level Makefiles in each example directory are strictly identical.

I've also copied the way the main prometheus repo tags its Dockerimage in the Makefile, I assume something else is givin its final tag by overriding DOCKER_IMAGE_NAME and DOCKER_IMAGE_TAG somewhere.

Updates: https://github.com/prometheus/client_golang/issues/347