### PR TITLE
Improve doc comment for NewGaugeFunc

### DIFF
--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -273,9 +273,12 @@ type GaugeFunc interface {
 // NewGaugeFunc creates a new GaugeFunc based on the provided GaugeOpts. The
 // value reported is determined by calling the given function from within the
 // Write method. Take into account that metric collection may happen
-// concurrently. If that results in concurrent calls to Write, like in the case
-// where a GaugeFunc is directly registered with Prometheus, the provided
-// function must be concurrency-safe.
+// concurrently. Therefore, it must be safe to call the provided function
+// concurrently.
+//
+// NewGaugeFunc is a good way to create an “info” style metric with a constant
+// value of 1. Example:
+// https://github.com/prometheus/common/blob/8558a5b7db3c84fa38b4766966059a7bd5bfa2ee/version/info.go#L36-L56
 func NewGaugeFunc(opts GaugeOpts, function func() float64) GaugeFunc {
 	return newValueFunc(NewDesc(
 		BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),


### PR DESCRIPTION
- Simplify confusing wording about concurrency safety.
- Add link to example for info metric.

@finkr does this help?

Fixes #693 .