### PR TITLE
Make TestCounterAddLarge more robust

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -172,7 +172,7 @@ func TestCounterAddLarge(t *testing.T) {
 	}).(*counter)
 
 	// large overflows the underlying type and should therefore be stored in valBits.
-	large := float64(math.MaxUint64 + 1)
+	large := math.Nextafter(float64(math.MaxUint64), 1e20)
 	counter.Add(large)
 	if expected, got := large, math.Float64frombits(counter.valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)


### PR DESCRIPTION
The previous `float64(math.MaxUint64 + 1)` is too close to
`float64(math.MaxUint64)` to actually overflow as indended.

The counter code is actually converting forward and backward and
compare the original and twice-converted value. On most platform, this
will create a deviation and thus trigger the expected behavior. By
sheer "luck", one might end up with the same value and thus still use
the uint64 representation. Which is OK within the precision we can
expect. But it breaks the test. With this change, the next
representable floating point value greater than the floating point
value used to represent math.MaxUint64 is used.

@xnox this should fix #530. Could you verify?
@TheTincho you might have seen this issue, too, for the Debian builds on the affected platforms.