### PR TITLE
Adjust to breaking change in prometheus/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
-	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
+	github.com/prometheus/common v0.0.0-20181218105931-67670fe90761
 	github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a
-	golang.org/x/net v0.0.0-20181201002055-351d144fa1fc
+	golang.org/x/net v0.0.0-20181217023233-e147a9138326
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,11 +6,11 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
-github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 h1:PnBWHBf+6L0jOqq0gIVUe6Yk0/QMZ640k6NvkxcBf+8=
-github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.0.0-20181218105931-67670fe90761 h1:z6tvbDJ5OLJ48FFmnksv04a78maSTRBUIhkdHYV5Y98=
+github.com/prometheus/common v0.0.0-20181218105931-67670fe90761/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-golang.org/x/net v0.0.0-20181201002055-351d144fa1fc h1:a3CU5tJYVj92DY2LaA1kUkrsqD5/3mLDhx2NcNqyW+0=
-golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181217023233-e147a9138326 h1:iCzOf0xz39Tstp+Tu/WwyGjUXCk34QhQORRxBeXXTA4=
+golang.org/x/net v0.0.0-20181217023233-e147a9138326/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -109,11 +109,11 @@ error collecting metric Desc{fqName: "invalid_metric", help: "not helpful", cons
 `
 	wantOKBody := `# HELP name docstring
 # TYPE name counter
-name{constname="constvalue",labelname="val1"} 1
-name{constname="constvalue",labelname="val2"} 1
+name{constname="constvalue",labelname="val1"} 1.0
+name{constname="constvalue",labelname="val2"} 1.0
 # HELP the_count Ah-ah-ah! Thunder and lightning!
 # TYPE the_count counter
-the_count 0
+the_count 0.0
 `
 
 	errorHandler.ServeHTTP(writer, request)
@@ -163,11 +163,11 @@ func TestInstrumentMetricHandler(t *testing.T) {
 		t.Errorf("got HTTP status code %d, want %d", got, want)
 	}
 
-	want := "promhttp_metric_handler_requests_in_flight 1\n"
+	want := "promhttp_metric_handler_requests_in_flight 1.0\n"
 	if got := writer.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("got body %q, does not contain %q", got, want)
 	}
-	want = "promhttp_metric_handler_requests_total{code=\"200\"} 0\n"
+	want = "promhttp_metric_handler_requests_total{code=\"200\"} 0.0\n"
 	if got := writer.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("got body %q, does not contain %q", got, want)
 	}
@@ -178,11 +178,11 @@ func TestInstrumentMetricHandler(t *testing.T) {
 		t.Errorf("got HTTP status code %d, want %d", got, want)
 	}
 
-	want = "promhttp_metric_handler_requests_in_flight 1\n"
+	want = "promhttp_metric_handler_requests_in_flight 1.0\n"
 	if got := writer.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("got body %q, does not contain %q", got, want)
 	}
-	want = "promhttp_metric_handler_requests_total{code=\"200\"} 1\n"
+	want = "promhttp_metric_handler_requests_total{code=\"200\"} 1.0\n"
 	if got := writer.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("got body %q, does not contain %q", got, want)
 	}

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -99,7 +99,7 @@ func testHandler(t testing.TB) {
 	externalMetricFamilyAsBytes := externalBuf.Bytes()
 	externalMetricFamilyAsText := []byte(`# HELP externalname externaldocstring
 # TYPE externalname counter
-externalname{externalconstname="externalconstvalue",externallabelname="externalval1"} 1
+externalname{externalconstname="externalconstvalue",externallabelname="externalval1"} 1.0
 `)
 	externalMetricFamilyAsProtoText := []byte(`name: "externalname"
 help: "externaldocstring"
@@ -167,8 +167,8 @@ metric: <
 	expectedMetricFamilyAsBytes := buf.Bytes()
 	expectedMetricFamilyAsText := []byte(`# HELP name docstring
 # TYPE name counter
-name{constname="constvalue",labelname="val1"} 1
-name{constname="constvalue",labelname="val2"} 1
+name{constname="constvalue",labelname="val1"} 1.0
+name{constname="constvalue",labelname="val2"} 1.0
 `)
 	expectedMetricFamilyAsProtoText := []byte(`name: "name"
 help: "docstring"
@@ -267,8 +267,8 @@ collected metric "name" { label:<name:"constname" value:"\377" > label:<name:"la
 complex{quantile="0.5"} NaN
 complex{quantile="0.9"} NaN
 complex{quantile="0.99"} NaN
-complex_sum 0
-complex_count 0
+complex_sum 0.0
+complex_count 0.0
 `)
 	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "complex",
@@ -288,7 +288,7 @@ complex_count 0
 	}
 	externalMetricFamilyWithBucketSuffixAsText := []byte(`# HELP complex_bucket externaldocstring
 # TYPE complex_bucket counter
-complex_bucket 1
+complex_bucket 1.0
 `)
 	externalMetricFamilyWithCountSuffix := &dto.MetricFamily{
 		Name: proto.String("complex_count"),
@@ -883,33 +883,33 @@ func TestHistogramVecRegisterGatherConcurrency(t *testing.T) {
 func TestWriteToTextfile(t *testing.T) {
 	expectedOut := `# HELP test_counter test counter
 # TYPE test_counter counter
-test_counter{name="qux"} 1
+test_counter{name="qux"} 1.0
 # HELP test_gauge test gauge
 # TYPE test_gauge gauge
 test_gauge{name="baz"} 1.1
 # HELP test_hist test histogram
 # TYPE test_hist histogram
-test_hist_bucket{name="bar",le="0.005"} 0
-test_hist_bucket{name="bar",le="0.01"} 0
-test_hist_bucket{name="bar",le="0.025"} 0
-test_hist_bucket{name="bar",le="0.05"} 0
-test_hist_bucket{name="bar",le="0.1"} 0
-test_hist_bucket{name="bar",le="0.25"} 0
-test_hist_bucket{name="bar",le="0.5"} 0
-test_hist_bucket{name="bar",le="1"} 1
-test_hist_bucket{name="bar",le="2.5"} 1
-test_hist_bucket{name="bar",le="5"} 2
-test_hist_bucket{name="bar",le="10"} 2
-test_hist_bucket{name="bar",le="+Inf"} 2
+test_hist_bucket{name="bar",le="0.005"} 0.0
+test_hist_bucket{name="bar",le="0.01"} 0.0
+test_hist_bucket{name="bar",le="0.025"} 0.0
+test_hist_bucket{name="bar",le="0.05"} 0.0
+test_hist_bucket{name="bar",le="0.1"} 0.0
+test_hist_bucket{name="bar",le="0.25"} 0.0
+test_hist_bucket{name="bar",le="0.5"} 0.0
+test_hist_bucket{name="bar",le="1.0"} 1.0
+test_hist_bucket{name="bar",le="2.5"} 1.0
+test_hist_bucket{name="bar",le="5.0"} 2.0
+test_hist_bucket{name="bar",le="10.0"} 2.0
+test_hist_bucket{name="bar",le="+Inf"} 2.0
 test_hist_sum{name="bar"} 3.64
-test_hist_count{name="bar"} 2
+test_hist_count{name="bar"} 2.0
 # HELP test_summary test summary
 # TYPE test_summary summary
-test_summary{name="foo",quantile="0.5"} 10
-test_summary{name="foo",quantile="0.9"} 20
-test_summary{name="foo",quantile="0.99"} 20
-test_summary_sum{name="foo"} 30
-test_summary_count{name="foo"} 2
+test_summary{name="foo",quantile="0.5"} 10.0
+test_summary{name="foo",quantile="0.9"} 20.0
+test_summary{name="foo",quantile="0.99"} 20.0
+test_summary_sum{name="foo"} 30.0
+test_summary_count{name="foo"} 2.0
 `
 
 	registry := prometheus.NewRegistry()
@@ -975,6 +975,6 @@ test_summary_count{name="foo"} 2
 	fileContents := string(fileBytes)
 
 	if fileContents != expectedOut {
-		t.Error("file contents didn't match unexpected")
+		t.Error("file contents didn't match expected result")
 	}
 }

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -135,7 +135,7 @@ func TestCollectAndCompare(t *testing.T) {
 
 	expected := `
 
-		some_total{ label1 = "value1" } 1
+		some_total{ label1 = "value1" } 1.0
 	`
 
 	if err := CollectAndCompare(c, strings.NewReader(metadata+expected), "some_total"); err != nil {
@@ -157,7 +157,7 @@ func TestCollectAndCompareNoLabel(t *testing.T) {
 
 	expected := `
 
-		some_total 1
+		some_total 1.0
 	`
 
 	if err := CollectAndCompare(c, strings.NewReader(metadata+expected), "some_total"); err != nil {
@@ -186,10 +186,10 @@ func TestCollectAndCompareHistogram(t *testing.T) {
 				# TYPE some_histogram histogram
 			`,
 			expect: `
-				some_histogram{le="1"} 0
-				some_histogram{le="2"} 0
-				some_histogram{le="3"} 1
-        			some_histogram_bucket{le="+Inf"} 1
+				some_histogram{le="1"} 0.0
+				some_histogram{le="2"} 0.0
+				some_histogram{le="3"} 1.0
+        			some_histogram_bucket{le="+Inf"} 1.0
         			some_histogram_sum 2.5
         			some_histogram_count 1
 
@@ -209,12 +209,12 @@ func TestCollectAndCompareHistogram(t *testing.T) {
 				# TYPE some_histogram histogram
 			`,
 			expect: `
-            			some_histogram_bucket{test="test",le="1"} 0
-            			some_histogram_bucket{test="test",le="2"} 0
-            			some_histogram_bucket{test="test",le="3"} 1
-            			some_histogram_bucket{test="test",le="+Inf"} 1
+            			some_histogram_bucket{test="test",le="1"} 0.0
+            			some_histogram_bucket{test="test",le="2"} 0.0
+            			some_histogram_bucket{test="test",le="3"} 1.0
+            			some_histogram_bucket{test="test",le="+Inf"} 1.0
             			some_histogram_sum{test="test"} 2.5
-           		 	some_histogram_count{test="test"} 1
+           		 	some_histogram_count{test="test"} 1.0
 		
 			`,
 			observation: 2.5,
@@ -257,7 +257,7 @@ func TestNoMetricFilter(t *testing.T) {
 	c.Inc()
 
 	expected := `
-		some_total{label1="value1"} 1
+		some_total{label1="value1"} 1.0
 	`
 
 	if err := CollectAndCompare(c, strings.NewReader(metadata+expected)); err != nil {
@@ -281,7 +281,7 @@ func TestMetricNotFound(t *testing.T) {
 	c.Inc()
 
 	expected := `
-		some_other_metric{label1="value1"} 1
+		some_other_metric{label1="value1"} 1.0
 	`
 
 	expectedError := `
@@ -289,14 +289,14 @@ metric output does not match expectation; want:
 
 # HELP some_other_metric A value that represents a counter.
 # TYPE some_other_metric counter
-some_other_metric{label1="value1"} 1
+some_other_metric{label1="value1"} 1.0
 
 
 got:
 
 # HELP some_total A value that represents a counter.
 # TYPE some_total counter
-some_total{label1="value1"} 1
+some_total{label1="value1"} 1.0
 
 `
 


### PR DESCRIPTION
This updates the Go modules and it will then also fix the pre-Go1.11 builds (which always build from head of the dependencies).