### PR TITLE
Update travis Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: go
 
 go:
- - 1.7.x
- - 1.8.x
- - 1.9.x
+  - 1.7.x # See README.md for current minimum version.
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
 
 script:
- - go test -short ./...
+  - go test -short ./...


### PR DESCRIPTION
* Add Go 1.10.x.
* Fix indenting.
* Run all tests.

Signed-off-by: Ben Kochie <superq@gmail.com>