### PR TITLE
Remove old reference to basicMetricVec

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -24,7 +24,7 @@ import (
 // their label values. metricVec is not used directly (and therefore
 // unexported). It is used as a building block for implementations of vectors of
 // a given metric type, like GaugeVec, CounterVec, SummaryVec, and HistogramVec.
-// It also handles label currying. It uses basicMetricVec internally.
+// It also handles label currying.
 type metricVec struct {
 	*metricMap
 


### PR DESCRIPTION
Contrary to the code comment, I see no `basicMetricVec` implementation. Grep'ing this project shows this is the only reference. So I suspect it's an outdated comment and can be removed to minimize confusion.

I'm unclear whether other parts of that comment are also incorrect and need updating.