### PR TITLE
Don't use newlines in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## unreleased / unreleased
+
+* [BUGFIX] Don't use newlines in error messages
+
 ## 1.8.0 / 2020-10-15
 
 * [CHANGE] API client: Use `time.Time` rather than `string` for timestamps in `RuntimeinfoResult`. #777
 * [FEATURE] Export `MetricVec` to facilitate implementation of vectors of custom `Metric` types. #803
-* [FEATURE API client: Support `/status/tsdb` endpoint. #773
+* [FEATURE] API client: Support `/status/tsdb` endpoint. #773
 * [ENHANCEMENT] API client: Enable GET fallback on status code 501. #802
 * [ENHANCEMENT] Remove `Metric` references after reslicing to free up more memory. #784
 

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -222,7 +222,7 @@ func (errs MultiError) Error() string {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "%d error(s) occurred:", len(errs))
 	for _, err := range errs {
-		fmt.Fprintf(buf, "\n* %s", err)
+		fmt.Fprintf(buf, "; %s", err)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Don't use newlines for error formatting, avoids newlines in logs.

Related to https://github.com/prometheus/node_exporter/issues/1886

Signed-off-by: Ben Kochie <superq@gmail.com>