### PR TITLE
Fix unit test failing with Go1.14+

### DIFF
--- a/prometheus/promhttp/instrument_client_test.go
+++ b/prometheus/promhttp/instrument_client_test.go
@@ -15,10 +15,10 @@ package promhttp
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -186,8 +186,9 @@ func TestClientMiddlewareAPIWithRequestContextTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("did not get timeout error")
 	}
-	if want, got := fmt.Sprintf("Get %s: context deadline exceeded", backend.URL), err.Error(); want != got {
-		t.Fatalf("want error %q, got %q", want, got)
+	expectedMsg := "context deadline exceeded"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Fatalf("unexpected error: %q, expect error: %q", err.Error(), expectedMsg)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: RainbowMango <renhongcai@huawei.com>

The following tests will fail when run with Go 1.14+:
```
[root@ecs-d8b6 client_golang]# go test ./prometheus/promhttp/ -run=TestClientMiddlewareAPIWithRequestContextTimeout
--- FAIL: TestClientMiddlewareAPIWithRequestContextTimeout (0.10s)
    instrument_client_test.go:190: want error "Get http://127.0.0.1:45001: context deadline exceeded", got "Get \"http://127.0.0.1:45001\": context deadline exceeded"
FAIL
FAIL	github.com/prometheus/client_golang/prometheus/promhttp	0.106s
```
The difference is whether the string included by double quotation marks.
Got: `"http://127.0.0.1:45001"`
Expected: `http://127.0.0.1:45001` (no `""`)


The error msg printed by Go `net/url` package, but the formatting has been changed in Go1.14.

Go 1.14-, such as 1.13.7:
https://github.com/golang/go/blob/7d2473dc81c659fba3f3b83bc6e93ca5fe37a898/src/net/url/url.go#L29
```go
func (e *Error) Error() string { return e.Op + " " + e.URL + ": " + e.Err.Error() }
```

Go 1.14+:
https://github.com/golang/go/blob/20a838ab94178c55bc4dc23ddc332fce8545a493/src/net/url/url.go#L29
```go
func (e *Error) Error() string { return fmt.Sprintf("%s %q: %s", e.Op, e.URL, e.Err) }
```

I think we shouldn't expect an individual message dump from the std package. 
So, this PR just change it to expect some key worlds.
