### PR TITLE
Add testutil package

### DIFF
--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -1,18 +1,15 @@
-/*
-Copyright 2018 The Prometheus Authors All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package testutil
 

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testutils
+package testutil
 
 import (
 	"bytes"

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -19,9 +19,11 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // GatherAndCompare retrieves all metrics exposed by a collector and compares it

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 he Prometheus Authors
+// Copyright 2018 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,12 +14,13 @@
 package testutil
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func TestGatherAndCompare(t *testing.T) {
+func TestCollectAndCompare(t *testing.T) {
 	const metadata = `
 		# HELP some_total A value that represents a counter.
 		# TYPE some_total counter
@@ -39,7 +40,7 @@ func TestGatherAndCompare(t *testing.T) {
 		some_total{ label1 = "value1" } 1
 	`
 
-	if err := GatherAndCompare(c, metadata+expected, "some_total"); err != nil {
+	if err := CollectAndCompare(c, strings.NewReader(metadata+expected), "some_total"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -63,7 +64,7 @@ func TestNoMetricFilter(t *testing.T) {
 		some_total{label1="value1"} 1
 	`
 
-	if err := GatherAndCompare(c, metadata+expected); err != nil {
+	if err := CollectAndCompare(c, strings.NewReader(metadata+expected)); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -103,7 +104,7 @@ some_total{label1="value1"} 1
 
 `
 
-	err := GatherAndCompare(c, metadata+expected)
+	err := CollectAndCompare(c, strings.NewReader(metadata+expected))
 	if err == nil {
 		t.Error("Expected error, got no error.")
 	}

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -1,3 +1,16 @@
+// Copyright 2018 he Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutil
 
 import (

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -1,4 +1,4 @@
-package testutils
+package testutil
 
 import (
 	"testing"

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -32,8 +31,6 @@ import (
 // to an expected output in the Prometheus text exposition format.
 // metricNames allows only comparing the given metrics. All are compared if it's nil.
 func GatherAndCompare(c prometheus.Collector, expected string, metricNames ...string) error {
-	expected = removeUnusedWhitespace(expected)
-
 	reg := prometheus.NewPedanticRegistry()
 	if err := reg.Register(c); err != nil {
 		return fmt.Errorf("registering collector failed: %s", err)
@@ -98,26 +95,6 @@ func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFam
 		}
 	}
 	return filtered
-}
-
-func removeUnusedWhitespace(s string) string {
-	var (
-		trimmedLine  string
-		trimmedLines []string
-		lines        = strings.Split(s, "\n")
-	)
-
-	for _, l := range lines {
-		trimmedLine = strings.TrimSpace(l)
-
-		if len(trimmedLine) > 0 {
-			trimmedLines = append(trimmedLines, trimmedLine)
-		}
-	}
-
-	// The Prometheus metrics representation parser expects an empty line at the
-	// end otherwise fails with an unexpected EOF error.
-	return strings.Join(trimmedLines, "\n") + "\n"
 }
 
 // The below sorting code is copied form the Prometheus client library modulo the added

--- a/testutils/testutils_test.go
+++ b/testutils/testutils_test.go
@@ -22,7 +22,8 @@ func TestGatherAndCompare(t *testing.T) {
 	c.Inc()
 
 	expected := `
-		some_total{label1="value1"} 1
+
+		some_total{ label1 = "value1" } 1
 	`
 
 	if err := GatherAndCompare(c, metadata+expected, "some_total"); err != nil {


### PR DESCRIPTION
This is derived from #423. I recreated it so that it is pulling from a branch I can push to...

Changes to #423 are based on the review that has already happened. I packaged it nicely in commits with messages, so you can follow along.

I will add more documentation and the single-value retrieval helpers (cf. #230) in a separate PR. Same with the creation of an internal package for the duplicated code. Don't want to put too many things into this one PR.

@grobie @brancz 