### PR TITLE
Add support for fetching rules with API client

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -173,10 +173,10 @@ type RulesResult struct {
 
 // RuleGroup models a rule group that contains a set of recording and alerting rules.
 type RuleGroup struct {
-	Name     string        `json:"name"`
-	File     string        `json:"file"`
-	Interval float64       `json:"interval"`
-	Rules    []interface{} `json:"rules"`
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Interval float64 `json:"interval"`
+	Rules    Rules   `json:"rules"`
 }
 
 // Recording and alerting rules are stored in the same slice to preserve the order

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -180,7 +180,9 @@ type RuleGroup struct {
 }
 
 // Recording and alerting rules are stored in the same slice to preserve the order
-// that rules are returned in by the API. Rule types can be determined using a type switch:
+// that rules are returned in by the API.
+//
+// Rule types can be determined using a type switch:
 //   switch v := rule.(type) {
 //   case RecordingRule:
 //   	fmt.Print("got a recording rule")

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -158,6 +158,12 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
+	doRules := func() func() (interface{}, error) {
+		return func() (interface{}, error) {
+			return promAPI.Rules(context.Background())
+		}
+	}
+
 	doTargets := func() func() (interface{}, error) {
 		return func() (interface{}, error) {
 			return promAPI.Targets(context.Background())
@@ -456,6 +462,110 @@ func TestAPIs(t *testing.T) {
 			do:        doAlertManagers(),
 			reqMethod: "GET",
 			reqPath:   "/api/v1/alertmanagers",
+			inErr:     fmt.Errorf("some error"),
+			err:       fmt.Errorf("some error"),
+		},
+
+		{
+			do:        doRules(),
+			reqMethod: "GET",
+			reqPath:   "/api/v1/rules",
+			inRes: map[string]interface{}{
+				"groups": []map[string]interface{}{
+					{
+						"file":     "/rules.yaml",
+						"interval": 60,
+						"name":     "example",
+						"rules": []map[string]interface{}{
+							{
+								"alerts": []map[string]interface{}{
+									{
+										"activeAt": testTime.UTC().Format(time.RFC3339Nano),
+										"annotations": map[string]interface{}{
+											"summary": "High request latency",
+										},
+										"labels": map[string]interface{}{
+											"alertname": "HighRequestLatency",
+											"severity":  "page",
+										},
+										"state": "firing",
+										"value": 1,
+									},
+								},
+								"annotations": map[string]interface{}{
+									"summary": "High request latency",
+								},
+								"duration": 600,
+								"health":   "ok",
+								"labels": map[string]interface{}{
+									"severity": "page",
+								},
+								"name":  "HighRequestLatency",
+								"query": "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5",
+								"type":  "alerting",
+							},
+							{
+								"health": "ok",
+								"name":   "job:http_inprogress_requests:sum",
+								"query":  "sum(http_inprogress_requests) by (job)",
+								"type":   "recording",
+							},
+						},
+					},
+				},
+			},
+			res: RulesResult{
+				Groups: []RuleGroup{
+					{
+						Name:     "example",
+						File:     "/rules.yaml",
+						Interval: 60,
+						Rules: []Rule{
+							{
+								Alerts: []Alert{
+									{
+										ActiveAt: testTime.UTC(),
+										Annotations: model.LabelSet{
+											"summary": "High request latency",
+										},
+										Labels: model.LabelSet{
+											"alertname": "HighRequestLatency",
+											"severity":  "page",
+										},
+										State: AlertStateFiring,
+										Value: 1,
+									},
+								},
+								Annotations: model.LabelSet{
+									"summary": "High request latency",
+								},
+								Labels: model.LabelSet{
+									"severity": "page",
+								},
+								Duration:  600,
+								Health:    RuleHealthGood,
+								Name:      "HighRequestLatency",
+								Query:     "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5",
+								Type:      RuleTypeAlerting,
+								LastError: "",
+							},
+							{
+								Health:    RuleHealthGood,
+								Name:      "job:http_inprogress_requests:sum",
+								Query:     "sum(http_inprogress_requests) by (job)",
+								Type:      RuleTypeRecording,
+								LastError: "",
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			do:        doRules(),
+			reqMethod: "GET",
+			reqPath:   "/api/v1/rules",
 			inErr:     fmt.Errorf("some error"),
 			err:       fmt.Errorf("some error"),
 		},

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -520,16 +520,8 @@ func TestAPIs(t *testing.T) {
 						Name:     "example",
 						File:     "/rules.yaml",
 						Interval: 60,
-						RecordingRules: []RecordingRule{
-							{
-								Health:    RuleHealthGood,
-								Name:      "job:http_inprogress_requests:sum",
-								Query:     "sum(http_inprogress_requests) by (job)",
-								LastError: "",
-							},
-						},
-						AlertingRules: []AlertingRule{
-							{
+						Rules: []interface{}{
+							AlertingRule{
 								Alerts: []*Alert{
 									{
 										ActiveAt: testTime.UTC(),
@@ -554,6 +546,12 @@ func TestAPIs(t *testing.T) {
 								Health:    RuleHealthGood,
 								Name:      "HighRequestLatency",
 								Query:     "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5",
+								LastError: "",
+							},
+							RecordingRule{
+								Health:    RuleHealthGood,
+								Name:      "job:http_inprogress_requests:sum",
+								Query:     "sum(http_inprogress_requests) by (job)",
 								LastError: "",
 							},
 						},

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -520,9 +520,17 @@ func TestAPIs(t *testing.T) {
 						Name:     "example",
 						File:     "/rules.yaml",
 						Interval: 60,
-						Rules: []Rule{
+						RecordingRules: []RecordingRule{
 							{
-								Alerts: []Alert{
+								Health:    RuleHealthGood,
+								Name:      "job:http_inprogress_requests:sum",
+								Query:     "sum(http_inprogress_requests) by (job)",
+								LastError: "",
+							},
+						},
+						AlertingRules: []AlertingRule{
+							{
+								Alerts: []*Alert{
 									{
 										ActiveAt: testTime.UTC(),
 										Annotations: model.LabelSet{
@@ -546,14 +554,6 @@ func TestAPIs(t *testing.T) {
 								Health:    RuleHealthGood,
 								Name:      "HighRequestLatency",
 								Query:     "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5",
-								Type:      RuleTypeAlerting,
-								LastError: "",
-							},
-							{
-								Health:    RuleHealthGood,
-								Name:      "job:http_inprogress_requests:sum",
-								Query:     "sum(http_inprogress_requests) by (job)",
-								Type:      RuleTypeRecording,
 								LastError: "",
 							},
 						},


### PR DESCRIPTION
This PR adds support for fetching [rules](https://prometheus.io/docs/prometheus/latest/querying/api/#rules) via the `/api/v1/rules` endpoint using the API client. Currently, the API client exposes no way to do this and it would be nice to have for external systems that wish to retrieve this information.

cc @beorn7