### PR TITLE
Adding extension testutils.ToInt()

### DIFF
--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -112,6 +112,11 @@ func ToFloat64(c prometheus.Collector) float64 {
 	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
 }
 
+// ToInt returns the integer value of the collected Metric. For more information see ToFloat64.
+func ToInt(c prometheus.Collector) int {
+	return int(ToFloat64(c))
+}
+
 // CollectAndCount registers the provided Collector with a newly created
 // pedantic Registry. It then calls GatherAndCount with that Registry and with
 // the provided metricNames. In the unlikely case that the registration or the


### PR DESCRIPTION
@bwplotka, @kakkoyun

During testing I need to read metrics which are very often (in our case mostly) integer values.
Prometheus offers only the `testutils.ToFloat64` function, so all results need to be continuously re-typed into integers.
This PR only extends the ToFloat functionality by adding the ToInt function.

Signed-off-by: kuritka <kuritka@gmail.com>