### PR TITLE
Added a faster counter

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -28,11 +28,25 @@ func TestCounterAdd(t *testing.T) {
 		ConstLabels: Labels{"a": "1", "b": "2"},
 	}).(*counter)
 	counter.Inc()
-	if expected, got := 1., math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+		t.Errorf("Expected %f, got %f.", expected, got)
+	}
+	if expected, got := int64(1), counter.valInt; expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 	counter.Add(42)
-	if expected, got := 43., math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+		t.Errorf("Expected %f, got %f.", expected, got)
+	}
+	if expected, got := int64(43), counter.valInt; expected != got {
+		t.Errorf("Expected %f, got %f.", expected, got)
+	}
+
+	counter.Add(24.42)
+	if expected, got := 24.42, math.Float64frombits(counter.valBits); expected != got {
+		t.Errorf("Expected %f, got %f.", expected, got)
+	}
+	if expected, got := int64(43), counter.valInt; expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 
@@ -43,7 +57,7 @@ func TestCounterAdd(t *testing.T) {
 	m := &dto.Metric{}
 	counter.Write(m)
 
-	if expected, got := `label:<name:"a" value:"1" > label:<name:"b" value:"2" > counter:<value:43 > `, m.String(); expected != got {
+	if expected, got := `label:<name:"a" value:"1" > label:<name:"b" value:"2" > counter:<value:67.42 > `, m.String(); expected != got {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
 }

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -45,7 +45,6 @@ type value struct {
 	// to go first in the struct to guarantee alignment for atomic
 	// operations.  http://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	valBits uint64
-
 	// valInt is used to store values that are exact integers
 	valInt int64
 
@@ -99,8 +98,9 @@ func (v *value) Dec() {
 }
 
 func (v *value) Add(val float64) {
-	if math.Trunc(val) == val {
-		atomic.AddInt64(&v.valInt, int64(val))
+	ival := int64(val)
+	if float64(ival) == val {
+		v.add(ival)
 		return
 	}
 


### PR DESCRIPTION
We would like to use something in the prometheus ecosystem with comparable performance to `github.com/rcrowley/go-metrics`. It seems as though the use of [`atomic.CompareAndSwap`](https://github.com/prometheus/client_golang/blob/master/prometheus/value.go#L97) slows things down a bit, so we've made a counter that stores and uses an `int64` directly and leans on `atomic.*Int64` for locking.

This branch introduces the `FixedPrecisionCounter` type and I'd like some feedback on the approach generally (and name) before I plumb through the vector version of this counter.

As to how I benchmarked performance I used the following test file:

```go
package fpc

import (
        "testing"

        "github.com/prometheus/client_golang/prometheus"
        metrics "github.com/rcrowley/go-metrics"
)

var fpc prometheus.Counter
var p prometheus.Counter

func init() {
        fpc = prometheus.NewFixedPrecisionCounter(prometheus.Opts{
                Name: "foo",
                Help: "helpful message about foo",
        }, 0)
        p = prometheus.NewCounter(prometheus.CounterOpts{Name: "pfoo", Help: "pfoo help"})
        prometheus.MustRegister(fpc)
        prometheus.MustRegister(p)
}

func BenchmarkGoMetrics(b *testing.B) {
        c := metrics.NewCounter()
        b.RunParallel(func(pb *testing.PB) {
                for pb.Next() {
                        c.Inc(1)
                }
        })
}

func BenchmarkPromCounter(b *testing.B) {
        b.RunParallel(func(pb *testing.PB) {
                for pb.Next() {
                        p.Inc()
                }
        })
}

func BenchmarkFixedPrecisionCounter(b *testing.B) {
        b.RunParallel(func(pb *testing.PB) {
                for pb.Next() {
                        fpc.Inc()
                }
        })
}
```

We get the following performance numbers:

```
go test -cpu=64 -benchtime=5s -v -bench=. github.com/smcquay/fpc
goos: darwin
goarch: amd64
pkg: github.com/smcquay/fpc
BenchmarkGoMetrics-64                   500000000               13.2 ns/op
BenchmarkPromCounter-64                 100000000               62.1 ns/op
BenchmarkFixedPrecisionCounter-64       300000000               22.5 ns/op
PASS
ok      github.com/smcquay/fpc  23.261s
```