### PR TITLE
Minor improvements to the push code

### DIFF
--- a/prometheus/push/push.go
+++ b/prometheus/push/push.go
@@ -220,7 +220,7 @@ func (p *Pusher) Delete() error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 202 {
+	if resp.StatusCode != http.StatusAccepted {
 		body, _ := ioutil.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
 		return fmt.Errorf("unexpected status code %d while deleting %s: %s", resp.StatusCode, p.fullURL(), body)
 	}
@@ -267,7 +267,8 @@ func (p *Pusher) push(method string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 && resp.StatusCode != 202 {
+	// Pushgateway 0.10+ responds with StatusOK, earlier versions with StatusAccepted.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		body, _ := ioutil.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
 		return fmt.Errorf("unexpected status code %d while pushing to %s: %s", resp.StatusCode, p.fullURL(), body)
 	}

--- a/prometheus/push/push_test.go
+++ b/prometheus/push/push_test.go
@@ -33,7 +33,8 @@ func TestPush(t *testing.T) {
 		lastPath   string
 	)
 
-	// Fake a Pushgateway that always responds with 202.
+	// Fake a Pushgateway that responds with 202 to DELETE and with 200 in
+	// all other cases.
 	pgwOK := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			lastMethod = r.Method
@@ -44,7 +45,11 @@ func TestPush(t *testing.T) {
 			}
 			lastPath = r.URL.EscapedPath()
 			w.Header().Set("Content-Type", `text/plain; charset=utf-8`)
-			w.WriteHeader(http.StatusAccepted)
+			if r.Method == http.MethodDelete {
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
 		}),
 	)
 	defer pgwOK.Close()


### PR DESCRIPTION
- Match fake-Pushgateway's behavior to v0.10+ in the test.
- Use constants for status code, not number literals.