### PR TITLE
Remove encode of params in query before DoGetFallback

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -538,8 +538,6 @@ func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time) (model.
 		q.Set("time", ts.Format(time.RFC3339Nano))
 	}
 
-	u.RawQuery = q.Encode()
-
 	_, body, err := api.DoGetFallback(h.client, ctx, u, q)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Thomas Jackson <jacksontj.89@gmail.com>

cc @krasi-georgiev this was missed, so right now it sends it as query params and post body for the post request.