### PR TITLE
Update Makefile.common to current upstream version

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -29,6 +29,8 @@ GO           ?= go
 GOFMT        ?= $(GO)fmt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 GOOPTS       ?=
+GOHOSTOS     ?= $(shell $(GO) env GOHOSTOS)
+GOHOSTARCH   ?= $(shell $(GO) env GOHOSTARCH)
 
 GO_VERSION        ?= $(shell $(GO) version)
 GO_VERSION_NUMBER ?= $(word 3, $(GO_VERSION))
@@ -62,16 +64,29 @@ PROMU        := $(FIRST_GOPATH)/bin/promu
 STATICCHECK  := $(FIRST_GOPATH)/bin/staticcheck
 pkgs          = ./...
 
-GO_VERSION        ?= $(shell $(GO) version)
-GO_BUILD_PLATFORM ?= $(subst /,-,$(lastword $(GO_VERSION)))
+ifeq (arm, $(GOHOSTARCH))
+	GOHOSTARM ?= $(shell GOARM= $(GO) env GOARM)
+	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)v$(GOHOSTARM)
+else
+	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)
+endif
 
 PROMU_VERSION ?= 0.2.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
+STATICCHECK_VERSION ?= 2019.1
+STATICCHECK_URL     := https://github.com/dominikh/go-tools/releases/download/$(STATICCHECK_VERSION)/staticcheck_$(GOHOSTOS)_$(GOHOSTARCH)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 DOCKER_REPO             ?= prom
+
+ifeq ($(GOHOSTARCH),amd64)
+        ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin windows))
+                # Only supported on amd64
+                test-flags := -race
+        endif
+endif
 
 .PHONY: all
 all: precheck style staticcheck unused build test
@@ -110,12 +125,12 @@ common-test-short:
 .PHONY: common-test
 common-test:
 	@echo ">> running all tests"
-	GO111MODULE=$(GO111MODULE) $(GO) test -race $(GOOPTS) $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) test $(test-flags) $(GOOPTS) $(pkgs)
 
 .PHONY: common-format
 common-format:
 	@echo ">> formatting code"
-	GO111MODULE=$(GO111MODULE) $(GO) fmt $(GOOPTS) $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) fmt $(pkgs)
 
 .PHONY: common-vet
 common-vet:
@@ -125,8 +140,12 @@ common-vet:
 .PHONY: common-staticcheck
 common-staticcheck: $(STATICCHECK)
 	@echo ">> running staticcheck"
+	chmod +x $(STATICCHECK)
 ifdef GO111MODULE
-	GO111MODULE=$(GO111MODULE) $(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" -checks "SA*" $(pkgs)
+# 'go list' needs to be executed before staticcheck to prepopulate the modules cache.
+# Otherwise staticcheck might fail randomly for some reason not yet explained.
+	GO111MODULE=$(GO111MODULE) $(GO) list -e -compiled -test=true -export=false -deps=true -find=false -tags= -- ./... > /dev/null
+	GO111MODULE=$(GO111MODULE) $(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
 else
 	$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
 endif
@@ -140,8 +159,9 @@ else
 ifdef GO111MODULE
 	@echo ">> running check for unused/missing packages in go.mod"
 	GO111MODULE=$(GO111MODULE) $(GO) mod tidy
+ifeq (,$(wildcard vendor))
 	@git diff --exit-code -- go.sum go.mod
-ifneq (,$(wildcard vendor))
+else
 	@echo ">> running check for unused packages in vendor/"
 	GO111MODULE=$(GO111MODULE) $(GO) mod vendor
 	@git diff --exit-code -- go.sum go.mod vendor/
@@ -175,30 +195,20 @@ common-docker-tag-latest:
 promu: $(PROMU)
 
 $(PROMU):
-	curl -s -L $(PROMU_URL) | tar -xvz -C /tmp
-	mkdir -v -p $(FIRST_GOPATH)/bin
-	cp -v /tmp/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM)/promu $(PROMU)
+	$(eval PROMU_TMP := $(shell mktemp -d))
+	curl -s -L $(PROMU_URL) | tar -xvzf - -C $(PROMU_TMP)
+	mkdir -p $(FIRST_GOPATH)/bin
+	cp $(PROMU_TMP)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM)/promu $(FIRST_GOPATH)/bin/promu
+	rm -r $(PROMU_TMP)
 
 .PHONY: proto
 proto:
 	@echo ">> generating code from proto files"
 	@./scripts/genproto.sh
 
-.PHONY: $(STATICCHECK)
 $(STATICCHECK):
-ifdef GO111MODULE
-# Get staticcheck from a temporary directory to avoid modifying the local go.{mod,sum}.
-# See https://github.com/golang/go/issues/27643.
-# For now, we are using the next branch of staticcheck because master isn't compatible yet with Go modules.
-	tmpModule=$$(mktemp -d 2>&1) && \
-	mkdir -p $${tmpModule}/staticcheck && \
-	cd "$${tmpModule}"/staticcheck && \
-	GO111MODULE=on $(GO) mod init example.com/staticcheck && \
-	GO111MODULE=on GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck@next && \
-	rm -rf $${tmpModule};
-else
-	GOOS= GOARCH= GO111MODULE=off $(GO) get -u honnef.co/go/tools/cmd/staticcheck
-endif
+	mkdir -p $(FIRST_GOPATH)/bin
+	curl -s -L $(STATICCHECK_URL) > $(STATICCHECK)
 
 ifdef GOVENDOR
 .PHONY: $(GOVENDOR)

--- a/prometheus/push/push_test.go
+++ b/prometheus/push/push_test.go
@@ -96,7 +96,7 @@ func TestPush(t *testing.T) {
 	if lastMethod != "PUT" {
 		t.Error("want method PUT for Push, got", lastMethod)
 	}
-	if bytes.Compare(lastBody, wantBody) != 0 {
+	if !bytes.Equal(lastBody, wantBody) {
 		t.Errorf("got body %v, want %v", lastBody, wantBody)
 	}
 	if lastPath != "/metrics/job/testjob" {
@@ -113,7 +113,7 @@ func TestPush(t *testing.T) {
 	if lastMethod != "POST" {
 		t.Error("want method POST for Add, got", lastMethod)
 	}
-	if bytes.Compare(lastBody, wantBody) != 0 {
+	if !bytes.Equal(lastBody, wantBody) {
 		t.Errorf("got body %v, want %v", lastBody, wantBody)
 	}
 	if lastPath != "/metrics/job/testjob" {
@@ -170,7 +170,7 @@ func TestPush(t *testing.T) {
 	if lastMethod != "PUT" {
 		t.Error("want method PUT for Push, got", lastMethod)
 	}
-	if bytes.Compare(lastBody, wantBody) != 0 {
+	if !bytes.Equal(lastBody, wantBody) {
 		t.Errorf("got body %v, want %v", lastBody, wantBody)
 	}
 
@@ -185,7 +185,7 @@ func TestPush(t *testing.T) {
 	if lastMethod != "POST" {
 		t.Error("want method POST for Add, got", lastMethod)
 	}
-	if bytes.Compare(lastBody, wantBody) != 0 {
+	if !bytes.Equal(lastBody, wantBody) {
 		t.Errorf("got body %v, want %v", lastBody, wantBody)
 	}
 	if lastPath != "/metrics/job/testjob/a/x/b/y" && lastPath != "/metrics/job/testjob/b/y/a/x" {

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -165,11 +165,9 @@ func compare(got, want []*dto.MetricFamily) error {
 metric output does not match expectation; want:
 
 %s
-
 got:
 
-%s
-`, wantBuf.String(), gotBuf.String())
+%s`, wantBuf.String(), gotBuf.String())
 
 	}
 	return nil

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -171,7 +171,6 @@ func TestCollectAndCompareHistogram(t *testing.T) {
 		c           prometheus.Collector
 		metadata    string
 		expect      string
-		labels      []string
 		observation float64
 	}{
 		{
@@ -291,13 +290,11 @@ metric output does not match expectation; want:
 # TYPE some_other_metric counter
 some_other_metric{label1="value1"} 1.0
 
-
 got:
 
 # HELP some_total A value that represents a counter.
 # TYPE some_total counter
 some_total{label1="value1"} 1.0
-
 `
 
 	err := CollectAndCompare(c, strings.NewReader(metadata+expected))
@@ -306,6 +303,6 @@ some_total{label1="value1"} 1.0
 	}
 
 	if err.Error() != expectedError {
-		t.Errorf("Expected\n%#+v\nGot:\n%#+v\n", expectedError, err.Error())
+		t.Errorf("Expected\n%#+v\nGot:\n%#+v", expectedError, err.Error())
 	}
 }


### PR DESCRIPTION
This should fix the staticcheck test failures with Go 1.10

Signed-off-by: beorn7 <beorn@soundcloud.com>