### PR TITLE
Use a map to describe discovered labels, as they are not validated by the server

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -231,17 +231,17 @@ type TargetsResult struct {
 
 // ActiveTarget models an active Prometheus scrape target.
 type ActiveTarget struct {
-	DiscoveredLabels model.LabelSet `json:"discoveredLabels"`
-	Labels           model.LabelSet `json:"labels"`
-	ScrapeURL        string         `json:"scrapeUrl"`
-	LastError        string         `json:"lastError"`
-	LastScrape       time.Time      `json:"lastScrape"`
-	Health           HealthStatus   `json:"health"`
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+	Labels           model.LabelSet    `json:"labels"`
+	ScrapeURL        string            `json:"scrapeUrl"`
+	LastError        string            `json:"lastError"`
+	LastScrape       time.Time         `json:"lastScrape"`
+	Health           HealthStatus      `json:"health"`
 }
 
 // DroppedTarget models a dropped Prometheus scrape target.
 type DroppedTarget struct {
-	DiscoveredLabels model.LabelSet `json:"discoveredLabels"`
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
 }
 
 // queryResult contains result data for a query.

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -605,7 +605,7 @@ func TestAPIs(t *testing.T) {
 			res: TargetsResult{
 				Active: []ActiveTarget{
 					{
-						DiscoveredLabels: model.LabelSet{
+						DiscoveredLabels: map[string]string{
 							"__address__":      "127.0.0.1:9090",
 							"__metrics_path__": "/metrics",
 							"__scheme__":       "http",
@@ -623,7 +623,7 @@ func TestAPIs(t *testing.T) {
 				},
 				Dropped: []DroppedTarget{
 					{
-						DiscoveredLabels: model.LabelSet{
+						DiscoveredLabels: map[string]string{
 							"__address__":      "127.0.0.1:9100",
 							"__metrics_path__": "/metrics",
 							"__scheme__":       "http",


### PR DESCRIPTION
The `/targets` endpoint generates a JSON decoding error when you try to send a request to it while having the Node Exporter configured in Prometheus. It looks like discovered labels are being presented as is, without any validation. In particular I received this error: `"__param_collect[]" is not a valid label name`.

Here is the part of Prometheus server code that uses a `map[string]string` to describe discovered labels internally.
https://github.com/prometheus/prometheus/blob/a1f34bec2e6584a2fee9aec901f3157e3e12cbaa/web/api/v1/api.go#L505-L517