### PR TITLE
Fix build against GopherJS

### DIFF
--- a/prometheus/get_pid.go
+++ b/prometheus/get_pid.go
@@ -1,3 +1,4 @@
+//go:build !js || wasm
 // +build !js wasm
 
 // Copyright 2015 The Prometheus Authors

--- a/prometheus/get_pid.go
+++ b/prometheus/get_pid.go
@@ -1,6 +1,3 @@
-//go:build !js || wasm
-// +build !js wasm
-
 // Copyright 2015 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +10,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build !js || wasm
+// +build !js wasm
 
 package prometheus
 

--- a/prometheus/get_pid.go
+++ b/prometheus/get_pid.go
@@ -1,0 +1,25 @@
+// +build !js wasm
+
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import "os"
+
+func getPIDFn() func() (int, error) {
+	pid := os.Getpid()
+	return func() (int, error) {
+		return pid, nil
+	}
+}

--- a/prometheus/get_pid_gopherjs.go
+++ b/prometheus/get_pid_gopherjs.go
@@ -1,6 +1,3 @@
-//go:build js && !wasm
-// +build js,!wasm
-
 // Copyright 2015 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +10,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build js && !wasm
+// +build js,!wasm
 
 package prometheus
 

--- a/prometheus/get_pid_gopherjs.go
+++ b/prometheus/get_pid_gopherjs.go
@@ -1,3 +1,4 @@
+//go:build js && !wasm
 // +build js,!wasm
 
 // Copyright 2015 The Prometheus Authors

--- a/prometheus/get_pid_gopherjs.go
+++ b/prometheus/get_pid_gopherjs.go
@@ -1,0 +1,22 @@
+// +build js,!wasm
+
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+func getPIDFn() func() (int, error) {
+	return func() (int, error) {
+		return 1, nil
+	}
+}

--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -248,7 +248,7 @@ func (c *baseGoCollector) Collect(ch chan<- Metric) {
 	ch <- MustNewConstMetric(c.goroutinesDesc, GaugeValue, float64(runtime.NumGoroutine()))
 
 	n := getRuntimeNumThreads()
-	ch <- MustNewConstMetric(c.threadsDesc, GaugeValue, float64(n))
+	ch <- MustNewConstMetric(c.threadsDesc, GaugeValue, n)
 
 	var stats debug.GCStats
 	stats.PauseQuantiles = make([]time.Duration, 5)

--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -246,7 +246,8 @@ func (c *baseGoCollector) Describe(ch chan<- *Desc) {
 // Collect returns the current state of all metrics of the collector.
 func (c *baseGoCollector) Collect(ch chan<- Metric) {
 	ch <- MustNewConstMetric(c.goroutinesDesc, GaugeValue, float64(runtime.NumGoroutine()))
-	n, _ := runtime.ThreadCreateProfile(nil)
+
+	n := getRuntimeNumThreads()
 	ch <- MustNewConstMetric(c.threadsDesc, GaugeValue, float64(n))
 
 	var stats debug.GCStats

--- a/prometheus/num_threads.go
+++ b/prometheus/num_threads.go
@@ -1,0 +1,24 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !js wasm
+
+package prometheus
+
+import "runtime"
+
+// getRuntimeNumThreads returns the number of open OS threads.
+func getRuntimeNumThreads() float64 {
+	n, _ := runtime.ThreadCreateProfile(nil)
+	return float64(n)
+}

--- a/prometheus/num_threads.go
+++ b/prometheus/num_threads.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !js || wasm
 // +build !js wasm
 
 package prometheus

--- a/prometheus/num_threads_gopherjs.go
+++ b/prometheus/num_threads_gopherjs.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build js,!wasm
+
+package prometheus
+
+// getRuntimeNumThreads returns the number of open OS threads.
+func getRuntimeNumThreads() float64 {
+	return 1
+}

--- a/prometheus/num_threads_gopherjs.go
+++ b/prometheus/num_threads_gopherjs.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build js && !wasm
 // +build js,!wasm
 
 package prometheus

--- a/prometheus/process_collector.go
+++ b/prometheus/process_collector.go
@@ -103,8 +103,7 @@ func NewProcessCollector(opts ProcessCollectorOpts) Collector {
 	}
 
 	if opts.PidFn == nil {
-		pid := os.Getpid()
-		c.pidFn = func() (int, error) { return pid, nil }
+		c.pidFn = getPIDFn()
 	} else {
 		c.pidFn = opts.PidFn
 	}

--- a/prometheus/process_collector_js.go
+++ b/prometheus/process_collector_js.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build js
 // +build js
 
 package prometheus

--- a/prometheus/process_collector_js.go
+++ b/prometheus/process_collector_js.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build js
+
+package prometheus
+
+func canCollectProcess() bool {
+	return false
+}
+
+func (c *processCollector) processCollect(ch chan<- Metric) {
+	// noop on this platform
+	return
+}

--- a/prometheus/process_collector_other.go
+++ b/prometheus/process_collector_other.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !js
+// +build !windows,!js
 
 package prometheus
 


### PR DESCRIPTION
When building against GopherJS, ThreadCreateProfile and Getpid are not available.

Return 1 to shim the functions.

Fixes "gopherjs build ./..."