### PR TITLE
README, travis: minimum version is now Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.7.x # See README.md for current minimum version.
-  - 1.8.x
+  - 1.8.x # See README.md for current minimum version.
   - 1.9.x
   - 1.10.x
   - 1.11.x

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the [Go](http://golang.org) client library for
 instrumenting application code, and one for creating clients that talk to the
 Prometheus HTTP API.
 
-__This library requires Go1.7 or later.__
+__This library requires Go1.8 or later.__
 
 ## Important note about releases, versioning, tagging, and stability
 


### PR DESCRIPTION
I'd like to use `sort.SliceStable` (available in Go 1.8+) in common, and that repository and this one have synced minimum Go versions. Let's bump that version to 1.8.