### PR TITLE
registry: permit the collection of the same metric with multiple timestamps

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -897,6 +898,14 @@ func checkMetricConsistency(
 		h.WriteString(lp.GetValue())
 		h.Write(separatorByteSlice)
 	}
+
+	// If a timestamp if being associated to the metric, use it as part of the checksum.
+	// This will permit the multiple collection of a single metric with different timestamps.
+	// Useful when attempting to generate a dump.
+	if dtoMetric.TimestampMs != nil {
+		h.WriteString(strconv.FormatInt(*dtoMetric.TimestampMs, 10))
+	}
+
 	hSum := h.Sum64()
 	if _, exists := metricHashes[hSum]; exists {
 		return fmt.Errorf(


### PR DESCRIPTION
When a timestamp if being associated to the metric, use it as part of the checksum. This will permit the multiple collection of a single metric with different timestamps. It can be useful when attempting to generate a dump. As an example:

```go
package main

import (
	"net/http"
	"time"

	"github.com/prometheus/client_golang/prometheus"
	"github.com/prometheus/client_golang/prometheus/promhttp"
)

type myCollector struct {
	metric *prometheus.Desc
}

func (c *myCollector) Describe(ch chan<- *prometheus.Desc) {
	ch <- c.metric
}

func (c *myCollector) Collect(ch chan<- prometheus.Metric) {
	t := time.Now().Add(-1 * time.Hour)
	ch <- prometheus.NewMetricWithTimestamp(t, prometheus.MustNewConstMetric(c.metric, prometheus.CounterValue, 123))

	t = time.Now().Add(-2 * time.Hour)
	ch <- prometheus.NewMetricWithTimestamp(t, prometheus.MustNewConstMetric(c.metric, prometheus.CounterValue, 456))
}

func main() {
	collector := &myCollector{
		metric: prometheus.NewDesc(
			"my_metric",
			"This is my metric with custom TS",
			nil,
			nil,
		),
	}

	r := prometheus.NewRegistry()
	r.MustRegister(collector)
	http.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{EnableOpenMetrics: true}))
	http.ListenAndServe(":8000", nil)
}
```

output:

```shell
~$ curl http://localhost:8000/metrics
my_metric 456 1637838943285
my_metric 123 1637842543285
```