### PR TITLE
Improve CollectAndCount

### DIFF
--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -306,3 +306,30 @@ some_total{label1="value1"} 1
 		t.Errorf("Expected\n%#+v\nGot:\n%#+v", expectedError, err.Error())
 	}
 }
+
+func TestCollectAndCount(t *testing.T) {
+	c := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "some_total",
+			Help: "A value that represents a counter.",
+		},
+		[]string{"foo"},
+	)
+	if got, want := CollectAndCount(c), 0; got != want {
+		t.Errorf("unexpected metric count, got %d, want %d", got, want)
+	}
+	c.WithLabelValues("bar")
+	if got, want := CollectAndCount(c), 1; got != want {
+		t.Errorf("unexpected metric count, got %d, want %d", got, want)
+	}
+	c.WithLabelValues("baz")
+	if got, want := CollectAndCount(c), 2; got != want {
+		t.Errorf("unexpected metric count, got %d, want %d", got, want)
+	}
+	if got, want := CollectAndCount(c, "some_total"), 2; got != want {
+		t.Errorf("unexpected metric count, got %d, want %d", got, want)
+	}
+	if got, want := CollectAndCount(c, "some_other_total"), 0; got != want {
+		t.Errorf("unexpected metric count, got %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
Now that we have also added CollectAndLint and GatherAndLint, I
thought we should bring CollectAndCount in line. So:

- Add GatherAndCount.
- Add filtering by metric name.
- Add tests.

Minor wart: CollectAndCount should now return `(int, error)`, but that
would be a breaking change as the current version just returns
`int`. I decided to let the new version panic when it should return an
error. An error is anyway very unlikely, so the biggest annoyance here
is really just the inconsistency.

@bwplotka you might like this.

@cstyan you needed this recently (but as already discussed, with `promauto` you won't, but your request still inspired this PR)