### PR TITLE
Explicitly forward metricVec methods Collect, Describe, Reset

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -91,6 +91,18 @@ func (m *metricVec) Delete(labels Labels) bool {
 	return m.metricMap.deleteByHashWithLabels(h, labels, m.curry)
 }
 
+// Without explicit forwarding of Describe, Collect, Reset, those methods won't
+// show up in GoDoc.
+
+// Describe implements Collector.
+func (m *metricVec) Describe(ch chan<- *Desc) { m.metricMap.Describe(ch) }
+
+// Collect implements Collector.
+func (m *metricVec) Collect(ch chan<- Metric) { m.metricMap.Collect(ch) }
+
+// Reset deletes all metrics in this vector.
+func (m *metricVec) Reset() { m.metricMap.Reset() }
+
 func (m *metricVec) curryWith(labels Labels) (*metricVec, error) {
 	var (
 		newCurry []curriedLabelValue


### PR DESCRIPTION
Interestingly, methods implicitly forwarded from embedded types are
detected by GoDoc if they are just one level deep. Methods of embedded types in
the embedded type are not recognized. This commit therefore adds
explicit forwarding methods for Collect, Describe, and Reset.

@bwplotka I discovered that while working on the promauto changes. Please have a look, easy review. (o: