### PR TITLE
Add GaugeFuncVec collecting vectors of GaugeFuncs

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -315,5 +315,5 @@ func NewCounterFunc(opts CounterOpts, function func() float64) CounterFunc {
 		opts.Help,
 		nil,
 		opts.ConstLabels,
-	), CounterValue, function)
+	), CounterValue, nil, function)
 }

--- a/prometheus/gauge_test.go
+++ b/prometheus/gauge_test.go
@@ -16,6 +16,7 @@ package prometheus
 import (
 	"math"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"testing/quick"
@@ -199,4 +200,199 @@ func TestGaugeSetCurrentTime(t *testing.T) {
 	if math.Abs(delta) > 5 {
 		t.Errorf("Gauge set to current time deviates from current time by more than 5s, delta is %f seconds", delta)
 	}
+}
+
+func TestGaugeFuncVecEndToEnd(t *testing.T) {
+	gfv := NewGaugeFuncVec(
+		GaugeOpts{
+			Name:        "test_name",
+			Help:        "test help",
+			ConstLabels: Labels{"const": "42"},
+		},
+		[]string{"var", "curried"},
+	)
+	// add by labels
+	err := gfv.Add(func() float64 { return 10 }, Labels{"var": "labels", "curried": "false"})
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	// add by labels and remove later
+	err = gfv.Add(func() float64 { return 20 }, Labels{"var": "to_be_removed", "curried": "false"})
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	// add by labels and remove + add again later
+	err = gfv.Add(func() float64 { return 30 }, Labels{"var": "to_be_replaced", "curried": "false"})
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	// add by label values
+	err = gfv.AddWithLabels(func() float64 { return 40 }, "label_values", "false")
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	// add by label values and remove later
+	err = gfv.AddWithLabels(func() float64 { return 50 }, "label_values_to_be_removed", "false")
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	// remove the one added by labels by label values
+	deleted := gfv.DeleteLabelValues("to_be_removed", "false")
+	if !deleted {
+		t.Errorf("should be deleted")
+	}
+
+	// remove the one added by label values by labels
+	deleted = gfv.Delete(Labels{"var": "label_values_to_be_removed", "curried": "false"})
+	if !deleted {
+		t.Errorf("should be deleted")
+	}
+
+	// remove and add again with a new value
+	deleted = gfv.DeleteLabelValues("to_be_replaced", "false")
+	if !deleted {
+		t.Errorf("should be deleted")
+	}
+	err = gfv.Add(func() float64 { return 60 }, Labels{"var": "to_be_replaced", "curried": "false"})
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	curriedGfv, err := gfv.CurryWith(Labels{"curried": "true"})
+	if err != nil {
+		t.Fatalf("should be able to curry: %s", err)
+	}
+
+	// add curried in both ways
+	err = curriedGfv.AddWithLabels(func() float64 { return 70 }, "label_values")
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+	err = curriedGfv.Add(func() float64 { return 80 }, Labels{"var": "labels"})
+	if err != nil {
+		t.Fatalf("metric should be added correctly: %s", err)
+	}
+
+	metricChan := make(chan Metric)
+	go func() {
+		gfv.Collect(metricChan)
+		close(metricChan)
+	}()
+
+	expected := map[string]bool{
+		`label:<name:"const" value:"42" > label:<name:"curried" value:"false" > label:<name:"var" value:"labels" > gauge:<value:10 >`:         true,
+		`label:<name:"const" value:"42" > label:<name:"curried" value:"false" > label:<name:"var" value:"label_values" > gauge:<value:40 >`:   true,
+		`label:<name:"const" value:"42" > label:<name:"curried" value:"false" > label:<name:"var" value:"to_be_replaced" > gauge:<value:60 >`: true,
+		`label:<name:"const" value:"42" > label:<name:"curried" value:"true" > label:<name:"var" value:"label_values" > gauge:<value:70 >`:    true,
+		`label:<name:"const" value:"42" > label:<name:"curried" value:"true" > label:<name:"var" value:"labels" > gauge:<value:80 >`:          true,
+	}
+
+	got := map[string]bool{}
+	for metric := range metricChan {
+		m := &dto.Metric{}
+		if err := metric.Write(m); err != nil {
+			t.Fatalf("can't read metric: %s", err)
+		}
+		got[strings.TrimSpace(m.String())] = true
+	}
+
+	for m := range expected {
+		if !got[m] {
+			t.Errorf("Expected `%s` but didn't get", m)
+		}
+	}
+	for m := range got {
+		if !expected[m] {
+			t.Errorf("Got unexpected `%s`", m)
+		}
+	}
+}
+
+func TestGaugeFuncVecFailingAdd(t *testing.T) {
+	gfv := NewGaugeFuncVec(
+		GaugeOpts{
+			Name:        "test_name",
+			Help:        "test help",
+			ConstLabels: Labels{"const": "42"},
+		},
+		[]string{"var", "curried"},
+	)
+	f := func() float64 { return 0 }
+
+	expectErr := func(err error) {
+		t.Helper()
+		if err == nil {
+			t.Errorf("should receive an error, got nil")
+		}
+	}
+
+	expectPanic := func(panicker func()) {
+		t.Helper()
+		panicked := false
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					panicked = true
+				}
+			}()
+			panicker()
+		}()
+		if !panicked {
+			t.Errorf("should panic, but didn't")
+		}
+	}
+
+	t.Run("missing label", func(t *testing.T) {
+		expectErr(gfv.Add(f, Labels{"var": "missing_curried"}))
+		expectPanic(func() {
+			gfv.MustAdd(f, Labels{"var": "missing_curried"})
+		})
+	})
+
+	t.Run("too few labels", func(t *testing.T) {
+		expectErr(gfv.AddWithLabels(f, "few"))
+		expectPanic(func() {
+			gfv.MustAddWithLabels(f, "few")
+		})
+	})
+
+	t.Run("too many labels", func(t *testing.T) {
+		expectErr(gfv.AddWithLabels(f, "too", "many", "labels"))
+		expectPanic(func() {
+			gfv.MustAddWithLabels(f, "too", "many", "labels")
+		})
+	})
+
+	t.Run("unexpected label", func(t *testing.T) {
+		expectErr(gfv.Add(f, Labels{"var": "ok", "curried": "false", "extra": "unexpected"}))
+		expectPanic(func() {
+			gfv.MustAdd(f, Labels{"var": "ok", "curried": "false", "unexpected": "label"})
+		})
+	})
+
+	t.Run("curry unexpected label", func(t *testing.T) {
+		expectPanic(func() {
+			gfv.MustCurryWith(Labels{"unexpected": "label"})
+		})
+	})
+
+	t.Run("curry same label", func(t *testing.T) {
+		curried := gfv.MustCurryWith(Labels{"curried": "true"})
+		expectPanic(func() {
+			curried.MustCurryWith(Labels{"curried": "true"})
+		})
+	})
+
+	t.Run("add curried label", func(t *testing.T) {
+		curried := gfv.MustCurryWith(Labels{"curried": "true"})
+		expectErr(curried.Add(f, Labels{"var": "ok", "curried": "true"}))
+		expectPanic(func() {
+			curried.MustAdd(f, Labels{"var": "ok", "curried": "true"})
+		})
+	})
 }

--- a/prometheus/untyped.go
+++ b/prometheus/untyped.go
@@ -38,5 +38,5 @@ func NewUntypedFunc(opts UntypedOpts, function func() float64) UntypedFunc {
 		opts.Help,
 		nil,
 		opts.ConstLabels,
-	), UntypedValue, function)
+	), UntypedValue, nil, function)
 }

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -57,12 +57,12 @@ type valueFunc struct {
 // happen concurrently. If that results in concurrent calls to Write, like in
 // the case where a valueFunc is directly registered with Prometheus, the
 // provided function must be concurrency-safe.
-func newValueFunc(desc *Desc, valueType ValueType, function func() float64) *valueFunc {
+func newValueFunc(desc *Desc, valueType ValueType, lvs []string, function func() float64) *valueFunc {
 	result := &valueFunc{
 		desc:       desc,
 		valType:    valueType,
 		function:   function,
-		labelPairs: makeLabelPairs(desc, nil),
+		labelPairs: makeLabelPairs(desc, lvs),
 	}
 	result.init(result)
 	return result


### PR DESCRIPTION
`GaugeFunc` is great for datasources that can provide instant collection of metrics, like `sql.DB.Stats()`, however they don't allow multiple gauges on the same metric name with different label values.

A `GaugeFuncVec` works similarly to a `GaugeVec`, but instead of creating `Gauge` metrics, it accepts a function as the datasource (just like `GaugeFunc`) and registers it for a given set of labels.

Most of the code was already present in the `metricVec`, we just need to skip the metric creation part and provide method for adding metrics directly.

I did't open a previous discussion on Google Groups because this is a port of my own piece of code I did in https://github.com/colega/gaugefuncvec however I considered that it might be interesting to have that in the client.

- Pros: people can find this easily and it reuses most of the code from `metricsVec`. It's also easier to keep the API updated with most of the changes.
- Cons: makes the API of this client wider which isn't necessary since the implementation in my library provides same contract and (and performance in most cases). I can also understand the concern of letting people expose too many gauge funcs affecting the scraping performance, however I'd also expect people to understand what they're doing (and maybe add a warning in the comments?) 

Anyway, we can move the discussion about this to Google Groups if needed.