### PR TITLE
Respect existing request context when instrumenting clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/prometheus/common v0.3.0
 	github.com/prometheus/procfs v0.0.0-20190412120340-e22ddced7142
 	github.com/prometheus/tsdb v0.7.1
+	github.com/stretchr/testify v1.2.2
 )

--- a/prometheus/promhttp/instrument_client.go
+++ b/prometheus/promhttp/instrument_client.go
@@ -213,7 +213,11 @@ func InstrumentRoundTripperTrace(it *InstrumentTrace, next http.RoundTripper) Ro
 				}
 			},
 		}
-		r = r.WithContext(httptrace.WithClientTrace(context.Background(), trace))
+		if ctx := r.Context(); ctx != nil {
+			r = r.WithContext(httptrace.WithClientTrace(ctx, trace))
+		} else {
+			r = r.WithContext(httptrace.WithClientTrace(context.Background(), trace))
+		}
 
 		return next.RoundTrip(r)
 	})


### PR DESCRIPTION
Currently, the [`InstrumentRoundTripperTrace`](https://github.com/prometheus/client_golang/blob/master/prometheus/promhttp/instrument_client.go#L136) forcesets its own context, overriding whatever context might have been set to the client before its instrumentation. The proposed PR fixes that by conditionally employing the old behavior but respecting and reusing supplied contexts, if any.

Fixes #580 