### PR TITLE
Use time.Time for timestamps in Runtimeinfo

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -285,18 +285,18 @@ type FlagsResult map[string]string
 
 // RuntimeinfoResult contains the result from querying the runtimeinfo endpoint.
 type RuntimeinfoResult struct {
-	StartTime           string `json:"startTime"`
-	CWD                 string `json:"CWD"`
-	ReloadConfigSuccess bool   `json:"reloadConfigSuccess"`
-	LastConfigTime      string `json:"lastConfigTime"`
-	ChunkCount          int    `json:"chunkCount"`
-	TimeSeriesCount     int    `json:"timeSeriesCount"`
-	CorruptionCount     int    `json:"corruptionCount"`
-	GoroutineCount      int    `json:"goroutineCount"`
-	GOMAXPROCS          int    `json:"GOMAXPROCS"`
-	GOGC                string `json:"GOGC"`
-	GODEBUG             string `json:"GODEBUG"`
-	StorageRetention    string `json:"storageRetention"`
+	StartTime           time.Time `json:"startTime"`
+	CWD                 string    `json:"CWD"`
+	ReloadConfigSuccess bool      `json:"reloadConfigSuccess"`
+	LastConfigTime      time.Time `json:"lastConfigTime"`
+	ChunkCount          int       `json:"chunkCount"`
+	TimeSeriesCount     int       `json:"timeSeriesCount"`
+	CorruptionCount     int       `json:"corruptionCount"`
+	GoroutineCount      int       `json:"goroutineCount"`
+	GOMAXPROCS          int       `json:"GOMAXPROCS"`
+	GOGC                string    `json:"GOGC"`
+	GODEBUG             string    `json:"GODEBUG"`
+	StorageRetention    string    `json:"storageRetention"`
 }
 
 // SnapshotResult contains the result from querying the snapshot endpoint.

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -646,10 +646,10 @@ func TestAPIs(t *testing.T) {
 				"storageRetention":    "1d",
 			},
 			res: RuntimeinfoResult{
-				StartTime:           "2020-05-18T15:52:53.4503113Z",
+				StartTime:           time.Date(2020, 5, 18, 15, 52, 53, 450311300, time.UTC),
 				CWD:                 "/prometheus",
 				ReloadConfigSuccess: true,
-				LastConfigTime:      "2020-05-18T15:52:56Z",
+				LastConfigTime:      time.Date(2020, 5, 18, 15, 52, 56, 0, time.UTC),
 				ChunkCount:          72692,
 				TimeSeriesCount:     18476,
 				CorruptionCount:     0,


### PR DESCRIPTION
fixes #776