### PR TITLE
Make the Go 1.17 collector thread-safe

### DIFF
--- a/prometheus/collector.go
+++ b/prometheus/collector.go
@@ -118,3 +118,11 @@ func (c *selfCollector) Describe(ch chan<- *Desc) {
 func (c *selfCollector) Collect(ch chan<- Metric) {
 	ch <- c.self
 }
+
+// collectorMetric is a metric that is also a collector.
+// Because of selfCollector, most (if not all) Metrics in
+// this package are also collectors.
+type collectorMetric interface {
+	Metric
+	Collector
+}


### PR DESCRIPTION
Currently the Go 1.17 collector does not protect access to rmSampleBuf,
and Collect may be invoked concurrently. This change adds a mutex around
all uses of rmSampleBuf and pulls out operations that may block on
channels, so concurrent calls to Collect can at least pipeline those two
operations.

Fixes #968 