### PR TITLE
Fix potential race with LabelPairs

### DIFF
--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -360,7 +360,7 @@ func (h *histogram) Write(out *dto.Metric) error {
 
 	his.Bucket = buckets
 	out.Histogram = his
-	out.Label = h.labelPairs
+	out.Label = copyLabelPairs(h.labelPairs)
 
 	// Finally add all the cold counts to the new hot counts and reset the cold counts.
 	atomic.AddUint64(&hotCounts.count, count)

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -872,7 +872,7 @@ func checkMetricConsistency(
 	h = hashAddByte(h, separatorByte)
 	// Make sure label pairs are sorted. We depend on it for the consistency
 	// check.
-	sort.Sort(labelPairSorter(dtoMetric.Label))
+	sort.Stable(labelPairSorter(dtoMetric.Label))
 	for _, lp := range dtoMetric.Label {
 		h = hashAdd(h, lp.GetName())
 		h = hashAddByte(h, separatorByte)

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -791,7 +791,7 @@ func TestHistogramVecRegisterGatherConcurrency(t *testing.T) {
 				Help:        "This helps testing.",
 				ConstLabels: prometheus.Labels{"foo": "bar"},
 			},
-			[]string{"one", "two", "three"},
+			[]string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen"},
 		)
 		labelValues = []string{"a", "b", "c", "alpha", "beta", "gamma", "aleph", "beth", "gimel"}
 		quit        = make(chan struct{})
@@ -807,6 +807,19 @@ func TestHistogramVecRegisterGatherConcurrency(t *testing.T) {
 			default:
 				obs := rand.NormFloat64()*.1 + .2
 				hv.WithLabelValues(
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
+					labelValues[rand.Intn(len(labelValues))],
 					labelValues[rand.Intn(len(labelValues))],
 					labelValues[rand.Intn(len(labelValues))],
 					labelValues[rand.Intn(len(labelValues))],
@@ -848,7 +861,7 @@ func TestHistogramVecRegisterGatherConcurrency(t *testing.T) {
 					if len(g) != 1 {
 						t.Error("Gathered unexpected number of metric families:", len(g))
 					}
-					if len(g[0].Metric[0].Label) != 4 {
+					if len(g[0].Metric[0].Label) != 17 {
 						t.Error("Gathered unexpected number of label pairs:", len(g[0].Metric[0].Label))
 					}
 				}
@@ -869,7 +882,7 @@ func TestHistogramVecRegisterGatherConcurrency(t *testing.T) {
 	go gather()
 	go observe()
 
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 	close(quit)
 	wg.Wait()
 }

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -125,7 +125,7 @@ func populateMetric(
 	labelPairs []*dto.LabelPair,
 	m *dto.Metric,
 ) error {
-	m.Label = labelPairs
+	m.Label = copyLabelPairs(labelPairs)
 	switch t {
 	case CounterValue:
 		m.Counter = &dto.Counter{Value: proto.Float64(v)}
@@ -158,5 +158,17 @@ func makeLabelPairs(desc *Desc, labelValues []string) []*dto.LabelPair {
 	}
 	labelPairs = append(labelPairs, desc.constLabelPairs...)
 	sort.Sort(labelPairSorter(labelPairs))
+	return labelPairs
+}
+
+func copyLabelPairs(source []*dto.LabelPair) []*dto.LabelPair {
+	labelPairs := make([]*dto.LabelPair, 0, len(source))
+	for _, pair := range source {
+		labelPairs = append(labelPairs, &dto.LabelPair{
+			Name:  pair.Name,
+			Value: pair.Value,
+		})
+	}
+	// shouldn't need sorting, as it should already be sorted
 	return labelPairs
 }


### PR DESCRIPTION
Add a `copyLabelPairs` method to `prometheus/value.go` and have `populateMetric` and `histogram.Write` use that method for serialization of labelPairs.

This is an attempt to address: https://github.com/istio/istio/issues/10236

There may be better ways to address this, etc. This PR is merely meant to suggest one solution.

Before this PR, with the modifications to the unit test shown in this PR:

```
--- FAIL: TestHistogramVecRegisterGatherConcurrency (2.04s)
    registry_test.go:856: Gathering failed: labels in collected metric test_histogram label:<name:"eight" value:"alpha" > label:<name:"eleven" value:"gimel" > label:<name:"fifteen" value:"beta" > label:<name:"five" value:"aleph" > label:<name:"foo" value:"bar" > label:<name:"four" value:"gimel" > label:<name:"fourteen" value:"b" > label:<name:"nine" value:"a" > label:<name:"one" value:"aleph" > label:<name:"seven" value:"c" > label:<name:"six" value:"gimel" > label:<name:"sixteen" value:"gamma" > label:<name:"ten" value:"gimel" > label:<name:"thirteen" value:"alpha" > label:<name:"three" value:"alpha" > label:<name:"twelve" value:"aleph" > label:<name:"two" value:"gimel" > histogram:<sample_count:1 sample_sum:0.14491978781995843 bucket:<cumulative_count:0 upper_bound:0.005 > bucket:<cumulative_count:0 upper_bound:0.01 > bucket:<cumulative_count:0 upper_bound:0.025 > bucket:<cumulative_count:0 upper_bound:0.05 > bucket:<cumulative_count:0 upper_bound:0.1 > bucket:<cumulative_count:1 upper_bound:0.25 > bucket:<cumulative_count:1 upper_bound:0.5 > bucket:<cumulative_count:1 upper_bound:1 > bucket:<cumulative_count:1 upper_bound:2.5 > bucket:<cumulative_count:1 upper_bound:5 > bucket:<cumulative_count:1 upper_bound:10 > >  are inconsistent with descriptor Desc{fqName: "test_histogram", help: "This helps testing.", constLabels: {foo="bar"}, variableLabels: [one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]}
    registry_test.go:856: Gathering failed: labels in collected metric test_histogram label:<name:"eight" value:"c" > label:<name:"eleven" value:"gamma" > label:<name:"fifteen" value:"a" > label:<name:"five" value:"b" > label:<name:"foo" value:"bar" > label:<name:"four" value:"aleph" > label:<name:"fourteen" value:"b" > label:<name:"nine" value:"gamma" > label:<name:"one" value:"gimel" > label:<name:"seven" value:"beth" > label:<name:"six" value:"c" > label:<name:"sixteen" value:"aleph" > label:<name:"ten" value:"alpha" > label:<name:"thirteen" value:"b" > label:<name:"three" value:"beta" > label:<name:"twelve" value:"alpha" > label:<name:"two" value:"gimel" > histogram:<sample_count:1 sample_sum:0.2885442155939729 bucket:<cumulative_count:0 upper_bound:0.005 > bucket:<cumulative_count:0 upper_bound:0.01 > bucket:<cumulative_count:0 upper_bound:0.025 > bucket:<cumulative_count:0 upper_bound:0.05 > bucket:<cumulative_count:0 upper_bound:0.1 > bucket:<cumulative_count:0 upper_bound:0.25 > bucket:<cumulative_count:1 upper_bound:0.5 > bucket:<cumulative_count:1 upper_bound:1 > bucket:<cumulative_count:1 upper_bound:2.5 > bucket:<cumulative_count:1 upper_bound:5 > bucket:<cumulative_count:1 upper_bound:10 > >  are inconsistent with descriptor Desc{fqName: "test_histogram", help: "This helps testing.", constLabels: {foo="bar"}, variableLabels: [one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]}
    registry_test.go:856: Gathering failed: labels in collected metric test_histogram label:<name:"eight" value:"c" > label:<name:"eleven" value:"gamma" > label:<name:"five" value:"gamma" > label:<name:"foo" value:"bar" > label:<name:"four" value:"gamma" > label:<name:"nine" value:"beta" > label:<name:"fourteen" value:"gamma" > label:<name:"one" value:"c" > label:<name:"seven" value:"beth" > label:<name:"fifteen" value:"gimel" > label:<name:"six" value:"gamma" > label:<name:"sixteen" value:"gimel" > label:<name:"ten" value:"beta" > label:<name:"thirteen" value:"alpha" > label:<name:"three" value:"beta" > label:<name:"twelve" value:"b" > label:<name:"two" value:"aleph" > histogram:<sample_count:1 sample_sum:0.453247760614353 bucket:<cumulative_count:0 upper_bound:0.005 > bucket:<cumulative_count:0 upper_bound:0.01 > bucket:<cumulative_count:0 upper_bound:0.025 > bucket:<cumulative_count:0 upper_bound:0.05 > bucket:<cumulative_count:0 upper_bound:0.1 > bucket:<cumulative_count:0 upper_bound:0.25 > bucket:<cumulative_count:1 upper_bound:0.5 > bucket:<cumulative_count:1 upper_bound:1 > bucket:<cumulative_count:1 upper_bound:2.5 > bucket:<cumulative_count:1 upper_bound:5 > bucket:<cumulative_count:1 upper_bound:10 > >  are inconsistent with descriptor Desc{fqName: "test_histogram", help: "This helps testing.", constLabels: {foo="bar"}, variableLabels: [one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]}
    registry_test.go:856: Gathering failed: labels in collected metric test_histogram label:<name:"eight" value:"c" > label:<name:"eleven" value:"gamma" > label:<name:"five" value:"gamma" > label:<name:"foo" value:"bar" > label:<name:"four" value:"gamma" > label:<name:"nine" value:"beta" > label:<name:"fourteen" value:"gamma" > label:<name:"one" value:"c" > label:<name:"seven" value:"beth" > label:<name:"fifteen" value:"gimel" > label:<name:"six" value:"gamma" > label:<name:"sixteen" value:"gimel" > label:<name:"ten" value:"beta" > label:<name:"thirteen" value:"alpha" > label:<name:"three" value:"beta" > label:<name:"twelve" value:"b" > label:<name:"two" value:"aleph" > histogram:<sample_count:1 sample_sum:0.453247760614353 bucket:<cumulative_count:0 upper_bound:0.005 > bucket:<cumulative_count:0 upper_bound:0.01 > bucket:<cumulative_count:0 upper_bound:0.025 > bucket:<cumulative_count:0 upper_bound:0.05 > bucket:<cumulative_count:0 upper_bound:0.1 > bucket:<cumulative_count:0 upper_bound:0.25 > bucket:<cumulative_count:1 upper_bound:0.5 > bucket:<cumulative_count:1 upper_bound:1 > bucket:<cumulative_count:1 upper_bound:2.5 > bucket:<cumulative_count:1 upper_bound:5 > bucket:<cumulative_count:1 upper_bound:10 > >  are inconsistent with descriptor Desc{fqName: "test_histogram", help: "This helps testing.", constLabels: {foo="bar"}, variableLabels: [one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]}
    registry_test.go:856: Gathering failed: 2 error(s) occurred:
        * labels in collected metric test_histogram label:<name:"eight" value:"aleph" > label:<name:"eleven" value:"alpha" > label:<name:"fifteen" value:"a" > label:<name:"five" value:"gimel" > label:<name:"foo" value:"bar" > label:<name:"four" value:"beth" > label:<name:"fourteen" value:"gamma" > label:<name:"nine" value:"b" > label:<name:"one" value:"beta" > label:<name:"seven" value:"alpha" > label:<name:"six" value:"gamma" > label:<name:"sixteen" value:"a" > label:<name:"ten" value:"beta" > label:<name:"thirteen" value:"b" > label:<name:"three" value:"b" > label:<name:"twelve" value:"b" > label:<name:"two" value:"c" > histogram:<sample_count:1 sample_sum:0.09970312840959775 bucket:<cumulative_count:0 upper_bound:0.005 > bucket:<cumulative_count:0 upper_bound:0.01 > bucket:<cumulative_count:0 upper_bound:0.025 > bucket:<cumulative_count:0 upper_bound:0.05 > bucket:<cumulative_count:1 upper_bound:0.1 > bucket:<cumulative_count:1 upper_bound:0.25 > bucket:<cumulative_count:1 upper_bound:0.5 > bucket:<cumulative_count:1 upper_bound:1 > bucket:<cumulative_count:1 upper_bound:2.5 > bucket:<cumulative_count:1 upper_bound:5 > bucket:<cumulative_count:1 upper_bound:10 > >  are inconsistent with descriptor Desc{fqName: "test_histogram", help: "This helps testing.", constLabels: {foo="bar"}, variableLabels: [one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]}
        * labels in collected metric test_histogram label:<name:"eight" value:"beta" > label:<name:"eleven" value:"alpha" > label:<name:"fifteen" value:"beta" > label:<name:"five" value:"gimel" > label:<name:"foo" value:"bar" > label:<name:"four" value:"c" > label:<name:"fourteen" value:"alpha" > label:<name:"nine" value:"gamma" > label:<name:"one" value:"beth" > label:<name:"seven" value:"gamma" >label:<name:"six" value:"gamma" > label:<name:"sixteen" value:"gimel" > label:<name:"ten" value:"gimel" > label:<name:"thirteen" value:"aleph" > label:<name:"three" value:"aleph" > label:<name:"twelve" value:"gamma" > label:<name:"two" value:"a" > histogram:<sample_count:1 sample_sum:0.11973892090427114 bucket:<cumulative_count:0 upper_bound:0.005 > bucket:<cumulative_count:0 upper_bound:0.01 > bucket:<cumulative_count:0 upper_bound:0.025 > bucket:<cumulative_count:0 upper_bound:0.05 > bucket:<cumulative_count:0 upper_bound:0.1 > bucket:<cumulative_count:1 upper_bound:0.25 > bucket:<cumulative_count:1 upper_bound:0.5 > bucket:<cumulative_count:1 upper_bound:1 > bucket:<cumulative_count:1 upper_bound:2.5 > bucket:<cumulative_count:1 upper_bound:5 > bucket:<cumulative_count:1 upper_bound:10 > > are inconsistent with descriptor Desc{fqName: "test_histogram", help: "This helps testing.", constLabels: {foo="bar"}, variableLabels: [one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]}
```

With the `copyLabelPairs` patch:

```
$ GO111MODULE=on go test -v prometheus/registry_test.go
=== RUN   TestHandler
--- PASS: TestHandler (0.01s)
=== RUN   TestAlreadyRegistered
--- PASS: TestAlreadyRegistered (0.00s)
=== RUN   TestHistogramVecRegisterGatherConcurrency
--- PASS: TestHistogramVecRegisterGatherConcurrency (2.05s)
=== RUN   TestWriteToTextfile
--- PASS: TestWriteToTextfile (0.00s)
PASS
ok      command-line-arguments  2.117s
```

cc: @beorn7 