### PR TITLE
fix exponential buckets failure message

### DIFF
--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -344,7 +344,7 @@ func TestBuckets(t *testing.T) {
 	got = ExponentialBuckets(100, 1.2, 3)
 	want = []float64{100, 120, 144}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("linear buckets: got %v, want %v", got, want)
+		t.Errorf("exponential buckets: got %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
it appears there is a copy/paste error in the exponential buckets test failure message which is fixed here.  @beorn7 does this seem right?