### PR TITLE
Automate Metric Documentation

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -586,7 +586,7 @@ func WriteToTextfile(filename string, g Gatherer) error {
 	return os.Rename(tmp.Name(), filename)
 }
 
-// WriteMetricsDoc writes all of the registered metrics along with their
+// WriteMetricsMarkdown writes all of the registered metrics along with their
 // help text and labels as a markdown file. It first writes it to a temp file and
 // on success the temporary file is renamed to the provided filename.
 //


### PR DESCRIPTION
@bwplotka @kakkoyun
**Overview**
This PR implements a new function, `WriteMetricsMarkdown`, which creates a markdown file containing all of the registered metrics with their corresponding help text and labels.

**Explanation**
The goal for this function to enable developers to automatically generate and keep an up to date METRICS.md file. 

Previously to generate this type of file, a developer would have to hit the metrics endpoint for the help text and then manually use that to generate a markdown file. This also wouldn't guarantee that all of the metrics were covered as the vectors may not show up in the metrics endpoint if it has not yet been used. 

With the addition of this function, this could be automated for developers, and would ensure completeness as this function returns all of the metrics (including the vectors that have not yet been used). It would also ensure that documentation stays up to date as metrics are added.

**Example**
This code would be added to a user's code base:
```code
registry := prometheus.NewRegistry()
histogram := prometheus.NewHistogramVec(
		prometheus.HistogramOpts{
			Name: "example_histogram",
			Help: "example histogram",
		},
		[]string{"example"},
	)
registry.MustRegister(histogram)
prometheus.WriteMetricsMarkdown(registry, "METRICS.md", []string{})
```

The result would be a markdown file like this:
```markdown
# Metrics

## `example` Metrics
| *Metric* | *Description* | *Labels* |
|--|--|--|
| `example_histogram` | example histogram | `example` |

## `go` Metrics
| *Metric* | *Description* | *Labels* |
|--|--|--|
| `go_gc_duration_seconds` | A summary of the pause duration of garbage collection cycles. | |
| `go_goroutines` | Number of goroutines that currently exist. | |
| `go_info` | Information about the Go environment. | |
| `go_memstats_alloc_bytes` | Number of bytes allocated and still in use. | |
| `go_memstats_alloc_bytes_total` | Total number of bytes allocated, even if freed. | |
| `go_memstats_buck_hash_sys_bytes` | Number of bytes used by the profiling bucket hash table. | |
| `go_memstats_frees_total` | Total number of frees. | |
| `go_memstats_gc_cpu_fraction` | The fraction of this program's available CPU time used by the GC since the program started. | |
| `go_memstats_gc_sys_bytes` | Number of bytes used for garbage collection system metadata. | |
| `go_memstats_heap_alloc_bytes` | Number of heap bytes allocated and still in use. | |
| `go_memstats_heap_idle_bytes` | Number of heap bytes waiting to be used. | |
| `go_memstats_heap_inuse_bytes` | Number of heap bytes that are in use. | |
| `go_memstats_heap_objects` | Number of allocated objects. | |
| `go_memstats_heap_released_bytes` | Number of heap bytes released to OS. | |
| `go_memstats_heap_sys_bytes` | Number of heap bytes obtained from system. | |
| `go_memstats_last_gc_time_seconds` | Number of seconds since 1970 of last garbage collection. | |
| `go_memstats_lookups_total` | Total number of pointer lookups. | |
| `go_memstats_mallocs_total` | Total number of mallocs. | |
| `go_memstats_mcache_inuse_bytes` | Number of bytes in use by mcache structures. | |
| `go_memstats_mcache_sys_bytes` | Number of bytes used for mcache structures obtained from system. | |
| `go_memstats_mspan_inuse_bytes` | Number of bytes in use by mspan structures. | |
| `go_memstats_mspan_sys_bytes` | Number of bytes used for mspan structures obtained from system. | |
| `go_memstats_next_gc_bytes` | Number of heap bytes when next garbage collection will take place. | |
| `go_memstats_other_sys_bytes` | Number of bytes used for other system allocations. | |
| `go_memstats_stack_inuse_bytes` | Number of bytes in use by the stack allocator. | |
| `go_memstats_stack_sys_bytes` | Number of bytes obtained from system for stack allocator. | |
| `go_memstats_sys_bytes` | Number of bytes obtained from system. | |
| `go_threads` | Number of OS threads created. | |
```

**Notes**
If there is concern over the additional map and memory, I can modify this to not include uninitialized vectors and make it a requirement that those are initialized before running this function. Then I could use the Gather function and loop through that.