### PR TITLE
WriteToTextfile function for node exporter textfiles

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -537,9 +537,12 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 	return internal.NormalizeMetricFamilies(metricFamiliesByName), errs.MaybeUnwrap()
 }
 
-// WriteToTextfile formats the metrics of the provided Gatherer interface and
-// emits them in text format to the path. Intended for use with the node_exporter
-// textfile collector
+// WriteToTextfile calls Gather on the provided Gatherer, encodes the result in the
+// Prometheus text format, and writes it to a temporary file. Upon success, the
+// temporary file is renamed to the provided filename.
+//
+// This is intended for use with the textfile collector of the node exporter.
+// Note that the node exporter expects the filename to be suffixed with ".prom".
 func WriteToTextfile(filename string, g Gatherer) error {
 	tmp, err := ioutil.TempFile(filepath.Dir(filename), filepath.Base(filename))
 	if err != nil {

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -562,7 +562,7 @@ func (r *Registry) WriteToTextfile(path string) error {
 			case dto.MetricType_GAUGE:
 				value := strconv.FormatFloat(metric.GetGauge().GetValue(), 'f', -1, 64)
 				labelString := fmt.Sprintf("{%s}", strings.Join(labelStrings, ","))
-				output = append(output, fmt.Sprintf("%s%s %is%s", metricFamily.GetName(), labelString, value, timestampString))
+				output = append(output, fmt.Sprintf("%s%s %s%s", metricFamily.GetName(), labelString, value, timestampString))
 			case dto.MetricType_UNTYPED:
 				value := strconv.FormatFloat(metric.GetUntyped().GetValue(), 'f', -1, 64)
 				labelString := fmt.Sprintf("{%s}", strings.Join(labelStrings, ","))

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -562,6 +562,10 @@ func WriteToTextfile(filename string, g Gatherer) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+
+	if err := os.Chmod(tmp.Name(), 0644); err != nil {
+		return err
+	}
 	return os.Rename(tmp.Name(), filename)
 }
 

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -958,7 +958,9 @@ test_summary_count{name="foo"} 2
 	}
 	defer os.Remove(tmpfile.Name())
 
-	registry.WriteToTextfile(tmpfile.Name())
+	if err := prometheus.WriteToTextfile(tmpfile.Name(), registry); err != nil {
+		t.Fatal(err)
+	}
 
 	fileBytes, err := ioutil.ReadFile(tmpfile.Name())
 	if err != nil {

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -21,9 +21,11 @@ package prometheus_test
 
 import (
 	"bytes"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -870,4 +872,101 @@ func TestHistogramVecRegisterGatherConcurrency(t *testing.T) {
 	time.Sleep(time.Second)
 	close(quit)
 	wg.Wait()
+}
+
+func TestWriteToTextfile(t *testing.T) {
+	expectedOut := `# HELP test_counter test counter
+# TYPE test_counter counter
+test_counter{name="qux"} 1
+# HELP test_gauge test gauge
+# TYPE test_gauge gauge
+test_gauge{name="baz"} 1.1
+# HELP test_hist test histogram
+# TYPE test_hist histogram
+test_hist_bucket{name="bar",le="0.005"} 0
+test_hist_bucket{name="bar",le="0.01"} 0
+test_hist_bucket{name="bar",le="0.025"} 0
+test_hist_bucket{name="bar",le="0.05"} 0
+test_hist_bucket{name="bar",le="0.1"} 0
+test_hist_bucket{name="bar",le="0.25"} 0
+test_hist_bucket{name="bar",le="0.5"} 0
+test_hist_bucket{name="bar",le="1"} 1
+test_hist_bucket{name="bar",le="2.5"} 1
+test_hist_bucket{name="bar",le="5"} 2
+test_hist_bucket{name="bar",le="10"} 2
+test_hist_bucket{name="bar",le="+Inf"} 2
+test_hist_sum{name="bar"} 3.64
+test_hist_count{name="bar"} 2
+# HELP test_summary test summary
+# TYPE test_summary summary
+test_summary{name="foo",quantile="0.5"} 10
+test_summary{name="foo",quantile="0.9"} 20
+test_summary{name="foo",quantile="0.99"} 20
+test_summary_sum{name="foo"} 30
+test_summary_count{name="foo"} 2
+`
+
+	registry := prometheus.NewRegistry()
+
+	summary := prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "test_summary",
+			Help: "test summary",
+		},
+		[]string{"name"},
+	)
+
+	histogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "test_hist",
+			Help: "test histogram",
+		},
+		[]string{"name"},
+	)
+
+	gauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "test_gauge",
+			Help: "test gauge",
+		},
+		[]string{"name"},
+	)
+
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "test_counter",
+			Help: "test counter",
+		},
+		[]string{"name"},
+	)
+
+	registry.MustRegister(summary)
+	registry.MustRegister(histogram)
+	registry.MustRegister(gauge)
+	registry.MustRegister(counter)
+
+	summary.With(prometheus.Labels{"name": "foo"}).Observe(10)
+	summary.With(prometheus.Labels{"name": "foo"}).Observe(20)
+	histogram.With(prometheus.Labels{"name": "bar"}).Observe(0.93)
+	histogram.With(prometheus.Labels{"name": "bar"}).Observe(2.71)
+	gauge.With(prometheus.Labels{"name": "baz"}).Set(1.1)
+	counter.With(prometheus.Labels{"name": "qux"}).Inc()
+
+	tmpfile, err := ioutil.TempFile("", "prom_registry_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	registry.WriteToTextfile(tmpfile.Name())
+
+	fileBytes, err := ioutil.ReadFile(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileContents := string(fileBytes)
+
+	if fileContents != expectedOut {
+		t.Error("file contents didn't match unexpected")
+	}
 }


### PR DESCRIPTION
@beorn7

This is my attempt to add (similar, and implementation copied from, [client_python](https://github.com/prometheus/client_python/blob/master/prometheus_client/exposition.py#L186)) WriteToTextfile for a Registry.

This is so we can write Go tools that emit Node Exporter textfiles.

My strategy is to create the same output from the promhttp HTML website.