### PR TITLE
Change maintainers from @beorn7 to @bwplotka/@kakkoyun

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,2 @@
-* Björn Rabenstein <beorn@grafana.com> @beorn7
+* Bartłomiej Płotka <bwplotka@gmail.com> @bwplotka
+* Kemal Akkoyun <kakkoyun@gmail.com> @kakkoyun


### PR DESCRIPTION
Lazy consensus was already established among prometheus-team. This
change will be announced on prometheus-developers@ once it is merged.

@kakkoyun (just tagging you here for bootstrapping – once this is merged, I'll grant you the appropriate GH permissions, and then we can also assign you as a reviewer to a PR in this repo)