### PR TITLE
ExampleInstrumentHandlerDuration: use “code” label

### DIFF
--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -353,7 +353,7 @@ func ExampleInstrumentHandlerDuration() {
 			Help:    "A histogram of latencies for requests.",
 			Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
 		},
-		[]string{"handler", "method"},
+		[]string{"code", "method"},
 	)
 
 	// responseSize has no labels, making it a zero-dimensional


### PR DESCRIPTION
The label name must be code, not handler. Without this change, InstrumentHandlerDuration panics.