### PR TITLE
Update DefaultRoundTripper to DialContext because Dial is deprecated

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -30,10 +30,10 @@ import (
 // DefaultRoundTripper is used if no RoundTripper is set in Config.
 var DefaultRoundTripper http.RoundTripper = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
-	Dial: (&net.Dialer{
+	DialContext: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-	}).Dial,
+	}).DialContext,
 	TLSHandshakeTimeout: 10 * time.Second,
 }
 


### PR DESCRIPTION
As per https://golang.org/pkg/net/http/#Transport.Dial documentation says

```
// Deprecated: Use DialContext instead, which allows the transport
// to cancel dials as soon as they are no longer needed.
// If both are set, DialContext takes priority.
```