### PR TITLE
Make delegators wrapping responseWriterDelegator have value receivers

### DIFF
--- a/prometheus/promhttp/delegator.go
+++ b/prometheus/promhttp/delegator.go
@@ -76,16 +76,16 @@ type flusherDelegator struct{ *responseWriterDelegator }
 type hijackerDelegator struct{ *responseWriterDelegator }
 type readerFromDelegator struct{ *responseWriterDelegator }
 
-func (d *closeNotifierDelegator) CloseNotify() <-chan bool {
+func (d closeNotifierDelegator) CloseNotify() <-chan bool {
 	return d.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
-func (d *flusherDelegator) Flush() {
+func (d flusherDelegator) Flush() {
 	d.ResponseWriter.(http.Flusher).Flush()
 }
-func (d *hijackerDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (d hijackerDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return d.ResponseWriter.(http.Hijacker).Hijack()
 }
-func (d *readerFromDelegator) ReadFrom(re io.Reader) (int64, error) {
+func (d readerFromDelegator) ReadFrom(re io.Reader) (int64, error) {
 	if !d.wroteHeader {
 		d.WriteHeader(http.StatusOK)
 	}

--- a/prometheus/promhttp/delegator.go
+++ b/prometheus/promhttp/delegator.go
@@ -102,34 +102,34 @@ func init() {
 		return d
 	}
 	pickDelegator[closeNotifier] = func(d *responseWriterDelegator) delegator { // 1
-		return &closeNotifierDelegator{d}
+		return closeNotifierDelegator{d}
 	}
 	pickDelegator[flusher] = func(d *responseWriterDelegator) delegator { // 2
-		return &flusherDelegator{d}
+		return flusherDelegator{d}
 	}
 	pickDelegator[flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 3
 		return struct {
 			*responseWriterDelegator
 			http.Flusher
 			http.CloseNotifier
-		}{d, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[hijacker] = func(d *responseWriterDelegator) delegator { // 4
-		return &hijackerDelegator{d}
+		return hijackerDelegator{d}
 	}
 	pickDelegator[hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 5
 		return struct {
 			*responseWriterDelegator
 			http.Hijacker
 			http.CloseNotifier
-		}{d, &hijackerDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 6
 		return struct {
 			*responseWriterDelegator
 			http.Hijacker
 			http.Flusher
-		}{d, &hijackerDelegator{d}, &flusherDelegator{d}}
+		}{d, hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 7
 		return struct {
@@ -137,7 +137,7 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, &hijackerDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom] = func(d *responseWriterDelegator) delegator { // 8
 		return readerFromDelegator{d}
@@ -147,14 +147,14 @@ func init() {
 			*responseWriterDelegator
 			io.ReaderFrom
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, &readerFromDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom+flusher] = func(d *responseWriterDelegator) delegator { // 10
 		return struct {
 			*responseWriterDelegator
 			io.ReaderFrom
 			http.Flusher
-		}{d, &readerFromDelegator{d}, &flusherDelegator{d}}
+		}{d, &readerFromDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[readerFrom+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 11
 		return struct {
@@ -162,14 +162,14 @@ func init() {
 			io.ReaderFrom
 			http.Flusher
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, &readerFromDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker] = func(d *responseWriterDelegator) delegator { // 12
 		return struct {
 			*responseWriterDelegator
 			io.ReaderFrom
 			http.Hijacker
-		}{d, &readerFromDelegator{d}, &hijackerDelegator{d}}
+		}{d, &readerFromDelegator{d}, hijackerDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 13
 		return struct {
@@ -177,7 +177,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, &hijackerDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, &readerFromDelegator{d}, hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 14
 		return struct {
@@ -185,7 +185,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.Flusher
-		}{d, &readerFromDelegator{d}, &hijackerDelegator{d}, &flusherDelegator{d}}
+		}{d, &readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 15
 		return struct {
@@ -194,6 +194,6 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, &hijackerDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, &readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 }

--- a/prometheus/promhttp/delegator.go
+++ b/prometheus/promhttp/delegator.go
@@ -147,14 +147,14 @@ func init() {
 			*responseWriterDelegator
 			io.ReaderFrom
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, closeNotifierDelegator{d}}
+		}{d, readerFromDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom+flusher] = func(d *responseWriterDelegator) delegator { // 10
 		return struct {
 			*responseWriterDelegator
 			io.ReaderFrom
 			http.Flusher
-		}{d, &readerFromDelegator{d}, flusherDelegator{d}}
+		}{d, readerFromDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[readerFrom+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 11
 		return struct {
@@ -162,14 +162,14 @@ func init() {
 			io.ReaderFrom
 			http.Flusher
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
+		}{d, readerFromDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker] = func(d *responseWriterDelegator) delegator { // 12
 		return struct {
 			*responseWriterDelegator
 			io.ReaderFrom
 			http.Hijacker
-		}{d, &readerFromDelegator{d}, hijackerDelegator{d}}
+		}{d, readerFromDelegator{d}, hijackerDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 13
 		return struct {
@@ -177,7 +177,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, hijackerDelegator{d}, closeNotifierDelegator{d}}
+		}{d, readerFromDelegator{d}, hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 14
 		return struct {
@@ -185,7 +185,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.Flusher
-		}{d, &readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}}
+		}{d, readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[readerFrom+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 15
 		return struct {
@@ -194,6 +194,6 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, &readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
+		}{d, readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 }

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -22,27 +22,27 @@ import (
 
 type pusherDelegator struct{ *responseWriterDelegator }
 
-func (d *pusherDelegator) Push(target string, opts *http.PushOptions) error {
+func (d pusherDelegator) Push(target string, opts *http.PushOptions) error {
 	return d.ResponseWriter.(http.Pusher).Push(target, opts)
 }
 
 func init() {
 	pickDelegator[pusher] = func(d *responseWriterDelegator) delegator { // 16
-		return &pusherDelegator{d}
+		return pusherDelegator{d}
 	}
 	pickDelegator[pusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 17
 		return struct {
 			*responseWriterDelegator
 			http.Pusher
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+flusher] = func(d *responseWriterDelegator) delegator { // 18
 		return struct {
 			*responseWriterDelegator
 			http.Pusher
 			http.Flusher
-		}{d, &pusherDelegator{d}, &flusherDelegator{d}}
+		}{d, pusherDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[pusher+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 19
 		return struct {
@@ -50,14 +50,14 @@ func init() {
 			http.Pusher
 			http.Flusher
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker] = func(d *responseWriterDelegator) delegator { // 20
 		return struct {
 			*responseWriterDelegator
 			http.Pusher
 			http.Hijacker
-		}{d, &pusherDelegator{d}, &hijackerDelegator{d}}
+		}{d, pusherDelegator{d}, &hijackerDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 21
 		return struct {
@@ -65,7 +65,7 @@ func init() {
 			http.Pusher
 			http.Hijacker
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &hijackerDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, &hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 22
 		return struct {
@@ -73,7 +73,7 @@ func init() {
 			http.Pusher
 			http.Hijacker
 			http.Flusher
-		}{d, &pusherDelegator{d}, &hijackerDelegator{d}, &flusherDelegator{d}}
+		}{d, pusherDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { //23
 		return struct {
@@ -82,14 +82,14 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &hijackerDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom] = func(d *responseWriterDelegator) delegator { // 24
 		return struct {
 			*responseWriterDelegator
 			http.Pusher
 			io.ReaderFrom
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+closeNotifier] = func(d *responseWriterDelegator) delegator { // 25
 		return struct {
@@ -97,7 +97,7 @@ func init() {
 			http.Pusher
 			io.ReaderFrom
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+flusher] = func(d *responseWriterDelegator) delegator { // 26
 		return struct {
@@ -105,7 +105,7 @@ func init() {
 			http.Pusher
 			io.ReaderFrom
 			http.Flusher
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &flusherDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 27
 		return struct {
@@ -114,7 +114,7 @@ func init() {
 			io.ReaderFrom
 			http.Flusher
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker] = func(d *responseWriterDelegator) delegator { // 28
 		return struct {
@@ -122,7 +122,7 @@ func init() {
 			http.Pusher
 			io.ReaderFrom
 			http.Hijacker
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &hijackerDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 29
 		return struct {
@@ -131,7 +131,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &hijackerDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 30
 		return struct {
@@ -140,7 +140,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.Flusher
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &hijackerDelegator{d}, &flusherDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 31
 		return struct {
@@ -150,7 +150,7 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, &pusherDelegator{d}, &readerFromDelegator{d}, &hijackerDelegator{d}, &flusherDelegator{d}, &closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 }
 

--- a/prometheus/promhttp/delegator_1_8.go
+++ b/prometheus/promhttp/delegator_1_8.go
@@ -57,7 +57,7 @@ func init() {
 			*responseWriterDelegator
 			http.Pusher
 			http.Hijacker
-		}{d, pusherDelegator{d}, &hijackerDelegator{d}}
+		}{d, pusherDelegator{d}, hijackerDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 21
 		return struct {
@@ -65,7 +65,7 @@ func init() {
 			http.Pusher
 			http.Hijacker
 			http.CloseNotifier
-		}{d, pusherDelegator{d}, &hijackerDelegator{d}, closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 22
 		return struct {
@@ -73,7 +73,7 @@ func init() {
 			http.Pusher
 			http.Hijacker
 			http.Flusher
-		}{d, pusherDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}}
+		}{d, pusherDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[pusher+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { //23
 		return struct {
@@ -82,7 +82,7 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, pusherDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom] = func(d *responseWriterDelegator) delegator { // 24
 		return struct {
@@ -122,7 +122,7 @@ func init() {
 			http.Pusher
 			io.ReaderFrom
 			http.Hijacker
-		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, hijackerDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker+closeNotifier] = func(d *responseWriterDelegator) delegator { // 29
 		return struct {
@@ -131,7 +131,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.CloseNotifier
-		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}, closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, hijackerDelegator{d}, closeNotifierDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker+flusher] = func(d *responseWriterDelegator) delegator { // 30
 		return struct {
@@ -140,7 +140,7 @@ func init() {
 			io.ReaderFrom
 			http.Hijacker
 			http.Flusher
-		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}}
 	}
 	pickDelegator[pusher+readerFrom+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 31
 		return struct {
@@ -150,7 +150,7 @@ func init() {
 			http.Hijacker
 			http.Flusher
 			http.CloseNotifier
-		}{d, pusherDelegator{d}, readerFromDelegator{d}, &hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
+		}{d, pusherDelegator{d}, readerFromDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}, closeNotifierDelegator{d}}
 	}
 }
 


### PR DESCRIPTION
Without doing so, they don't actually implement the interfaces they claim to.

EDIT: They do implement the interfaces in actual usage but can now more universally do so regardless of how they are references (value or pointer)