### PR TITLE
API Client: Support new metadata endpoint in v1

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -130,6 +130,7 @@ const (
 	epSeries          = apiPrefix + "/series"
 	epTargets         = apiPrefix + "/targets"
 	epTargetsMetadata = apiPrefix + "/targets/metadata"
+	epMetricsMetadata = apiPrefix + "/metadata"
 	epRules           = apiPrefix + "/rules"
 	epSnapshot        = apiPrefix + "/admin/tsdb/snapshot"
 	epDeleteSeries    = apiPrefix + "/admin/tsdb/delete_series"
@@ -248,6 +249,8 @@ type API interface {
 	Targets(ctx context.Context) (TargetsResult, error)
 	// TargetsMetadata returns metadata about metrics currently scraped by the target.
 	TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]MetricMetadata, error)
+	// MetricMetadata returns metadata about metrics currently scraped by the metric name.
+	MetricsMetadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error)
 }
 
 // AlertsResult contains the result from querying the alerts endpoint.
@@ -357,13 +360,20 @@ type DroppedTarget struct {
 	DiscoveredLabels map[string]string `json:"discoveredLabels"`
 }
 
-// MetricMetadata models the metadata of a metric.
+// MetricMetadata models the metadata of a metric with its scrape target and name.
 type MetricMetadata struct {
 	Target map[string]string `json:"target"`
 	Metric string            `json:"metric,omitempty"`
 	Type   MetricType        `json:"type"`
 	Help   string            `json:"help"`
 	Unit   string            `json:"unit"`
+}
+
+// Metadata models the metadata of a metric.
+type Metadata struct {
+	Type MetricType `json:"type"`
+	Help string     `json:"help"`
+	Unit string     `json:"unit"`
 }
 
 // queryResult contains result data for a query.
@@ -799,6 +809,29 @@ func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget string, metri
 	}
 
 	var res []MetricMetadata
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) MetricsMetadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error) {
+	u := h.client.URL(epMetricsMetadata, nil)
+	q := u.Query()
+
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string][]Metadata
 	return res, json.Unmarshal(body, &res)
 }
 

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -130,7 +130,7 @@ const (
 	epSeries          = apiPrefix + "/series"
 	epTargets         = apiPrefix + "/targets"
 	epTargetsMetadata = apiPrefix + "/targets/metadata"
-	epMetricsMetadata = apiPrefix + "/metadata"
+	epMetadata        = apiPrefix + "/metadata"
 	epRules           = apiPrefix + "/rules"
 	epSnapshot        = apiPrefix + "/admin/tsdb/snapshot"
 	epDeleteSeries    = apiPrefix + "/admin/tsdb/delete_series"
@@ -249,8 +249,8 @@ type API interface {
 	Targets(ctx context.Context) (TargetsResult, error)
 	// TargetsMetadata returns metadata about metrics currently scraped by the target.
 	TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]MetricMetadata, error)
-	// MetricMetadata returns metadata about metrics currently scraped by the metric name.
-	MetricsMetadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error)
+	// Metadata returns metadata about metrics currently scraped by the metric name.
+	Metadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error)
 }
 
 // AlertsResult contains the result from querying the alerts endpoint.
@@ -812,8 +812,8 @@ func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget string, metri
 	return res, json.Unmarshal(body, &res)
 }
 
-func (h *httpAPI) MetricsMetadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error) {
-	u := h.client.URL(epMetricsMetadata, nil)
+func (h *httpAPI) Metadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error) {
+	u := h.client.URL(epMetadata, nil)
 	q := u.Query()
 
 	q.Set("metric", metric)

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -202,9 +202,9 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
-	doMetricsMetadata := func(metric string, limit string) func() (interface{}, Warnings, error) {
+	doMetadata := func(metric string, limit string) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			v, err := promAPI.MetricsMetadata(context.Background(), metric, limit)
+			v, err := promAPI.Metadata(context.Background(), metric, limit)
 			return v, nil, err
 		}
 	}
@@ -866,7 +866,7 @@ func TestAPIs(t *testing.T) {
 		},
 
 		{
-			do: doMetricsMetadata("go_goroutines", "1"),
+			do: doMetadata("go_goroutines", "1"),
 			inRes: map[string]interface{}{
 				"go_goroutines": []map[string]interface{}{
 					{
@@ -894,7 +894,7 @@ func TestAPIs(t *testing.T) {
 		},
 
 		{
-			do:        doMetricsMetadata("", "1"),
+			do:        doMetadata("", "1"),
 			inErr:     fmt.Errorf("some error"),
 			reqMethod: "GET",
 			reqPath:   "/api/v1/metadata",

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -202,7 +202,7 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
-	doMetricsMetadata := func(metring string, limit string) func() (interface{}, Warnings, error) {
+	doMetricsMetadata := func(metric string, limit string) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.MetricsMetadata(context.Background(), metring, limit)
 			return v, nil, err

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -204,7 +204,7 @@ func TestAPIs(t *testing.T) {
 
 	doMetricsMetadata := func(metric string, limit string) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			v, err := promAPI.MetricsMetadata(context.Background(), metring, limit)
+			v, err := promAPI.MetricsMetadata(context.Background(), metric, limit)
 			return v, nil, err
 		}
 	}


### PR DESCRIPTION
Introduces support for the new metadata endpoint from Prometheus. The new endpoint provides information independent of targets and collapses the unique combinations of HELP, TYPE and UNIT.

Fixes #705

Signed-off-by: gotjosh <josue@grafana.com>