### PR TITLE
Add WriteHeader call to Flush

### DIFF
--- a/prometheus/promhttp/delegator.go
+++ b/prometheus/promhttp/delegator.go
@@ -62,6 +62,8 @@ func (r *responseWriterDelegator) WriteHeader(code int) {
 }
 
 func (r *responseWriterDelegator) Write(b []byte) (int, error) {
+	// If applicable, call WriteHeader here so that observeWriteHeader is
+	// handled appropriately.
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)
 	}
@@ -82,12 +84,19 @@ func (d closeNotifierDelegator) CloseNotify() <-chan bool {
 	return d.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 func (d flusherDelegator) Flush() {
+	// If applicable, call WriteHeader here so that observeWriteHeader is
+	// handled appropriately.
+	if !d.wroteHeader {
+		d.WriteHeader(http.StatusOK)
+	}
 	d.ResponseWriter.(http.Flusher).Flush()
 }
 func (d hijackerDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return d.ResponseWriter.(http.Hijacker).Hijack()
 }
 func (d readerFromDelegator) ReadFrom(re io.Reader) (int64, error) {
+	// If applicable, call WriteHeader here so that observeWriteHeader is
+	// handled appropriately.
 	if !d.wroteHeader {
 		d.WriteHeader(http.StatusOK)
 	}


### PR DESCRIPTION
Flush is another of the methods that will call WriteHeader if it
hasn't happened yet. Since we want to call observeWriteHeader (if
set), we need to do the WriteHeader call already here, similar to what
we have done in Write and ReadFrom.

This commit also adds comments explaining the above to not tempt
developers to remove the WriteHeader call.

Signed-off-by: beorn7 <beorn@grafana.com>