### PR TITLE
Unflake TestGoCollectorGC

### DIFF
--- a/prometheus/go_collector_test.go
+++ b/prometheus/go_collector_test.go
@@ -138,11 +138,11 @@ func TestGoCollectorGC(t *testing.T) {
 				close(waitCh)
 				continue
 			}
-			if diff := *pb.GetSummary().SampleCount - oldGC; diff != 1 {
-				t.Errorf("want 1 new garbage collection run, got %d", diff)
+			if diff := *pb.GetSummary().SampleCount - oldGC; diff < 1 {
+				t.Errorf("want at least 1 new garbage collection run, got %d", diff)
 			}
 			if diff := *pb.GetSummary().SampleSum - oldPause; diff <= 0 {
-				t.Errorf("want moar pause, got %f", diff)
+				t.Errorf("want an increase in pause time, got a change of %f", diff)
 			}
 		case <-time.After(1 * time.Second):
 			t.Fatalf("expected collect timed out")


### PR DESCRIPTION
It is perfectly possible that a normal GC happens just before the
forced one. Thus seeing 2 GCs is fine.

Whenever this test failed, it was because two GCs were seen.

Signed-off-by: beorn7 <bjoern@rabenste.in>