### PR TITLE
Porting promlint from prometheus/prometheus

### DIFF
--- a/prometheus/testutil/promlint/promlint.go
+++ b/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,372 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	r io.Reader
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// problems is a slice of Problems with a helper method to easily append
+// additional Problems to the slice.
+type problems []Problem
+
+// Add appends a new Problem to the slice for the specified metric, with
+// the specified issue text.
+func (p *problems) Add(mf dto.MetricFamily, text string) {
+	*p = append(*p, Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	})
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics.
+// Only the text exposition format is supported.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream.  The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	// TODO(mdlayher): support for protobuf exposition format?
+	d := expfmt.NewDecoder(l.r, expfmt.FmtText)
+
+	var problems []Problem
+
+	var mf dto.MetricFamily
+	for {
+		if err := d.Decode(&mf); err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return nil, err
+		}
+
+		problems = append(problems, lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func lint(mf dto.MetricFamily) []Problem {
+	fns := []func(mf dto.MetricFamily) []Problem{
+		lintHelp,
+		lintMetricUnits,
+		lintCounter,
+		lintHistogramSummaryReserved,
+		lintMetricTypeInName,
+		lintReservedChars,
+		lintCamelCase,
+		lintUnitAbbreviations,
+	}
+
+	var problems []Problem
+	for _, fn := range fns {
+		problems = append(problems, fn(mf)...)
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}
+
+// lintHelp detects issues related to the help text for a metric.
+func lintHelp(mf dto.MetricFamily) []Problem {
+	var problems problems
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems.Add(mf, "no help text")
+	}
+
+	return problems
+}
+
+// lintMetricUnits detects issues with metric unit names.
+func lintMetricUnits(mf dto.MetricFamily) []Problem {
+	var problems problems
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems.Add(mf, fmt.Sprintf("use base unit %q instead of %q", base, unit))
+
+	return problems
+}
+
+// lintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func lintCounter(mf dto.MetricFamily) []Problem {
+	var problems problems
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems.Add(mf, `counter metrics should have "_total" suffix`)
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems.Add(mf, `non-counter metrics should not have "_total" suffix`)
+	}
+
+	return problems
+}
+
+// lintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func lintHistogramSummaryReserved(mf dto.MetricFamily) []Problem {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems problems
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems.Add(mf, `non-histogram metrics should not have "_bucket" suffix`)
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems.Add(mf, `non-histogram and non-summary metrics should not have "_count" suffix`)
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems.Add(mf, `non-histogram and non-summary metrics should not have "_sum" suffix`)
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems.Add(mf, `non-histogram metrics should not have "le" label`)
+			}
+			if !isSummary && ln == "quantile" {
+				problems.Add(mf, `non-summary metrics should not have "quantile" label`)
+			}
+		}
+	}
+
+	return problems
+}
+
+// lintMetricTypeInName detects when metric types are included in the metric name.
+func lintMetricTypeInName(mf dto.MetricFamily) []Problem {
+	var problems problems
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems.Add(mf, fmt.Sprintf(`metric name should not include type '%s'`, typename))
+		}
+	}
+	return problems
+}
+
+// lintReservedChars detects colons in metric names.
+func lintReservedChars(mf dto.MetricFamily) []Problem {
+	var problems problems
+	if strings.Contains(mf.GetName(), ":") {
+		problems.Add(mf, "metric names should not contain ':'")
+	}
+	return problems
+}
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// lintCamelCase detects metric names and label names written in camelCase.
+func lintCamelCase(mf dto.MetricFamily) []Problem {
+	var problems problems
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems.Add(mf, "metric names should be written in 'snake_case' not 'camelCase'")
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems.Add(mf, "label names should be written in 'snake_case' not 'camelCase'")
+			}
+		}
+	}
+	return problems
+}
+
+// lintUnitAbbreviations detects abbreviated units in the metric name.
+func lintUnitAbbreviations(mf dto.MetricFamily) []Problem {
+	var problems problems
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems.Add(mf, "metric names should not contain abbreviated units")
+		}
+	}
+	return problems
+}
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit string, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for unit, base := range units {
+		// Also check for "no prefix".
+		for _, p := range append(unitPrefixes, "") {
+			for _, s := range ss {
+				// Attempt to explicitly match a known unit with a known prefix,
+				// as some words may look like "units" when matching suffix.
+				//
+				// As an example, "thermometers" should not match "meters", but
+				// "kilometers" should.
+				if s == p+unit {
+					return p + unit, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Celsius is more common in practice than Kelvin.
+		"grams":   "grams",
+		"joules":  "joules",
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvin":     "celsius",
+		"kelvins":    "celsius",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)

--- a/prometheus/testutil/promlint/promlint_test.go
+++ b/prometheus/testutil/promlint/promlint_test.go
@@ -1,0 +1,788 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+type test struct {
+	name     string
+	in       string
+	problems []promlint.Problem
+}
+
+func TestLintNoHelpText(t *testing.T) {
+	const msg = "no help text"
+
+	tests := []test{
+		{
+			name: "no help",
+			in: `
+# TYPE go_goroutines gauge
+go_goroutines 24
+`,
+			problems: []promlint.Problem{{
+				Metric: "go_goroutines",
+				Text:   msg,
+			}},
+		},
+		{
+			name: "empty help",
+			in: `
+# HELP go_goroutines
+# TYPE go_goroutines gauge
+go_goroutines 24
+`,
+			problems: []promlint.Problem{{
+				Metric: "go_goroutines",
+				Text:   msg,
+			}},
+		},
+		{
+			name: "no help and empty help",
+			in: `
+# HELP go_goroutines
+# TYPE go_goroutines gauge
+go_goroutines 24
+# TYPE go_threads gauge
+go_threads 10
+`,
+			problems: []promlint.Problem{
+				{
+					Metric: "go_goroutines",
+					Text:   msg,
+				},
+				{
+					Metric: "go_threads",
+					Text:   msg,
+				},
+			},
+		},
+		{
+			name: "OK",
+			in: `
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 24
+`,
+		},
+	}
+	runTests(t, tests)
+}
+
+func TestLintMetricUnits(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		problems []promlint.Problem
+	}{
+		// good cases.
+		{
+			name: "amperes",
+			in: `
+# HELP x_amperes Test metric.
+# TYPE x_amperes untyped
+x_amperes 10
+`,
+		},
+		{
+			name: "bytes",
+			in: `
+# HELP x_bytes Test metric.
+# TYPE x_bytes untyped
+x_bytes 10
+`,
+		},
+		{
+			name: "grams",
+			in: `
+# HELP x_grams Test metric.
+# TYPE x_grams untyped
+x_grams 10
+`,
+		},
+		{
+			name: "celsius",
+			in: `
+# HELP x_celsius Test metric.
+# TYPE x_celsius untyped
+x_celsius 10
+`,
+		},
+		{
+			name: "meters",
+			in: `
+# HELP x_meters Test metric.
+# TYPE x_meters untyped
+x_meters 10
+`,
+		},
+		{
+			name: "metres",
+			in: `
+# HELP x_metres Test metric.
+# TYPE x_metres untyped
+x_metres 10
+`,
+		},
+		{
+			name: "moles",
+			in: `
+# HELP x_moles Test metric.
+# TYPE x_moles untyped
+x_moles 10
+`,
+		},
+		{
+			name: "seconds",
+			in: `
+# HELP x_seconds Test metric.
+# TYPE x_seconds untyped
+x_seconds 10
+`,
+		},
+		{
+			name: "joules",
+			in: `
+# HELP x_joules Test metric.
+# TYPE x_joules untyped
+x_joules 10
+`,
+		},
+		// bad cases.
+		{
+			name: "milliamperes",
+			in: `
+# HELP x_milliamperes Test metric.
+# TYPE x_milliamperes untyped
+x_milliamperes 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_milliamperes",
+				Text:   `use base unit "amperes" instead of "milliamperes"`,
+			}},
+		},
+		{
+			name: "gigabytes",
+			in: `
+# HELP x_gigabytes Test metric.
+# TYPE x_gigabytes untyped
+x_gigabytes 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_gigabytes",
+				Text:   `use base unit "bytes" instead of "gigabytes"`,
+			}},
+		},
+		{
+			name: "kilograms",
+			in: `
+# HELP x_kilograms Test metric.
+# TYPE x_kilograms untyped
+x_kilograms 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_kilograms",
+				Text:   `use base unit "grams" instead of "kilograms"`,
+			}},
+		},
+		{
+			name: "nanocelsius",
+			in: `
+# HELP x_nanocelsius Test metric.
+# TYPE x_nanocelsius untyped
+x_nanocelsius 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_nanocelsius",
+				Text:   `use base unit "celsius" instead of "nanocelsius"`,
+			}},
+		},
+		{
+			name: "kilometers",
+			in: `
+# HELP x_kilometers Test metric.
+# TYPE x_kilometers untyped
+x_kilometers 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_kilometers",
+				Text:   `use base unit "meters" instead of "kilometers"`,
+			}},
+		},
+		{
+			name: "picometers",
+			in: `
+# HELP x_picometers Test metric.
+# TYPE x_picometers untyped
+x_picometers 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_picometers",
+				Text:   `use base unit "meters" instead of "picometers"`,
+			}},
+		},
+		{
+			name: "microseconds",
+			in: `
+# HELP x_microseconds Test metric.
+# TYPE x_microseconds untyped
+x_microseconds 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_microseconds",
+				Text:   `use base unit "seconds" instead of "microseconds"`,
+			}},
+		},
+		{
+			name: "minutes",
+			in: `
+# HELP x_minutes Test metric.
+# TYPE x_minutes untyped
+x_minutes 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_minutes",
+				Text:   `use base unit "seconds" instead of "minutes"`,
+			}},
+		},
+		{
+			name: "hours",
+			in: `
+# HELP x_hours Test metric.
+# TYPE x_hours untyped
+x_hours 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_hours",
+				Text:   `use base unit "seconds" instead of "hours"`,
+			}},
+		},
+		{
+			name: "days",
+			in: `
+# HELP x_days Test metric.
+# TYPE x_days untyped
+x_days 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_days",
+				Text:   `use base unit "seconds" instead of "days"`,
+			}},
+		},
+		{
+			name: "kelvin",
+			in: `
+# HELP x_kelvin Test metric.
+# TYPE x_kelvin untyped
+x_kelvin 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_kelvin",
+				Text:   `use base unit "celsius" instead of "kelvin"`,
+			}},
+		},
+		{
+			name: "kelvins",
+			in: `
+# HELP x_kelvins Test metric.
+# TYPE x_kelvins untyped
+x_kelvins 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_kelvins",
+				Text:   `use base unit "celsius" instead of "kelvins"`,
+			}},
+		},
+		{
+			name: "fahrenheit",
+			in: `
+# HELP thermometers_fahrenheit Test metric.
+# TYPE thermometers_fahrenheit untyped
+thermometers_fahrenheit 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "thermometers_fahrenheit",
+				Text:   `use base unit "celsius" instead of "fahrenheit"`,
+			}},
+		},
+		{
+			name: "rankine",
+			in: `
+# HELP thermometers_rankine Test metric.
+# TYPE thermometers_rankine untyped
+thermometers_rankine 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "thermometers_rankine",
+				Text:   `use base unit "celsius" instead of "rankine"`,
+			}},
+		}, {
+			name: "inches",
+			in: `
+# HELP x_inches Test metric.
+# TYPE x_inches untyped
+x_inches 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_inches",
+				Text:   `use base unit "meters" instead of "inches"`,
+			}},
+		}, {
+			name: "yards",
+			in: `
+# HELP x_yards Test metric.
+# TYPE x_yards untyped
+x_yards 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_yards",
+				Text:   `use base unit "meters" instead of "yards"`,
+			}},
+		}, {
+			name: "miles",
+			in: `
+# HELP x_miles Test metric.
+# TYPE x_miles untyped
+x_miles 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_miles",
+				Text:   `use base unit "meters" instead of "miles"`,
+			}},
+		}, {
+			name: "bits",
+			in: `
+# HELP x_bits Test metric.
+# TYPE x_bits untyped
+x_bits 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bits",
+				Text:   `use base unit "bytes" instead of "bits"`,
+			}},
+		},
+		{
+			name: "calories",
+			in: `
+# HELP x_calories Test metric.
+# TYPE x_calories untyped
+x_calories 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_calories",
+				Text:   `use base unit "joules" instead of "calories"`,
+			}},
+		},
+		{
+			name: "pounds",
+			in: `
+# HELP x_pounds Test metric.
+# TYPE x_pounds untyped
+x_pounds 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_pounds",
+				Text:   `use base unit "grams" instead of "pounds"`,
+			}},
+		},
+		{
+			name: "ounces",
+			in: `
+# HELP x_ounces Test metric.
+# TYPE x_ounces untyped
+x_ounces 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_ounces",
+				Text:   `use base unit "grams" instead of "ounces"`,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := promlint.New(strings.NewReader(tt.in))
+
+			problems, err := l.Lint()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.problems, problems; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected problems:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+		})
+	}
+}
+
+func TestLintCounter(t *testing.T) {
+	tests := []test{
+		{
+			name: "counter without _total suffix",
+			in: `
+# HELP x_bytes Test metric.
+# TYPE x_bytes counter
+x_bytes 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes",
+				Text:   `counter metrics should have "_total" suffix`,
+			}},
+		},
+		{
+			name: "gauge with _total suffix",
+			in: `
+# HELP x_bytes_total Test metric.
+# TYPE x_bytes_total gauge
+x_bytes_total 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes_total",
+				Text:   `non-counter metrics should not have "_total" suffix`,
+			}},
+		},
+		{
+			name: "counter with _total suffix",
+			in: `
+# HELP x_bytes_total Test metric.
+# TYPE x_bytes_total counter
+x_bytes_total 10
+`,
+		},
+		{
+			name: "gauge without _total suffix",
+			in: `
+# HELP x_bytes Test metric.
+# TYPE x_bytes gauge
+x_bytes 10
+`,
+		},
+		{
+			name: "untyped with _total suffix",
+			in: `
+# HELP x_bytes_total Test metric.
+# TYPE x_bytes_total untyped
+x_bytes_total 10
+`,
+		},
+		{
+			name: "untyped without _total suffix",
+			in: `
+# HELP x_bytes Test metric.
+# TYPE x_bytes untyped
+x_bytes 10
+`,
+		},
+	}
+
+	runTests(t, tests)
+}
+
+func TestLintHistogramSummaryReserved(t *testing.T) {
+	tests := []test{
+		{
+			name: "gauge with _bucket suffix",
+			in: `
+# HELP x_bytes_bucket Test metric.
+# TYPE x_bytes_bucket gauge
+x_bytes_bucket 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes_bucket",
+				Text:   `non-histogram metrics should not have "_bucket" suffix`,
+			}},
+		},
+		{
+			name: "gauge with _count suffix",
+			in: `
+# HELP x_bytes_count Test metric.
+# TYPE x_bytes_count gauge
+x_bytes_count 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes_count",
+				Text:   `non-histogram and non-summary metrics should not have "_count" suffix`,
+			}},
+		},
+		{
+			name: "gauge with _sum suffix",
+			in: `
+# HELP x_bytes_sum Test metric.
+# TYPE x_bytes_sum gauge
+x_bytes_sum 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes_sum",
+				Text:   `non-histogram and non-summary metrics should not have "_sum" suffix`,
+			}},
+		},
+		{
+			name: "gauge with le label",
+			in: `
+# HELP x_bytes Test metric.
+# TYPE x_bytes gauge
+x_bytes{le="1"} 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes",
+				Text:   `non-histogram metrics should not have "le" label`,
+			}},
+		},
+		{
+			name: "gauge with quantile label",
+			in: `
+# HELP x_bytes Test metric.
+# TYPE x_bytes gauge
+x_bytes{quantile="1"} 10
+`,
+			problems: []promlint.Problem{{
+				Metric: "x_bytes",
+				Text:   `non-summary metrics should not have "quantile" label`,
+			}},
+		},
+		{
+			name: "histogram with quantile label",
+			in: `
+# HELP tsdb_compaction_duration Duration of compaction runs.
+# TYPE tsdb_compaction_duration histogram
+tsdb_compaction_duration_bucket{le="0.005",quantile="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.01",quantile="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.025",quantile="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.05",quantile="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.1",quantile="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.25",quantile="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.5",quantile="0.01"} 57
+tsdb_compaction_duration_bucket{le="1",quantile="0.01"} 68
+tsdb_compaction_duration_bucket{le="2.5",quantile="0.01"} 69
+tsdb_compaction_duration_bucket{le="5",quantile="0.01"} 69
+tsdb_compaction_duration_bucket{le="10",quantile="0.01"} 69
+tsdb_compaction_duration_bucket{le="+Inf",quantile="0.01"} 69
+tsdb_compaction_duration_sum 28.740810936000006
+tsdb_compaction_duration_count 69
+`,
+			problems: []promlint.Problem{{
+				Metric: "tsdb_compaction_duration",
+				Text:   `non-summary metrics should not have "quantile" label`,
+			}},
+		},
+		{
+			name: "summary with le label",
+			in: `
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0",le="0.01"} 4.2365e-05
+go_gc_duration_seconds{quantile="0.25",le="0.01"} 8.1492e-05
+go_gc_duration_seconds{quantile="0.5",le="0.01"} 0.000100656
+go_gc_duration_seconds{quantile="0.75",le="0.01"} 0.000113913
+go_gc_duration_seconds{quantile="1",le="0.01"} 0.021754305
+go_gc_duration_seconds_sum 1.769429004
+go_gc_duration_seconds_count 5962
+`,
+			problems: []promlint.Problem{{
+				Metric: "go_gc_duration_seconds",
+				Text:   `non-histogram metrics should not have "le" label`,
+			}},
+		},
+		{
+			name: "histogram OK",
+			in: `
+# HELP tsdb_compaction_duration Duration of compaction runs.
+# TYPE tsdb_compaction_duration histogram
+tsdb_compaction_duration_bucket{le="0.005"} 0
+tsdb_compaction_duration_bucket{le="0.01"} 0
+tsdb_compaction_duration_bucket{le="0.025"} 0
+tsdb_compaction_duration_bucket{le="0.05"} 0
+tsdb_compaction_duration_bucket{le="0.1"} 0
+tsdb_compaction_duration_bucket{le="0.25"} 0
+tsdb_compaction_duration_bucket{le="0.5"} 57
+tsdb_compaction_duration_bucket{le="1"} 68
+tsdb_compaction_duration_bucket{le="2.5"} 69
+tsdb_compaction_duration_bucket{le="5"} 69
+tsdb_compaction_duration_bucket{le="10"} 69
+tsdb_compaction_duration_bucket{le="+Inf"} 69
+tsdb_compaction_duration_sum 28.740810936000006
+tsdb_compaction_duration_count 69
+`,
+		},
+		{
+			name: "summary OK",
+			in: `
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 4.2365e-05
+go_gc_duration_seconds{quantile="0.25"} 8.1492e-05
+go_gc_duration_seconds{quantile="0.5"} 0.000100656
+go_gc_duration_seconds{quantile="0.75"} 0.000113913
+go_gc_duration_seconds{quantile="1"} 0.021754305
+go_gc_duration_seconds_sum 1.769429004
+go_gc_duration_seconds_count 5962
+`,
+		},
+	}
+	runTests(t, tests)
+}
+
+func TestLintMetricTypeInName(t *testing.T) {
+	genTest := func(n, t, err string, problems ...promlint.Problem) test {
+		return test{
+			name: fmt.Sprintf("%s with _%s suffix", t, t),
+			in: fmt.Sprintf(`
+# HELP %s Test metric.
+# TYPE %s %s
+%s 10
+`, n, n, t, n),
+			problems: append(problems, promlint.Problem{
+				Metric: n,
+				Text:   fmt.Sprintf(`metric name should not include type '%s'`, err),
+			}),
+		}
+	}
+
+	twoProbTest := genTest("http_requests_counter", "counter", "counter", promlint.Problem{
+		Metric: "http_requests_counter",
+		Text:   `counter metrics should have "_total" suffix`,
+	})
+
+	tests := []test{
+		twoProbTest,
+		genTest("instance_memory_limit_bytes_gauge", "gauge", "gauge"),
+		genTest("request_duration_seconds_summary", "summary", "summary"),
+		genTest("request_duration_seconds_summary", "histogram", "summary"),
+		genTest("request_duration_seconds_histogram", "histogram", "histogram"),
+		genTest("request_duration_seconds_HISTOGRAM", "histogram", "histogram"),
+
+		genTest("instance_memory_limit_gauge_bytes", "gauge", "gauge"),
+	}
+	runTests(t, tests)
+}
+
+func TestLintReservedChars(t *testing.T) {
+	tests := []test{
+		{
+			name: "request_duration::_seconds",
+			in: `
+# HELP request_duration::_seconds Test metric.
+# TYPE request_duration::_seconds histogram
+request_duration::_seconds 10
+`,
+			problems: []promlint.Problem{
+				{
+					Metric: "request_duration::_seconds",
+					Text:   "metric names should not contain ':'",
+				},
+			},
+		},
+	}
+	runTests(t, tests)
+}
+
+func TestLintCamelCase(t *testing.T) {
+	tests := []test{
+		{
+			name: "requestDuration_seconds",
+			in: `
+# HELP requestDuration_seconds Test metric.
+# TYPE requestDuration_seconds histogram
+requestDuration_seconds 10
+`,
+			problems: []promlint.Problem{
+				{
+					Metric: "requestDuration_seconds",
+					Text:   "metric names should be written in 'snake_case' not 'camelCase'",
+				},
+			},
+		},
+		{
+			name: "request_duration_seconds",
+			in: `
+# HELP request_duration_seconds Test metric.
+# TYPE request_duration_seconds histogram
+request_duration_seconds{httpService="foo"} 10
+`,
+			problems: []promlint.Problem{
+				{
+					Metric: "request_duration_seconds",
+					Text:   "label names should be written in 'snake_case' not 'camelCase'",
+				},
+			},
+		},
+	}
+	runTests(t, tests)
+}
+
+func TestLintUnitAbbreviations(t *testing.T) {
+	genTest := func(n string) test {
+		return test{
+			name: fmt.Sprintf("%s with abbreviated unit", n),
+			in: fmt.Sprintf(`
+# HELP %s Test metric.
+# TYPE %s gauge
+%s 10
+`, n, n, n),
+			problems: []promlint.Problem{
+				{
+					Metric: n,
+					Text:   "metric names should not contain abbreviated units",
+				},
+			},
+		}
+	}
+	tests := []test{
+		genTest("instance_memory_limit_b"),
+		genTest("instance_memory_limit_kb"),
+		genTest("instance_memory_limit_mb"),
+		genTest("instance_memory_limit_MB"),
+		genTest("instance_memory_limit_gb"),
+		genTest("instance_memory_limit_tb"),
+		genTest("instance_memory_limit_pb"),
+
+		genTest("request_duration_s"),
+		genTest("request_duration_ms"),
+		genTest("request_duration_us"),
+		genTest("request_duration_ns"),
+		genTest("request_duration_sec"),
+		genTest("request_sec_duration"),
+		genTest("request_duration_m"),
+		genTest("request_duration_h"),
+		genTest("request_duration_d"),
+	}
+	runTests(t, tests)
+}
+
+func runTests(t *testing.T, tests []test) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := promlint.New(strings.NewReader(tt.in))
+
+			problems, err := l.Lint()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.problems, problems; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected problems:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+		})
+	}
+}

--- a/prometheus/testutil/promlint/promlint_test.go
+++ b/prometheus/testutil/promlint/promlint_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Refer https://github.com/prometheus/prometheus/issues/5317.

I split this work into two commits:
- Porting : Just simply copy `promlint` in.
- Minor Improvement: Fix static check warning by some IDE, such as Goland. [More Deatils](https://github.com/prometheus/prometheus/pull/6445#issuecomment-564468169)

I wish it will be easier for the reviewer to catch what has been changed during porting.

