### PR TITLE
Improve API error handling

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -905,14 +905,14 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 		}
 	}
 
-	if apiError(code) != (result.Status == "error") {
+	if apiError(code) && result.Status == "success" {
 		err = &Error{
 			Type: ErrBadResponse,
 			Msg:  "inconsistent body for response code",
 		}
 	}
 
-	if apiError(code) && result.Status == "error" {
+	if result.Status == "error" {
 		err = &Error{
 			Type: result.ErrorType,
 			Msg:  result.Error,

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -1095,8 +1095,8 @@ func TestAPIClientDo(t *testing.T) {
 				Error:     "timed out",
 			},
 			expectedErr: &Error{
-				Type: ErrBadResponse,
-				Msg:  "inconsistent body for response code",
+				Type: ErrTimeout,
+				Msg:  "timed out",
 			},
 		},
 		{
@@ -1109,8 +1109,8 @@ func TestAPIClientDo(t *testing.T) {
 				Warnings:  []string{"a"},
 			},
 			expectedErr: &Error{
-				Type: ErrBadResponse,
-				Msg:  "inconsistent body for response code",
+				Type: ErrTimeout,
+				Msg:  "timed out",
 			},
 			expectedWarnings: []string{"a"},
 		},


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

The current way we handle error drops some info from `errorType` and `error` for some scenarios. 

Consider a real response example below, we expect the error object carry more info than `inconsistent body for response code`. 

```json
HTTP OK
---
{
    "status":"error",
    "errorType":"internal",
    "error":"multiple matches for labels: many-to-one matching must be explicit (group_left/group_right)"
}
```