### PR TITLE
Handle formatting when the time in nanoseconds requires more than a single int64

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -873,5 +873,5 @@ func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, [
 }
 
 func formatTime(t time.Time) string {
-	return strconv.FormatFloat(float64(t.UnixNano())/1e9, 'f', -1, 64)
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
 }


### PR DESCRIPTION
Signed-off-by: Thomas Jackson <jacksontj.89@gmail.com>

Fixup for #617

Fixes https://github.com/prometheus/client_golang/issues/614

cc @beorn7 