### PR TITLE
Update /api/v1/status/tsdb to include headStats

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -303,8 +303,6 @@ type RuntimeinfoResult struct {
 	CWD                 string    `json:"CWD"`
 	ReloadConfigSuccess bool      `json:"reloadConfigSuccess"`
 	LastConfigTime      time.Time `json:"lastConfigTime"`
-	ChunkCount          int       `json:"chunkCount"`
-	TimeSeriesCount     int       `json:"timeSeriesCount"`
 	CorruptionCount     int       `json:"corruptionCount"`
 	GoroutineCount      int       `json:"goroutineCount"`
 	GOMAXPROCS          int       `json:"GOMAXPROCS"`
@@ -431,10 +429,20 @@ type queryResult struct {
 
 // TSDBResult contains the result from querying the tsdb endpoint.
 type TSDBResult struct {
-	SeriesCountByMetricName     []Stat `json:"seriesCountByMetricName"`
-	LabelValueCountByLabelName  []Stat `json:"labelValueCountByLabelName"`
-	MemoryInBytesByLabelName    []Stat `json:"memoryInBytesByLabelName"`
-	SeriesCountByLabelValuePair []Stat `json:"seriesCountByLabelValuePair"`
+	HeadStats                   TSDBHeadStats `json:"headStats"`
+	SeriesCountByMetricName     []Stat        `json:"seriesCountByMetricName"`
+	LabelValueCountByLabelName  []Stat        `json:"labelValueCountByLabelName"`
+	MemoryInBytesByLabelName    []Stat        `json:"memoryInBytesByLabelName"`
+	SeriesCountByLabelValuePair []Stat        `json:"seriesCountByLabelValuePair"`
+}
+
+// TSDBHeadStats contains TSDB stats
+type TSDBHeadStats struct {
+	NumSeries     int `json:"numSeries"`
+	NumLabelPairs int `json:"numLabelPairs"`
+	ChunkCount    int `json:"chunkCount"`
+	MinTime       int `json:"minTime"`
+	MaxTime       int `json:"maxTime"`
 }
 
 // Stat models information about statistic value.

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -696,8 +696,6 @@ func TestAPIs(t *testing.T) {
 				"CWD":                 "/prometheus",
 				"reloadConfigSuccess": true,
 				"lastConfigTime":      "2020-05-18T15:52:56Z",
-				"chunkCount":          72692,
-				"timeSeriesCount":     18476,
 				"corruptionCount":     0,
 				"goroutineCount":      217,
 				"GOMAXPROCS":          2,
@@ -710,8 +708,6 @@ func TestAPIs(t *testing.T) {
 				CWD:                 "/prometheus",
 				ReloadConfigSuccess: true,
 				LastConfigTime:      time.Date(2020, 5, 18, 15, 52, 56, 0, time.UTC),
-				ChunkCount:          72692,
-				TimeSeriesCount:     18476,
 				CorruptionCount:     0,
 				GoroutineCount:      217,
 				GOMAXPROCS:          2,
@@ -1145,6 +1141,13 @@ func TestAPIs(t *testing.T) {
 			reqMethod: "GET",
 			reqPath:   "/api/v1/status/tsdb",
 			inRes: map[string]interface{}{
+				"headStats": map[string]interface{}{
+					"numSeries":     18476,
+					"numLabelPairs": 4301,
+					"chunkCount":    72692,
+					"minTime":       1634644800304,
+					"maxTime":       1634650590304,
+				},
 				"seriesCountByMetricName": []interface{}{
 					map[string]interface{}{
 						"name":  "kubelet_http_requests_duration_seconds_bucket",
@@ -1171,6 +1174,13 @@ func TestAPIs(t *testing.T) {
 				},
 			},
 			res: TSDBResult{
+				HeadStats: TSDBHeadStats{
+					NumSeries:     18476,
+					NumLabelPairs: 4301,
+					ChunkCount:    72692,
+					MinTime:       1634644800304,
+					MaxTime:       1634650590304,
+				},
 				SeriesCountByMetricName: []Stat{
 					{
 						Name:  "kubelet_http_requests_duration_seconds_bucket",


### PR DESCRIPTION
Current structs for v1 HTTP API assume that there is chunkCount and timeSeriesCount on /api/v1/status/runtimeinfo, which seems to be gone for at least a few releases. /api/v1/status/tsdb now holds an extra headStats block with chunkCount, numSeries and a few other fields.
Update API models and tests to reflect this change.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>