### PR TITLE
Add a benchmark for concurrent counter increments

### DIFF
--- a/prometheus/benchmark_test.go
+++ b/prometheus/benchmark_test.go
@@ -183,3 +183,17 @@ func BenchmarkHistogramNoLabels(b *testing.B) {
 		m.Observe(3.1415)
 	}
 }
+
+func BenchmarkParallelCounter(b *testing.B) {
+	c := NewCounter(CounterOpts{
+		Name: "benchmark_counter",
+		Help: "A Counter to benchmark it.",
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Inc()
+		}
+	})
+}


### PR DESCRIPTION
This is the simpler of the two tests that I was running, as asked for in #367.

The results of checking out `pre` and `post` the merge of our changes are as follows:

```bash
$ git co pre
$ go test -cpu=64 -benchtime=5s -v -bench Counter$ -run asldjkflaskjdf github.com/prometheus/client_golang/prometheus
goos: darwin
goarch: amd64
pkg: github.com/prometheus/client_golang/prometheus
BenchmarkCounter-64     100000000               65.7 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/prometheus/client_golang/prometheus  6.634s
$ git co post
$ go test -cpu=64 -benchtime=5s -v -bench Counter$ -run asldjkflaskjdf github.com/prometheus/client_golang/prometheus
goos: darwin
goarch: amd64
pkg: github.com/prometheus/client_golang/prometheus
BenchmarkCounter-64     500000000               14.7 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/prometheus/client_golang/prometheus  8.875s
```

The change seems to take 64-wide concurrent increments from `65.7` to `14.7` ns/op! Cool.

The main issue with the [other test I was using](https://github.com/smcquay/counters/blob/master/main.go) is that to get results that aren't impacted to the parallel benchmark implementation (to really force load on the counter) I had to test things as I did in that binary, outside the context of a Go benchmark. In fact the load on the scheduler prevented that test from simply saying "launch N goroutines, and be sure to exit after S seconds", because the sleep would never get scheduled because the greed of the computationally expensive other activities. You can see that binary forcing a `runtime.Gosched()` every `M` increments.

Alas, hopefully this helps.