### PR TITLE
Remove spurious commas from links to the docs site

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -89,7 +89,7 @@ type Opts struct {
 	// better covered by target labels set by the scraping Prometheus
 	// server, or by one specific metric (e.g. a build_info or a
 	// machine_role metric). See also
-	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels,-not-static-scraped-labels
+	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels
 	ConstLabels Labels
 }
 

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -110,7 +110,7 @@ type SummaryOpts struct {
 	// better covered by target labels set by the scraping Prometheus
 	// server, or by one specific metric (e.g. a build_info or a
 	// machine_role metric). See also
-	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels,-not-static-scraped-labels
+	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels
 	ConstLabels Labels
 
 	// Objectives defines the quantile rank estimates with their respective

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -32,7 +32,9 @@ import (
 // in a no-op Registerer.
 //
 // WrapRegistererWith provides a way to add fixed labels to a subset of
-// Collectors. It should not be used to add fixed labels to all metrics exposed.
+// Collectors. It should not be used to add fixed labels to all metrics
+// exposed. See also
+// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels
 //
 // Conflicts between Collectors registered through the original Registerer with
 // Collectors registered through the wrapping Registerer will still be


### PR DESCRIPTION
I assume older Nanoc versions rendered the anchors with commas, but
the current doesn't.

Also, this adds the same link to another doc comment where it is also
relevant.

Signed-off-by: beorn7 <beorn@grafana.com>