### PR TITLE
Fix collectorID calculation for Unregister()

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -361,7 +361,7 @@ func (r *Registry) Unregister(c Collector) bool {
 	var (
 		descChan    = make(chan *Desc, capDescChan)
 		descIDs     = map[uint64]struct{}{}
-		collectorID uint64 // Just a sum of the desc IDs.
+		collectorID uint64 // All desc IDs XOR'd together.
 	)
 	go func() {
 		c.Describe(descChan)
@@ -369,7 +369,7 @@ func (r *Registry) Unregister(c Collector) bool {
 	}()
 	for desc := range descChan {
 		if _, exists := descIDs[desc.id]; !exists {
-			collectorID += desc.id
+			collectorID ^= desc.id
 			descIDs[desc.id] = struct{}{}
 		}
 	}

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -863,6 +863,23 @@ func TestAlreadyRegistered(t *testing.T) {
 	}
 }
 
+// TestRegisterUnregisterCollector ensures registering and unregistering a
+// collector doesn't leave any dangling metrics.
+// We use NewGoCollector as a nice concrete example of a collector with
+// multiple metrics.
+func TestRegisterUnregisterCollector(t *testing.T) {
+	col := prometheus.NewGoCollector()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(col)
+	reg.Unregister(col)
+	if metrics, err := reg.Gather(); err != nil {
+		t.Error("error gathering sample metric")
+	} else if len(metrics) != 0 {
+		t.Error("should have unregistered metric")
+	}
+}
+
 // TestHistogramVecRegisterGatherConcurrency is an end-to-end test that
 // concurrently calls Observe on random elements of a HistogramVec while the
 // same HistogramVec is registered concurrently and the Gather method of the


### PR DESCRIPTION
This PR fixes the regression from 1.2.0 where the calculation of `collectorID` changed during `Register()`, but not during `Unregister()`

~It also brings the vec code closer to the rest by addopting `xxhash` everywhere.~ (reverted, see https://github.com/prometheus/client_golang/pull/663#issuecomment-543145728)

Finally, we also add a simple test case to ensure this doesn't happen again! :wink:  

fixes #662