### PR TITLE
Unify Representation of Counter Values

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -37,6 +37,7 @@ type Counter interface {
 	// Inc increments the counter by 1. Use Add to increment it by arbitrary
 	// non-negative values.
 	Inc()
+
 	// Add adds the given value to the counter. It panics if the value is <
 	// 0.
 	Add(float64)
@@ -72,7 +73,6 @@ type counter struct {
 	// in the struct to guarantee alignment for atomic operations.
 	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	valBits uint64
-	valInt  uint64
 
 	selfCollector
 	desc *Desc
@@ -88,11 +88,6 @@ func (c *counter) Add(v float64) {
 	if v < 0 {
 		panic(errors.New("counter cannot decrease in value"))
 	}
-	ival := uint64(v)
-	if float64(ival) == v {
-		atomic.AddUint64(&c.valInt, ival)
-		return
-	}
 
 	for {
 		oldBits := atomic.LoadUint64(&c.valBits)
@@ -104,14 +99,11 @@ func (c *counter) Add(v float64) {
 }
 
 func (c *counter) Inc() {
-	atomic.AddUint64(&c.valInt, 1)
+	c.Add(1)
 }
 
 func (c *counter) Write(out *dto.Metric) error {
-	fval := math.Float64frombits(atomic.LoadUint64(&c.valBits))
-	ival := atomic.LoadUint64(&c.valInt)
-	val := fval + float64(ival)
-
+	val := math.Float64frombits(atomic.LoadUint64(&c.valBits))
 	return populateMetric(CounterValue, val, c.labelPairs, out)
 }
 

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -28,28 +28,18 @@ func TestCounterAdd(t *testing.T) {
 		ConstLabels: Labels{"a": "1", "b": "2"},
 	}).(*counter)
 	counter.Inc()
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 1.0, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
-	}
-	if expected, got := uint64(1), counter.valInt; expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 	counter.Add(42)
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 43.0, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
-	}
-	if expected, got := uint64(43), counter.valInt; expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
 	counter.Add(24.42)
-	if expected, got := 24.42, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 67.42, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(43), counter.valInt; expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
-	}
-
 	if expected, got := "counter cannot decrease in value", decreaseCounter(counter).Error(); expected != got {
 		t.Errorf("Expected error %q, got %q.", expected, got)
 	}
@@ -134,27 +124,18 @@ func TestCounterAddInf(t *testing.T) {
 	}).(*counter)
 
 	counter.Inc()
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 1.0, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
-	}
-	if expected, got := uint64(1), counter.valInt; expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
 	counter.Add(math.Inf(1))
 	if expected, got := math.Inf(1), math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(1), counter.valInt; expected != got {
-		t.Errorf("valInts expected %d, got %d.", expected, got)
-	}
 
 	counter.Inc()
 	if expected, got := math.Inf(1), math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
-	}
-	if expected, got := uint64(2), counter.valInt; expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
 	m := &dto.Metric{}
@@ -173,12 +154,12 @@ func TestCounterAddLarge(t *testing.T) {
 
 	// large overflows the underlying type and should therefore be stored in valBits.
 	large := float64(math.MaxUint64 + 1)
+	if large == 0 {
+		t.Fatalf("yup")
+	}
 	counter.Add(large)
 	if expected, got := large, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
-	}
-	if expected, got := uint64(0), counter.valInt; expected != got {
-		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 
 	m := &dto.Metric{}
@@ -198,9 +179,6 @@ func TestCounterAddSmall(t *testing.T) {
 	counter.Add(small)
 	if expected, got := small, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
-	}
-	if expected, got := uint64(0), counter.valInt; expected != got {
-		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 
 	m := &dto.Metric{}


### PR DESCRIPTION
### Summery

In short, why use two fields when you can use one.

### Motivation

1. Equating the cast results of floating points is a [non-trivial problem](https://randomascii.wordpress.com/2017/06/19/sometimes-floating-point-math-is-perfect/) and it shouldn't be relied on this.
2. Using 2 load fences will generally always be less performant then 1.
3. My company is dropping metrics in production, while investigating the problem I realized very small values in the `Add()` field could be dropped (see: `1`)

### Changes

* Removes the `bitsInt` field from `counter`
* The old `Inc()` function is now wrapping `Add(1)`

### Additional Changes

I updated the test suite to have the correct values. 