### PR TITLE
Provide a mechanism to reset all metrics for a Gatherer

### DIFF
--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -1174,3 +1174,35 @@ func TestAlreadyRegisteredCollision(t *testing.T) {
 		}
 	}
 }
+
+// TestResetMetrics tests resetting metrics.
+func TestResetMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	metricVec := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "name",
+		},
+		[]string{},
+	)
+
+	reg.MustRegister(metricVec)
+
+	metricVec.WithLabelValues().Add(1)
+
+	if metrics, err := reg.Gather(); err != nil {
+		t.Error("error gathering sample metric")
+	} else if len(metrics) != 1 {
+		t.Errorf("unexpected metrics length: %d", len(metrics))
+	} else if *metrics[0].Metric[0].Counter.Value != float64(1) {
+		t.Errorf("unexpected initial counter value: %f", *metrics[0].Metric[0].Counter.Value)
+	}
+
+	reg.ResetMetrics()
+
+	if metrics, err := reg.Gather(); err != nil {
+		t.Error("error gathering sample metric")
+	} else if len(metrics) != 0 {
+		t.Errorf("unexpected metrics length: %d", len(metrics))
+	}
+}

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -35,6 +35,11 @@ type metricVec struct {
 	hashAddByte func(h uint64, b byte) uint64
 }
 
+type resetter interface {
+	// Reset deletes all metrics.
+	Reset()
+}
+
 // newMetricVec returns an initialized metricVec.
 func newMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) *metricVec {
 	return &metricVec{
@@ -234,7 +239,7 @@ func (m *metricMap) Collect(ch chan<- Metric) {
 	}
 }
 
-// Reset deletes all metrics in this vector.
+// Reset implements resetter.
 func (m *metricMap) Reset() {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()


### PR DESCRIPTION
@beorn7 
This PR adds the ability for consumers to reset all metrics—e.g. in a test or test suite where we're testing the values captured by a GaugeVec, we can call `prometheus.DefaultGatherer.ResetMetrics()`.

I wasn't sure if this was a worthy enough use case for adding to the `Gatherer` interface, but it seemed to fit well semantically. For the most common `prometheus.DefaultGatherer.ResetMetrics()` use case, we do need access to the `Registry`'s mutex to ensure correctness.