### PR TITLE
Update example Dockerfile and random/main.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 # This Dockerfile builds an image for a client_golang example.
 #
 # Use as (from the root for the client_golang repository):
-#    docker build -f examples/$name/Dockerfile -t prometheus/golang-example-$name .
+#    docker build -f Dockerfile -t prometheus/golang-example .
+
+# Run as
+#    docker run -P prometheus/golang-example /random
+# or
+#    docker run -P prometheus/golang-example /simple
+
+# Test as
+#    curl $ip:$port/metrics
 
 # Builder image, where we build the example.
 FROM golang:1 AS builder

--- a/examples/random/main.go
+++ b/examples/random/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 var (
@@ -65,7 +66,7 @@ func init() {
 	prometheus.MustRegister(rpcDurations)
 	prometheus.MustRegister(rpcDurationsHistogram)
 	// Add Go module build info.
-	prometheus.MustRegister(prometheus.NewBuildInfoCollector())
+	prometheus.MustRegister(collectors.NewBuildInfoCollector())
 }
 
 func main() {


### PR DESCRIPTION
1. the build command of Dockerfile `docker build -f examples/$name/Dockerfile -t prometheus/golang-example-$name .` can't work well, so I change it and add some details.

2. `prometheus.NewBuildInfoCollector` is Deprecated. Use `collectors.NewBuildInfoCollector` instead.