### PR TITLE
Implement noop process collector for js/wasm

### DIFF
--- a/prometheus/process_collector_js.go
+++ b/prometheus/process_collector_js.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build js,wasm
+// +build js
 
 package prometheus
 

--- a/prometheus/process_collector_js.go
+++ b/prometheus/process_collector_js.go
@@ -1,0 +1,22 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build js,wasm
+
+package prometheus
+
+func canCollectProcess() bool {
+	return false
+}
+
+func (c *processCollector) processCollect(ch chan<- Metric) {}

--- a/prometheus/process_collector_other.go
+++ b/prometheus/process_collector_other.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows,!js,!wasm
+// +build !windows,!js
 
 package prometheus
 

--- a/prometheus/process_collector_other.go
+++ b/prometheus/process_collector_other.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build !windows,!js,!wasm
 
 package prometheus
 


### PR DESCRIPTION
Adds minimal support for building for WebAssembly.

Builds targeting js/wasm currently fail trying to compile procfs. Browsers don't provide APIs for retrieving memory or CPU usage so metric collection is disabled.