### PR TITLE
Improve description of MaxAge in summary docs

### DIFF
--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -121,7 +121,9 @@ type SummaryOpts struct {
 	Objectives map[float64]float64
 
 	// MaxAge defines the duration for which an observation stays relevant
-	// for the summary. Must be positive. The default value is DefMaxAge.
+	// for the summary. Only applies to pre-calculated quantiles, does not
+	// apply to _sum and _count. Must be positive. The default value is 
+	// DefMaxAge.
 	MaxAge time.Duration
 
 	// AgeBuckets is the number of buckets used to exclude observations that

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -122,7 +122,7 @@ type SummaryOpts struct {
 
 	// MaxAge defines the duration for which an observation stays relevant
 	// for the summary. Only applies to pre-calculated quantiles, does not
-	// apply to _sum and _count. Must be positive. The default value is 
+	// apply to _sum and _count. Must be positive. The default value is
 	// DefMaxAge.
 	MaxAge time.Duration
 


### PR DESCRIPTION
Fixes: https://github.com/prometheus/client_golang/issues/737

Clarifies the purpose of the `MaxAge` field of the summary.