### PR TITLE
go.mod: Set minimal support version of go to 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,6 @@ workflows:
     jobs:
       # Refer to README.md for the currently supported versions.
       - test:
-          name: go-1-13
-          go_version: "1.13"
-          run_lint: true
-      - test:
-          name: go-1-14
-          go_version: "1.14"
-          run_lint: true
-      - test:
           name: go-1-15
           go_version: "1.15"
           run_lint: true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the [Go](http://golang.org) client library for
 instrumenting application code, and one for creating clients that talk to the
 Prometheus HTTP API.
 
-__This library requires Go1.13 or later.__
+__This library requires Go1.15 or later.__
 
 ## Important note about releases and stability
 

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 	google.golang.org/protobuf v1.26.0
 )
 
-go 1.13
+go 1.15


### PR DESCRIPTION
As requested in https://github.com/prometheus/common/pull/353#discussion_r793113705

