### PR TITLE
Add test-short target and use it in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ go:
   - 1.10.x
 
 script:
-  - make check_license style unused test
+  - make check_license style unused test-short
   - if [[ ! $TRAVIS_GO_VERSION =~ ^1\.(7|8)\.[x0-9]+$ ]]; then make staticcheck; fi

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ get_dep:
 
 .PHONY: test
 test: get_dep common-test
+
+.PHONY: test-short
+test-short: get_dep common-test-short


### PR DESCRIPTION
This is reinstating the old behavior. The longer tests are not only
long but also flaky. (The former is by design, the latter is a bug.)

Signed-off-by: beorn7 <beorn@soundcloud.com>

@simonpasquier @glefloch 