### PR TITLE
Only set start/end if the time is not Zero

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -704,8 +704,12 @@ func (h *httpAPI) Series(ctx context.Context, matches []string, startTime time.T
 		q.Add("match[]", m)
 	}
 
-	q.Set("start", startTime.Format(time.RFC3339Nano))
-	q.Set("end", endTime.Format(time.RFC3339Nano))
+	if !startTime.IsZero() {
+		q.Set("start", startTime.Format(time.RFC3339Nano))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", endTime.Format(time.RFC3339Nano))
+	}
 
 	u.RawQuery = q.Encode()
 


### PR DESCRIPTION
Fixes #614

Signed-off-by: Thomas Jackson <jacksontj.89@gmail.com>


This will allow clients to decide when they want to send a time vs letting prometheus do all of the time.