### PR TITLE
wait for done before writing to shared resp body

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -119,8 +119,8 @@ func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 
 	select {
 	case <-ctx.Done():
-		err = resp.Body.Close()
 		<-done
+		err = resp.Body.Close()
 		if err == nil {
 			err = ctx.Err()
 		}


### PR DESCRIPTION
This PR fixes what seems to be a data race condition. Previously if the caller of this Do() canceled the context, or the provided context has timed out the select statement would enter that branch and then close the response body. This could potentially occur concurrently with launched go routine on line 115. My solution simply moves the receive on the done channel before the close of the resp body. 

May want to consider whether we check context in the go routine launched on line 115 before reading the body as a good measure of "don't do work you don't need too". I'll wait for initial comments on this PR to make sure my logic is correct. 

fixes https://github.com/prometheus/client_golang/issues/531