### PR TITLE
Rewrite CurryWith wrappers in a more idomatic way

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -276,10 +276,10 @@ func (v *CounterVec) With(labels Labels) Counter {
 // method deletes all metrics, even if called on a curried vector.
 func (v *CounterVec) CurryWith(labels Labels) (*CounterVec, error) {
 	vec, err := v.curryWith(labels)
-	if vec != nil {
-		return &CounterVec{vec}, err
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return &CounterVec{vec}, nil
 }
 
 // MustCurryWith works as CurryWith but panics where CurryWith would have

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -245,10 +245,10 @@ func (v *GaugeVec) With(labels Labels) Gauge {
 // method deletes all metrics, even if called on a curried vector.
 func (v *GaugeVec) CurryWith(labels Labels) (*GaugeVec, error) {
 	vec, err := v.curryWith(labels)
-	if vec != nil {
-		return &GaugeVec{vec}, err
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return &GaugeVec{vec}, nil
 }
 
 // MustCurryWith works as CurryWith but panics where CurryWith would have

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -517,10 +517,10 @@ func (v *HistogramVec) With(labels Labels) Observer {
 // method deletes all metrics, even if called on a curried vector.
 func (v *HistogramVec) CurryWith(labels Labels) (ObserverVec, error) {
 	vec, err := v.curryWith(labels)
-	if vec != nil {
-		return &HistogramVec{vec}, err
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return &HistogramVec{vec}, nil
 }
 
 // MustCurryWith works as CurryWith but panics where CurryWith would have

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -630,10 +630,10 @@ func (v *SummaryVec) With(labels Labels) Observer {
 // method deletes all metrics, even if called on a curried vector.
 func (v *SummaryVec) CurryWith(labels Labels) (ObserverVec, error) {
 	vec, err := v.curryWith(labels)
-	if vec != nil {
-		return &SummaryVec{vec}, err
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return &SummaryVec{vec}, nil
 }
 
 // MustCurryWith works as CurryWith but panics where CurryWith would have


### PR DESCRIPTION
Hi @beorn7, I was diving into the prometheus code and I found  the CurryWith wrappers a bit confusing so here is a small PR I hope would help. Thanks