### PR TITLE
Fix delegator return value for single hijacker

### DIFF
--- a/prometheus/promhttp/delegator.go
+++ b/prometheus/promhttp/delegator.go
@@ -115,7 +115,7 @@ func init() {
 		}{d, &flusherDelegator{d}, &closeNotifierDelegator{d}}
 	}
 	pickDelegator[hijacker] = func(d *responseWriterDelegator) delegator { // 4
-		return hijackerDelegator{d}
+		return &hijackerDelegator{d}
 	}
 	pickDelegator[hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 5
 		return struct {


### PR DESCRIPTION
Previously, the pickDelegator function was not returning a
*hijackerDelegator so the return value did not implement the Hijacker
interface. As a result, code that attempts to hijack the connection
would fail when using a type assertion.

All the other cases returned the hijackerDelegator correctly.