### PR TITLE
Add lint:ignore for protobuf deprecation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,6 @@
 
 include Makefile.common
 
-# http.CloseNotifier is deprecated but we don't want to remove support
-# from client_golang to not break anybody still using it.
-STATICCHECK_IGNORE = \
-  github.com/prometheus/client_golang/prometheus/promhttp/delegator*.go:SA1019 \
-  github.com/prometheus/client_golang/prometheus/promhttp/instrument_server_test.go:SA1019 \
-  github.com/prometheus/client_golang/prometheus/http.go:SA1019
-
 .PHONY: test
 test: deps common-test
 

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/cespare/xxhash/v2"
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/model"
 

--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/expfmt"
 

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -24,6 +24,7 @@ import (
 	"testing/quick"
 	"time"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/model"
 

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -26,6 +26,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cespare/xxhash/v2"
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/expfmt"
 

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -33,6 +33,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/expfmt"
 

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/beorn7/perks/quantile"
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"sort"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"

--- a/prometheus/wrap_test.go
+++ b/prometheus/wrap_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	//lint:ignore SA1019 Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"


### PR DESCRIPTION
`github.com/golang/protobuf/proto` is deprecated in lieu of
`google.golang.org/protobuf/proto`. However, we cannot simply
migrate. Types from the proto package are exposed to users of packages
in this repo. If we migrate here, users have to migrate to. Thus, we
could only migrate with a major version bump.

In different news, with all the inline lint:ignore comments, including
the existing ones, there is no need to repeat the exception in the
Makefile.

A current version of `staticcheck` is happy with the code after this
commit. golangci-lint is broken at the moment, however, and ignores
the lint:ignore comments in the code as well as those via envvar.

@bentucker this does not fix the golangci-lint problem, but at least it addresses the legitimate protobuf deprecation warnings that even the proper staticcheck would catch.