### PR TITLE
Add the last few lines needed to show a new user how the Collector/Gatherer fits together

### DIFF
--- a/prometheus/example_clustermanager_test.go
+++ b/prometheus/example_clustermanager_test.go
@@ -13,7 +13,13 @@
 
 package prometheus_test
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"log"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
 
 // ClusterManager is an example for a system that might have been built without
 // Prometheus in mind. It models a central manager of jobs running in a
@@ -124,4 +130,13 @@ func ExampleCollector() {
 	// variables to then do something with them.
 	NewClusterManager("db", reg)
 	NewClusterManager("ca", reg)
+
+	// Add the built in process and golang metrics to this registry
+	reg.MustRegister(
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		prometheus.NewGoCollector(),
+	)
+
+	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
Or if that's too verbose, can we just add the `http.Handle("/metrics/inner", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))`  line to help the new user?