### PR TITLE
Pass warning back from response so we can tell if there is a problem with prometheus

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -827,6 +827,7 @@ func errorTypeAndMsgFor(resp *http.Response) (ErrorType, string) {
 
 func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, api.Warnings, error) {
 	resp, body, warnings, err := c.Client.Do(ctx, req)
+	append(warnings, body.warnings)
 	if err != nil {
 		return resp, body, warnings, err
 	}

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -827,7 +827,6 @@ func errorTypeAndMsgFor(resp *http.Response) (ErrorType, string) {
 
 func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, api.Warnings, error) {
 	resp, body, warnings, err := c.Client.Do(ctx, req)
-	append(warnings, body.warnings)
 	if err != nil {
 		return resp, body, warnings, err
 	}
@@ -867,8 +866,10 @@ func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, [
 			Msg:  result.Error,
 		}
 	}
+        var allWarnings  api.Warnings
+	allWarnings = append(result.Warnings, warnings...)
 
-	return resp, []byte(result.Data), warnings, err
+	return resp, []byte(result.Data), allWarnings, err
 
 }
 


### PR DESCRIPTION
@krasi-georgiev 
Was having a problem with prometheus not giving back expected results. Seems that warnings where always passing back nil (from the client). So added a simple fix to merge the warnings back from the client with warnings back rom the response.

Signed-off-by: Brian Gibbins <brian.eroteme@gmail.com>