### PR TITLE
Return Prometheus Warnings

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -25,8 +25,6 @@ import (
 	"time"
 )
 
-type Warnings []string
-
 // DefaultRoundTripper is used if no RoundTripper is set in Config.
 var DefaultRoundTripper http.RoundTripper = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,

--- a/api/client.go
+++ b/api/client.go
@@ -57,32 +57,7 @@ func (cfg *Config) roundTripper() http.RoundTripper {
 // Client is the interface for an API client.
 type Client interface {
 	URL(ep string, args map[string]string) *url.URL
-	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
-}
-
-// DoGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
-func DoGetFallback(c Client, ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
-	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, body, warnings, err := c.Do(ctx, req)
-	if resp != nil && resp.StatusCode == http.StatusMethodNotAllowed {
-		u.RawQuery = args.Encode()
-		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
-		if err != nil {
-			return nil, nil, warnings, err
-		}
-
-	} else {
-		if err != nil {
-			return resp, body, warnings, err
-		}
-		return resp, body, warnings, nil
-	}
-	return c.Do(ctx, req)
+	Do(context.Context, *http.Request) (*http.Response, []byte, error)
 }
 
 // NewClient returns a new Client.
@@ -120,7 +95,7 @@ func (c *httpClient) URL(ep string, args map[string]string) *url.URL {
 	return &u
 }
 
-func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
 	if ctx != nil {
 		req = req.WithContext(ctx)
 	}
@@ -132,7 +107,7 @@ func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 	}()
 
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	var body []byte
@@ -152,5 +127,5 @@ func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 	case <-done:
 	}
 
-	return resp, body, nil, err
+	return resp, body, err
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -14,10 +14,7 @@
 package api
 
 import (
-	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"testing"
 )
@@ -112,74 +109,5 @@ func TestClientURL(t *testing.T) {
 			t.Errorf("unexpected result: got %s, want %s", u, test.expected)
 			continue
 		}
-	}
-}
-
-func TestDoGetFallback(t *testing.T) {
-	v := url.Values{"a": []string{"1", "2"}}
-
-	type testResponse struct {
-		Values string
-		Method string
-	}
-
-	// Start a local HTTP server.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		req.ParseForm()
-		r := &testResponse{
-			Values: req.Form.Encode(),
-			Method: req.Method,
-		}
-
-		body, _ := json.Marshal(r)
-
-		if req.Method == http.MethodPost {
-			if req.URL.Path == "/blockPost" {
-				http.Error(w, string(body), http.StatusMethodNotAllowed)
-				return
-			}
-		}
-
-		w.Write(body)
-	}))
-	// Close the server when test finishes.
-	defer server.Close()
-
-	u, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := &httpClient{client: *(server.Client())}
-
-	// Do a post, and ensure that the post succeeds.
-	_, b, _, err := DoGetFallback(client, context.TODO(), u, v)
-	if err != nil {
-		t.Fatalf("Error doing local request: %v", err)
-	}
-	resp := &testResponse{}
-	if err := json.Unmarshal(b, resp); err != nil {
-		t.Fatal(err)
-	}
-	if resp.Method != http.MethodPost {
-		t.Fatalf("Mismatch method")
-	}
-	if resp.Values != v.Encode() {
-		t.Fatalf("Mismatch in values")
-	}
-
-	// Do a fallbcak to a get.
-	u.Path = "/blockPost"
-	_, b, _, err = DoGetFallback(client, context.TODO(), u, v)
-	if err != nil {
-		t.Fatalf("Error doing local request: %v", err)
-	}
-	if err := json.Unmarshal(b, resp); err != nil {
-		t.Fatal(err)
-	}
-	if resp.Method != http.MethodGet {
-		t.Fatalf("Mismatch method")
-	}
-	if resp.Values != v.Encode() {
-		t.Fatalf("Mismatch in values")
 	}
 }

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -1268,12 +1268,16 @@ func TestDoGetFallback(t *testing.T) {
 	// Start a local HTTP server.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		req.ParseForm()
-		r := &testResponse{
+		testResp, _ := json.Marshal(&testResponse{
 			Values: req.Form.Encode(),
 			Method: req.Method,
+		})
+
+		apiResp := &apiResponse{
+			Data: testResp,
 		}
 
-		body, _ := json.Marshal(r)
+		body, _ := json.Marshal(apiResp)
 
 		if req.Method == http.MethodPost {
 			if req.URL.Path == "/blockPost" {

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -30,12 +30,10 @@ import (
 	json "github.com/json-iterator/go"
 
 	"github.com/prometheus/common/model"
-
-	"github.com/prometheus/client_golang/api"
 )
 
 type apiTest struct {
-	do           func() (interface{}, api.Warnings, error)
+	do           func() (interface{}, Warnings, error)
 	inWarnings   []string
 	inErr        error
 	inStatusCode int
@@ -45,7 +43,7 @@ type apiTest struct {
 	reqParam  url.Values
 	reqMethod string
 	res       interface{}
-	warnings  api.Warnings
+	warnings  Warnings
 	err       error
 }
 
@@ -66,7 +64,7 @@ func (c *apiTestClient) URL(ep string, args map[string]string) *url.URL {
 	return u
 }
 
-func (c *apiTestClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, api.Warnings, error) {
+func (c *apiTestClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
 
 	test := c.curTest
 
@@ -94,7 +92,7 @@ func (c *apiTestClient) Do(ctx context.Context, req *http.Request) (*http.Respon
 	return resp, b, test.inWarnings, test.inErr
 }
 
-func (c *apiTestClient) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, api.Warnings, error) {
+func (c *apiTestClient) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
 	if err != nil {
 		return nil, nil, nil, err
@@ -113,92 +111,92 @@ func TestAPIs(t *testing.T) {
 		client: tc,
 	}
 
-	doAlertManagers := func() func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doAlertManagers := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.AlertManagers(context.Background())
 			return v, nil, err
 		}
 	}
 
-	doCleanTombstones := func() func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doCleanTombstones := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return nil, nil, promAPI.CleanTombstones(context.Background())
 		}
 	}
 
-	doConfig := func() func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doConfig := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.Config(context.Background())
 			return v, nil, err
 		}
 	}
 
-	doDeleteSeries := func(matcher string, startTime time.Time, endTime time.Time) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doDeleteSeries := func(matcher string, startTime time.Time, endTime time.Time) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return nil, nil, promAPI.DeleteSeries(context.Background(), []string{matcher}, startTime, endTime)
 		}
 	}
 
-	doFlags := func() func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doFlags := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.Flags(context.Background())
 			return v, nil, err
 		}
 	}
 
-	doLabelNames := func(label string) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doLabelNames := func(label string) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return promAPI.LabelNames(context.Background())
 		}
 	}
 
-	doLabelValues := func(label string) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doLabelValues := func(label string) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return promAPI.LabelValues(context.Background(), label)
 		}
 	}
 
-	doQuery := func(q string, ts time.Time) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doQuery := func(q string, ts time.Time) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return promAPI.Query(context.Background(), q, ts)
 		}
 	}
 
-	doQueryRange := func(q string, rng Range) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doQueryRange := func(q string, rng Range) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return promAPI.QueryRange(context.Background(), q, rng)
 		}
 	}
 
-	doSeries := func(matcher string, startTime time.Time, endTime time.Time) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doSeries := func(matcher string, startTime time.Time, endTime time.Time) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			return promAPI.Series(context.Background(), []string{matcher}, startTime, endTime)
 		}
 	}
 
-	doSnapshot := func(skipHead bool) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doSnapshot := func(skipHead bool) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.Snapshot(context.Background(), skipHead)
 			return v, nil, err
 		}
 	}
 
-	doRules := func() func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doRules := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.Rules(context.Background())
 			return v, nil, err
 		}
 	}
 
-	doTargets := func() func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doTargets := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.Targets(context.Background())
 			return v, nil, err
 		}
 	}
 
-	doTargetsMetadata := func(matchTarget string, metric string, limit string) func() (interface{}, api.Warnings, error) {
-		return func() (interface{}, api.Warnings, error) {
+	doTargetsMetadata := func(matchTarget string, metric string, limit string) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.TargetsMetadata(context.Background(), matchTarget, metric, limit)
 			return v, nil, err
 		}
@@ -911,7 +909,7 @@ type apiClientTest struct {
 	response         interface{}
 	expectedBody     string
 	expectedErr      *Error
-	expectedWarnings api.Warnings
+	expectedWarnings Warnings
 }
 
 func (c *testClient) URL(ep string, args map[string]string) *url.URL {


### PR DESCRIPTION
This PR replaces #648.

- Moved warnings from the `api` package to `api/prometheus/v1`
- Split the `api.Client` interface.  Previously it was being used in both `api` and `v1`.  Now a separate interface (`v1.apiClient`) better defines this internal http client.
- Moved DoGetFallback into method into `v1`
- Moved tests as appropriate.
- Correctly returned warnings from `Do` and `DoGetFallback`.