### PR TITLE
Add unique label lint

### DIFF
--- a/prometheus/testutil/promlint/promlint_test.go
+++ b/prometheus/testutil/promlint/promlint_test.go
@@ -764,6 +764,26 @@ func TestLintUnitAbbreviations(t *testing.T) {
 	runTests(t, tests)
 }
 
+func TestUniqueLabels(t *testing.T) {
+	tests := []test{
+		{
+			name: "x_duplicate",
+			in: `
+# HELP x_duplicate Test metric.
+# TYPE x_duplicate gauge
+x_duplicate{group_id="1",group_id="2"} 10
+`,
+			problems: []promlint.Problem{
+				{
+					Metric: "x_duplicate",
+					Text:   "label names should be unique",
+				},
+			},
+		},
+	}
+	runTests(t, tests)
+}
+
 func runTests(t *testing.T, tests []test) {
 	t.Helper()
 	for _, tt := range tests {


### PR DESCRIPTION
Prometheus will fail scrapes if a metric has more than one label with
the same name. However promtool does not report this failure currently.
This change will produce an error if a metric does not have unique label
names.

Signed-off-by: Jarod Watkins <jarod@42lines.net>