### PR TITLE
Do not parse json on 204 responses

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -477,10 +477,12 @@ func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, [
 
 	var result apiResponse
 
-	if err = json.Unmarshal(body, &result); err != nil {
-		return resp, body, &Error{
-			Type: ErrBadResponse,
-			Msg:  err.Error(),
+	if 204 != code {
+		if err = json.Unmarshal(body, &result); err != nil {
+			return resp, body, &Error{
+				Type: ErrBadResponse,
+				Msg:  err.Error(),
+			}
 		}
 	}
 

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -477,7 +477,7 @@ func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, [
 
 	var result apiResponse
 
-	if 204 != code {
+	if http.StatusNoContent != code {
 		if err = json.Unmarshal(body, &result); err != nil {
 			return resp, body, &Error{
 				Type: ErrBadResponse,


### PR DESCRIPTION
This pull request fixes a problem where 204 responses are parsed as JSON. This incorrectly results in an error of `bad_response...`, since HTTP 204 is "No Content" and represents a successful response.

Signed-off-by: Adam Jaso <2285656+adamjaso@users.noreply.github.com>