### PR TITLE
Make InstrumentHandlerCounter return a http.Handler.

### DIFF
--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -92,7 +92,7 @@ func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler) ht
 // If the wrapped Handler panics, the Counter is not incremented.
 //
 // See the example for InstrumentHandlerDuration for example usage.
-func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler) http.HandlerFunc {
+func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler) http.Handler {
 	code, method := checkLabels(counter)
 
 	if code {


### PR DESCRIPTION
This is backwards incompatible I think, so lets not merge - if we do want to do this I'll introduce a new function.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>