### PR TITLE
testutil/promlint: allow Kelvin as a base unit for color temperature

### DIFF
--- a/prometheus/testutil/promlint/promlint.go
+++ b/prometheus/testutil/promlint/promlint.go
@@ -313,9 +313,10 @@ var (
 		// Base units.
 		"amperes": "amperes",
 		"bytes":   "bytes",
-		"celsius": "celsius", // Celsius is more common in practice than Kelvin.
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
 		"grams":   "grams",
 		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
 		"meters":  "meters", // Both American and international spelling permitted.
 		"metres":  "metres",
 		"seconds": "seconds",
@@ -328,8 +329,7 @@ var (
 		"days":    "seconds",
 		"weeks":   "seconds",
 		// Temperature.
-		"kelvin":     "celsius",
-		"kelvins":    "celsius",
+		"kelvins":    "kelvin",
 		"fahrenheit": "celsius",
 		"rankine":    "celsius",
 		// Length.

--- a/prometheus/testutil/promlint/promlint_test.go
+++ b/prometheus/testutil/promlint/promlint_test.go
@@ -166,6 +166,14 @@ x_seconds 10
 x_joules 10
 `,
 		},
+		{
+			name: "kelvin",
+			in: `
+# HELP x_kelvin Test metric.
+# TYPE x_kelvin untyped
+x_kelvin 10
+`,
+		},
 		// bad cases.
 		{
 			name: "milliamperes",
@@ -288,18 +296,6 @@ x_days 10
 			}},
 		},
 		{
-			name: "kelvin",
-			in: `
-# HELP x_kelvin Test metric.
-# TYPE x_kelvin untyped
-x_kelvin 10
-`,
-			problems: []promlint.Problem{{
-				Metric: "x_kelvin",
-				Text:   `use base unit "celsius" instead of "kelvin"`,
-			}},
-		},
-		{
 			name: "kelvins",
 			in: `
 # HELP x_kelvins Test metric.
@@ -308,7 +304,7 @@ x_kelvins 10
 `,
 			problems: []promlint.Problem{{
 				Metric: "x_kelvins",
-				Text:   `use base unit "celsius" instead of "kelvins"`,
+				Text:   `use base unit "kelvin" instead of "kelvins"`,
 			}},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I'm exporting metrics from my new Elgato Key Light and the device exposes the color temperature of its light in Kelvin, e.g. 4200K. I don't think this measurement would make any sense in Celsius and propose allowing Kelvin as a "base unit", but still recommending that "kelvins" be changed to "kelvin".