### PR TITLE
Remove reference to Metric after reslicing

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -276,7 +276,9 @@ func (m *metricMap) deleteByHashWithLabelValues(
 	}
 
 	if len(metrics) > 1 {
+		old := metrics
 		m.metrics[h] = append(metrics[:i], metrics[i+1:]...)
+		old[len(old)-1] = metricWithLabelValues{}
 	} else {
 		delete(m.metrics, h)
 	}
@@ -302,7 +304,9 @@ func (m *metricMap) deleteByHashWithLabels(
 	}
 
 	if len(metrics) > 1 {
+		old := metrics
 		m.metrics[h] = append(metrics[:i], metrics[i+1:]...)
+		old[len(old)-1] = metricWithLabelValues{}
 	} else {
 		delete(m.metrics, h)
 	}


### PR DESCRIPTION
If we remove metric from slice, last value in old `metrics` still has value of `metricWithLabelValues` and holds reference to `Metric` (see Note in https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order).
```
m.metrics[h] = append(metrics[:i], metrics[i+1:]...)
```
So we must zero last value in old metrics slice after we ressliced `metrics`.
```
old := metrics
m.metrics[h] = append(metrics[:i], metrics[i+1:]...)
old[len(old)-1] = metricWithLabelValues{}
```

Signed-off-by: Dima Kozlov <hummerd@mail.ru>