### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,27 @@
-# Compiled Object files, Static and Dynamic libs (Shared Objects)
-*.o
-*.a
-*.so
-
-# Folders
-_obj
-_test
-
 # Examples
-/examples/simple/simple
-/examples/random/random
+examples/simple/simple
+examples/random/random
 
-# Architecture specific extensions/prefixes
-*.[568vq]
-[568vq].out
-
-*.cgo1.go
-*.cgo2.c
-_cgo_defun.c
-_cgo_gotypes.go
-_cgo_export.*
-
-_testmain.go
-
-*.exe
-
+# Typical backup/temporary files of editors
 *~
 *#
-.build
+
+# Never include any accidentally created vendor dirs.
+# This is a library!
+vendor/
+
+# The remainder of this file is taken from
+# https://github.com/github/gitignore/blob/master/Go.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out


### PR DESCRIPTION
Inspired by
https://github.com/prometheus/common/pull/202

A lot of entries in the old file were from times where we used cgo and had a completely different build system.

@tariq1890