### PR TITLE
Use a cleaner initialization of `separatorByteSlice`

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -18,13 +18,12 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/common/model"
 
 	dto "github.com/prometheus/client_model/go"
 )
 
-const separatorByte byte = 255
-
-var separatorByteSlice = []byte{255} // For convenient use with xxhash.
+var separatorByteSlice = []byte{model.SeparatorByte} // For convenient use with xxhash.
 
 // A Metric models a single sample value with its meta data being exported to
 // Prometheus. Implementations of Metric in this package are Gauge, Counter,


### PR DESCRIPTION
The `const separatorByte` wasn't used anymore actually. In `vec.go`,
we were using `model.SeparatorByte`, which is better anyway. So remove
the unused constant and initialize `separatorByteSlice` with
`model.SeparatorByte`, too.

@cstyan follow-up to your comment on #657 .