### PR TITLE
Be more explicit about the multi-line properties of MultiError

### DIFF
--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -303,8 +303,12 @@ type Logger interface {
 // HandlerOpts specifies options how to serve metrics via an http.Handler. The
 // zero value of HandlerOpts is a reasonable default.
 type HandlerOpts struct {
-	// ErrorLog specifies an optional logger for errors collecting and
-	// serving metrics. If nil, errors are not logged at all.
+	// ErrorLog specifies an optional Logger for errors collecting and
+	// serving metrics. If nil, errors are not logged at all. Note that the
+	// type of a reported error is often prometheus.MultiError, which
+	// formats into a multi-line error string. If you want to avoid the
+	// latter, create a Logger implementation that detects a
+	// prometheus.MultiError and formats the contained errors into one line.
 	ErrorLog Logger
 	// ErrorHandling defines how errors are handled. Note that errors are
 	// logged regardless of the configured ErrorHandling provided ErrorLog

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -215,6 +215,8 @@ func (err AlreadyRegisteredError) Error() string {
 // by a Gatherer to report multiple errors during MetricFamily gathering.
 type MultiError []error
 
+// Error formats the contained errors as a bullet point list, preceded by the
+// total number of errors. Note that this results in a multi-line string.
 func (errs MultiError) Error() string {
 	if len(errs) == 0 {
 		return ""


### PR DESCRIPTION
Note that changing the behavior will only be possible in v2 and is tracked in #820 .