### PR TITLE
Support matchers in labels API

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -230,9 +230,9 @@ type API interface {
 	DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
-	// LabelNames returns all the unique label names present in the block in sorted order.
+	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
 	LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]string, Warnings, error)
-	// LabelValues performs a query for the values of the given label.
+	// LabelValues performs a query for the values of the given label, time range and matchers.
 	LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time) (model.LabelValues, Warnings, error)
 	// Query performs a query for the given time.
 	Query(ctx context.Context, query string, ts time.Time) (model.Value, Warnings, error)

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -231,9 +231,9 @@ type API interface {
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
 	// LabelNames returns all the unique label names present in the block in sorted order.
-	LabelNames(ctx context.Context, startTime time.Time, endTime time.Time) ([]string, Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]string, Warnings, error)
 	// LabelValues performs a query for the values of the given label.
-	LabelValues(ctx context.Context, label string, startTime time.Time, endTime time.Time) (model.LabelValues, Warnings, error)
+	LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time) (model.LabelValues, Warnings, error)
 	// Query performs a query for the given time.
 	Query(ctx context.Context, query string, ts time.Time) (model.Value, Warnings, error)
 	// QueryRange performs a query for the given range.
@@ -691,11 +691,14 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 	return res, json.Unmarshal(body, &res)
 }
 
-func (h *httpAPI) LabelNames(ctx context.Context, startTime time.Time, endTime time.Time) ([]string, Warnings, error) {
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]string, Warnings, error) {
 	u := h.client.URL(epLabels, nil)
 	q := u.Query()
 	q.Set("start", formatTime(startTime))
 	q.Set("end", formatTime(endTime))
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
 
 	u.RawQuery = q.Encode()
 
@@ -711,11 +714,14 @@ func (h *httpAPI) LabelNames(ctx context.Context, startTime time.Time, endTime t
 	return labelNames, w, json.Unmarshal(body, &labelNames)
 }
 
-func (h *httpAPI) LabelValues(ctx context.Context, label string, startTime time.Time, endTime time.Time) (model.LabelValues, Warnings, error) {
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time) (model.LabelValues, Warnings, error) {
 	u := h.client.URL(epLabelValues, map[string]string{"name": label})
 	q := u.Query()
 	q.Set("start", formatTime(startTime))
 	q.Set("end", formatTime(endTime))
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
 
 	u.RawQuery = q.Encode()
 

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -151,15 +151,15 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
-	doLabelNames := func(label string) func() (interface{}, Warnings, error) {
+	doLabelNames := func(matches []string) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			return promAPI.LabelNames(context.Background(), time.Now().Add(-100*time.Hour), time.Now())
+			return promAPI.LabelNames(context.Background(), matches, time.Now().Add(-100*time.Hour), time.Now())
 		}
 	}
 
-	doLabelValues := func(label string) func() (interface{}, Warnings, error) {
+	doLabelValues := func(matches []string, label string) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			return promAPI.LabelValues(context.Background(), label, time.Now().Add(-100*time.Hour), time.Now())
+			return promAPI.LabelValues(context.Background(), label, matches, time.Now().Add(-100*time.Hour), time.Now())
 		}
 	}
 
@@ -359,14 +359,14 @@ func TestAPIs(t *testing.T) {
 		},
 
 		{
-			do:        doLabelNames("mylabel"),
+			do:        doLabelNames(nil),
 			inRes:     []string{"val1", "val2"},
 			reqMethod: "GET",
 			reqPath:   "/api/v1/labels",
 			res:       []string{"val1", "val2"},
 		},
 		{
-			do:         doLabelNames("mylabel"),
+			do:         doLabelNames(nil),
 			inRes:      []string{"val1", "val2"},
 			inWarnings: []string{"a"},
 			reqMethod:  "GET",
@@ -376,14 +376,14 @@ func TestAPIs(t *testing.T) {
 		},
 
 		{
-			do:        doLabelNames("mylabel"),
+			do:        doLabelNames(nil),
 			inErr:     fmt.Errorf("some error"),
 			reqMethod: "GET",
 			reqPath:   "/api/v1/labels",
 			err:       fmt.Errorf("some error"),
 		},
 		{
-			do:         doLabelNames("mylabel"),
+			do:         doLabelNames(nil),
 			inErr:      fmt.Errorf("some error"),
 			inWarnings: []string{"a"},
 			reqMethod:  "GET",
@@ -391,16 +391,24 @@ func TestAPIs(t *testing.T) {
 			err:        fmt.Errorf("some error"),
 			warnings:   []string{"a"},
 		},
+		{
+			do:        doLabelNames([]string{"up"}),
+			inRes:     []string{"val1", "val2"},
+			reqMethod: "GET",
+			reqPath:   "/api/v1/labels",
+			reqParam:  url.Values{"match[]": {"up"}},
+			res:       []string{"val1", "val2"},
+		},
 
 		{
-			do:        doLabelValues("mylabel"),
+			do:        doLabelValues(nil, "mylabel"),
 			inRes:     []string{"val1", "val2"},
 			reqMethod: "GET",
 			reqPath:   "/api/v1/label/mylabel/values",
 			res:       model.LabelValues{"val1", "val2"},
 		},
 		{
-			do:         doLabelValues("mylabel"),
+			do:         doLabelValues(nil, "mylabel"),
 			inRes:      []string{"val1", "val2"},
 			inWarnings: []string{"a"},
 			reqMethod:  "GET",
@@ -410,20 +418,28 @@ func TestAPIs(t *testing.T) {
 		},
 
 		{
-			do:        doLabelValues("mylabel"),
+			do:        doLabelValues(nil, "mylabel"),
 			inErr:     fmt.Errorf("some error"),
 			reqMethod: "GET",
 			reqPath:   "/api/v1/label/mylabel/values",
 			err:       fmt.Errorf("some error"),
 		},
 		{
-			do:         doLabelValues("mylabel"),
+			do:         doLabelValues(nil, "mylabel"),
 			inErr:      fmt.Errorf("some error"),
 			inWarnings: []string{"a"},
 			reqMethod:  "GET",
 			reqPath:    "/api/v1/label/mylabel/values",
 			err:        fmt.Errorf("some error"),
 			warnings:   []string{"a"},
+		},
+		{
+			do:        doLabelValues([]string{"up"}, "mylabel"),
+			inRes:     []string{"val1", "val2"},
+			reqMethod: "GET",
+			reqPath:   "/api/v1/label/mylabel/values",
+			reqParam:  url.Values{"match[]": {"up"}},
+			res:       model.LabelValues{"val1", "val2"},
 		},
 
 		{


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

As pr https://github.com/prometheus/prometheus/pull/8301 was merged, this pr adds `matches` to `LabelNames` and `LabelValues` APIs. 

One thing I am not very sure is the testing, seems we are just mocking the HTTP response in the unit tests, it cannot really ensure correctness. But I already test this manually and it works.