### PR TITLE
API: support wal replay status api

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -139,6 +139,7 @@ const (
 	epBuildinfo       = apiPrefix + "/status/buildinfo"
 	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
 	epTSDB            = apiPrefix + "/status/tsdb"
+	epWalReplay       = apiPrefix + "/status/walreplay"
 )
 
 // AlertState models the state of an alert.
@@ -261,6 +262,8 @@ type API interface {
 	Metadata(ctx context.Context, metric string, limit string) (map[string][]Metadata, error)
 	// TSDB returns the cardinality statistics.
 	TSDB(ctx context.Context) (TSDBResult, error)
+	// WalReplay returns the current replay status of the wal.
+	WalReplay(ctx context.Context) (WalReplayStatus, error)
 }
 
 // AlertsResult contains the result from querying the alerts endpoint.
@@ -435,6 +438,13 @@ type TSDBResult struct {
 	LabelValueCountByLabelName  []Stat `json:"labelValueCountByLabelName"`
 	MemoryInBytesByLabelName    []Stat `json:"memoryInBytesByLabelName"`
 	SeriesCountByLabelValuePair []Stat `json:"seriesCountByLabelValuePair"`
+}
+
+// WalReplayStatus represents the wal replay status.
+type WalReplayStatus struct {
+	Min     int `json:"min"`
+	Max     int `json:"max"`
+	Current int `json:"current"`
 }
 
 // Stat models information about statistic value.
@@ -981,6 +991,23 @@ func (h *httpAPI) TSDB(ctx context.Context) (TSDBResult, error) {
 	}
 
 	var res TSDBResult
+	return res, json.Unmarshal(body, &res)
+}
+
+func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
+	u := h.client.URL(epWalReplay, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return WalReplayStatus{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return WalReplayStatus{}, err
+	}
+
+	var res WalReplayStatus
 	return res, json.Unmarshal(body, &res)
 }
 

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -230,6 +230,13 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
+	doWalReply := func() func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
+			v, err := promAPI.WalReplay(context.Background())
+			return v, nil, err
+		}
+	}
+
 	doQueryExemplars := func(query string, startTime time.Time, endTime time.Time) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
 			v, err := promAPI.QueryExemplars(context.Background(), query, startTime, endTime)
@@ -1195,6 +1202,30 @@ func TestAPIs(t *testing.T) {
 						Value: 30000,
 					},
 				},
+			},
+		},
+
+		{
+			do:        doWalReply(),
+			reqMethod: "GET",
+			reqPath:   "/api/v1/status/walreplay",
+			inErr:     fmt.Errorf("some error"),
+			err:       fmt.Errorf("some error"),
+		},
+
+		{
+			do:        doWalReply(),
+			reqMethod: "GET",
+			reqPath:   "/api/v1/status/walreplay",
+			inRes: map[string]interface{}{
+				"min":     2,
+				"max":     5,
+				"current": 40,
+			},
+			res: WalReplayStatus{
+				Min:     2,
+				Max:     5,
+				Current: 40,
 			},
 		},
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Support the WAL Replay Status API https://prometheus.io/docs/prometheus/latest/querying/api/#wal-replay-stats.

From the document, there should be another field `state`:

```
$ curl http://localhost:9090/api/v1/status/walreplay
{
  "status": "success",
  "data": {
    "min": 2,
    "max": 5,
    "current": 40,
    "state": "in progress"
  }
}
```

But I cannot find it from the prometheus code https://github.com/prometheus/prometheus/blob/main/web/api/v1/api.go#L1375.