### PR TITLE
api client examples: avoid shadowing package with variable

### DIFF
--- a/api/prometheus/v1/example_test.go
+++ b/api/prometheus/v1/example_test.go
@@ -34,10 +34,10 @@ func ExampleAPI_query() {
 		os.Exit(1)
 	}
 
-	api := v1.NewAPI(client)
+	v1api := v1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result, warnings, err := api.Query(ctx, "up", time.Now())
+	result, warnings, err := v1api.Query(ctx, "up", time.Now())
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
@@ -57,7 +57,7 @@ func ExampleAPI_queryRange() {
 		os.Exit(1)
 	}
 
-	api := v1.NewAPI(client)
+	v1api := v1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	r := v1.Range{
@@ -65,7 +65,7 @@ func ExampleAPI_queryRange() {
 		End:   time.Now(),
 		Step:  time.Minute,
 	}
-	result, warnings, err := api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
+	result, warnings, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
@@ -85,10 +85,10 @@ func ExampleAPI_series() {
 		os.Exit(1)
 	}
 
-	api := v1.NewAPI(client)
+	v1api := v1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	lbls, warnings, err := api.Series(ctx, []string{
+	lbls, warnings, err := v1api.Series(ctx, []string{
 		"{__name__=~\"scrape_.+\",job=\"node\"}",
 		"{__name__=~\"scrape_.+\",job=\"prometheus\"}",
 	}, time.Now().Add(-time.Hour), time.Now())


### PR DESCRIPTION
Hi :wave:.  I'm coming from reading this example at https://godoc.org/github.com/prometheus/client_golang/api/prometheus/v1#example-API--Query.  (thanks #630)

In that rendered doc, one only sees the example body, package imports and their aliases are invisible.
It'd be reasonable to guess that `api` refers to `github.com/prometheus/client_golang/api`, it's the only directory of that name here.
However, below it becomes shadowed by a variable of same name `api := v1.NewAPI(client)`, which makes the whole example very confusing to read!  (I didn't even know you can do that in Go – access an import in same function before a variable of same name...)

This is an attempt to rename the variable, leaving package names at their default so one can still guess what they refer to.

cc @krasi-georgiev