### PR TITLE
api/prometheus/v1/api.go: Add support for status/runtimeinfo endpoint

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -137,6 +137,7 @@ const (
 	epCleanTombstones = apiPrefix + "/admin/tsdb/clean_tombstones"
 	epConfig          = apiPrefix + "/status/config"
 	epFlags           = apiPrefix + "/status/flags"
+	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
 )
 
 // AlertState models the state of an alert.
@@ -238,6 +239,8 @@ type API interface {
 	Query(ctx context.Context, query string, ts time.Time) (model.Value, Warnings, error)
 	// QueryRange performs a query for the given range.
 	QueryRange(ctx context.Context, query string, r Range) (model.Value, Warnings, error)
+	// Runtimeinfo returns the various runtime information properties about the Prometheus server.
+	Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error)
 	// Series finds series by label matchers.
 	Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, Warnings, error)
 	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
@@ -276,6 +279,22 @@ type ConfigResult struct {
 
 // FlagsResult contains the result from querying the flag endpoint.
 type FlagsResult map[string]string
+
+// RuntimeinfoResult contains the result from querying the runtimeinfo endpoint.
+type RuntimeinfoResult struct {
+	StartTime           string `json:"startTime"`
+	CWD                 string `json:"CWD"`
+	ReloadConfigSuccess bool   `json:"reloadConfigSuccess"`
+	LastConfigTime      string `json:"lastConfigTime"`
+	ChunkCount          int    `json:"chunkCount"`
+	TimeSeriesCount     int    `json:"timeSeriesCount"`
+	CorruptionCount     int    `json:"corruptionCount"`
+	GoroutineCount      int    `json:"goroutineCount"`
+	GOMAXPROCS          int    `json:"GOMAXPROCS"`
+	GOGC                string `json:"GOGC"`
+	GODEBUG             string `json:"GODEBUG"`
+	StorageRetention    string `json:"storageRetention"`
+}
 
 // SnapshotResult contains the result from querying the snapshot endpoint.
 type SnapshotResult struct {
@@ -637,6 +656,23 @@ func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
 	}
 
 	var res FlagsResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
+	u := h.client.URL(epRuntimeinfo, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return RuntimeinfoResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return RuntimeinfoResult{}, err
+	}
+
+	var res RuntimeinfoResult
 	return res, json.Unmarshal(body, &res)
 }
 

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -144,6 +144,13 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
+	doRuntimeinfo := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
+			v, err := promAPI.Runtimeinfo(context.Background())
+			return v, nil, err
+		}
+	}
+
 	doLabelNames := func(label string) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
 			return promAPI.LabelNames(context.Background())
@@ -603,6 +610,48 @@ func TestAPIs(t *testing.T) {
 			reqPath:   "/api/v1/status/flags",
 			inErr:     fmt.Errorf("some error"),
 			err:       fmt.Errorf("some error"),
+		},
+
+		{
+			do:        doRuntimeinfo(),
+			reqMethod: "GET",
+			reqPath:   "/api/v1/status/runtimeinfo",
+			inErr:     fmt.Errorf("some error"),
+			err:       fmt.Errorf("some error"),
+		},
+
+		{
+			do:        doRuntimeinfo(),
+			reqMethod: "GET",
+			reqPath:   "/api/v1/status/runtimeinfo",
+			inRes: map[string]interface{}{
+				"startTime":           "2020-05-18T15:52:53.4503113Z",
+				"CWD":                 "/prometheus",
+				"reloadConfigSuccess": true,
+				"lastConfigTime":      "2020-05-18T15:52:56Z",
+				"chunkCount":          72692,
+				"timeSeriesCount":     18476,
+				"corruptionCount":     0,
+				"goroutineCount":      217,
+				"GOMAXPROCS":          2,
+				"GOGC":                "100",
+				"GODEBUG":             "allocfreetrace",
+				"storageRetention":    "1d",
+			},
+			res: RuntimeinfoResult{
+				StartTime:           "2020-05-18T15:52:53.4503113Z",
+				CWD:                 "/prometheus",
+				ReloadConfigSuccess: true,
+				LastConfigTime:      "2020-05-18T15:52:56Z",
+				ChunkCount:          72692,
+				TimeSeriesCount:     18476,
+				CorruptionCount:     0,
+				GoroutineCount:      217,
+				GOMAXPROCS:          2,
+				GOGC:                "100",
+				GODEBUG:             "allocfreetrace",
+				StorageRetention:    "1d",
+			},
 		},
 
 		{


### PR DESCRIPTION
Adds support for the status/runtimeinfo API endpoint as per the API docs https://prometheus.io/docs/prometheus/latest/querying/api/#runtime-information

Closes #746

cc @beorn7 

