### PR TITLE
Add support for go 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ workflows:
           name: go-1-16
           go_version: "1.16"
           run_lint: true
-          # Style and unused/missing packages are only checked against
-          # the latest supported Go version.
+      - test:
+          name: go-1-17
+          go_version: "1.17"
+          run_lint: true
           run_style_and_unused: true

--- a/prometheus/collectors/dbstats_collector_go115.go
+++ b/prometheus/collectors/dbstats_collector_go115.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.15
 // +build go1.15
 
 package collectors

--- a/prometheus/collectors/dbstats_collector_pre_go115.go
+++ b/prometheus/collectors/dbstats_collector_pre_go115.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !go1.15
 // +build !go1.15
 
 package collectors

--- a/prometheus/process_collector_other.go
+++ b/prometheus/process_collector_other.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package prometheus

--- a/prometheus/process_collector_test.go
+++ b/prometheus/process_collector_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
 // +build linux
 
 package prometheus


### PR DESCRIPTION
This is a continuation of https://github.com/prometheus/client_golang/pull/911 which did not have any further activities. It fixes the go build lines that go 1.17 now prefers.  