### PR TITLE
Add exemplar support for const histogram

### DIFF
--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -16,12 +16,13 @@ package prometheus_test
 import (
 	"bytes"
 	"fmt"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"math"
 	"net/http"
 	"runtime"
 	"strings"
 	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
@@ -556,12 +557,12 @@ func ExampleNewConstHistogram() {
 	lp := dto.LabelPair{Name: &n, Value: &v}
 	var labelPairs []*dto.LabelPair
 	labelPairs = append(labelPairs, &lp)
-	val := float64(42)
+	vals := []float64{24.0, 42.0, 89.0, 157.0}
 	t, _ := time.Parse("unix", "Mon Jan _2 15:04:05 MST 2006")
 	ts := timestamppb.New(t)
 
 	for i := 0; i < 4; i++ {
-		e := dto.Exemplar{Label: labelPairs, Value: &val, Timestamp: ts}
+		e := dto.Exemplar{Label: labelPairs, Value: &vals[i], Timestamp: ts}
 		exemplars = append(exemplars, &e)
 	}
 
@@ -605,7 +606,7 @@ func ExampleNewConstHistogram() {
 	//         name: "testName"
 	//         value: "testVal"
 	//       >
-	//       value: 42
+	//       value: 24
 	//       timestamp: <
 	//         seconds: -62135596800
 	//       >
@@ -633,7 +634,7 @@ func ExampleNewConstHistogram() {
 	//         name: "testName"
 	//         value: "testVal"
 	//       >
-	//       value: 42
+	//       value: 89
 	//       timestamp: <
 	//         seconds: -62135596800
 	//       >
@@ -647,7 +648,7 @@ func ExampleNewConstHistogram() {
 	//         name: "testName"
 	//         value: "testVal"
 	//       >
-	//       value: 42
+	//       value: 157
 	//       timestamp: <
 	//         seconds: -62135596800
 	//       >

--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -16,6 +16,7 @@ package prometheus_test
 import (
 	"bytes"
 	"fmt"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"math"
 	"net/http"
 	"runtime"
@@ -549,11 +550,27 @@ func ExampleNewConstHistogram() {
 		prometheus.Labels{"owner": "example"},
 	)
 
+	var exemplars []*dto.Exemplar
+	n := "testName"
+	v := "testVal"
+	lp := dto.LabelPair{Name: &n, Value: &v}
+	var labelPairs []*dto.LabelPair
+	labelPairs = append(labelPairs, &lp)
+	val := float64(42)
+	t, _ := time.Parse("unix", "Mon Jan _2 15:04:05 MST 2006")
+	ts := timestamppb.New(t)
+
+	for i := 0; i < 4; i++ {
+		e := dto.Exemplar{Label: labelPairs, Value: &val, Timestamp: ts}
+		exemplars = append(exemplars, &e)
+	}
+
 	// Create a constant histogram from values we got from a 3rd party telemetry system.
-	h := prometheus.MustNewConstHistogram(
+	h := prometheus.MustNewConstHistogramWithExemplar(
 		desc,
 		4711, 403.34,
 		map[float64]uint64{25: 121, 50: 2403, 100: 3221, 200: 4233},
+		exemplars,
 		"200", "get",
 	)
 
@@ -583,18 +600,58 @@ func ExampleNewConstHistogram() {
 	//   bucket: <
 	//     cumulative_count: 121
 	//     upper_bound: 25
+	//     exemplar: <
+	//       label: <
+	//         name: "testName"
+	//         value: "testVal"
+	//       >
+	//       value: 42
+	//       timestamp: <
+	//         seconds: -62135596800
+	//       >
+	//     >
 	//   >
 	//   bucket: <
 	//     cumulative_count: 2403
 	//     upper_bound: 50
+	//     exemplar: <
+	//       label: <
+	//         name: "testName"
+	//         value: "testVal"
+	//       >
+	//       value: 42
+	//       timestamp: <
+	//         seconds: -62135596800
+	//       >
+	//     >
 	//   >
 	//   bucket: <
 	//     cumulative_count: 3221
 	//     upper_bound: 100
+	//     exemplar: <
+	//       label: <
+	//         name: "testName"
+	//         value: "testVal"
+	//       >
+	//       value: 42
+	//       timestamp: <
+	//         seconds: -62135596800
+	//       >
+	//     >
 	//   >
 	//   bucket: <
 	//     cumulative_count: 4233
 	//     upper_bound: 200
+	//     exemplar: <
+	//       label: <
+	//         name: "testName"
+	//         value: "testVal"
+	//       >
+	//       value: 42
+	//       timestamp: <
+	//         seconds: -62135596800
+	//       >
+	//     >
 	//   >
 	// >
 }

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -611,13 +611,6 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 	return nil
 }
 
-func (h *constHistogram) GetExemplars() []*dto.Exemplar {
-	if h != nil {
-		return h.exemplars
-	}
-	return nil
-}
-
 // NewConstHistogram returns a metric representing a Prometheus histogram with
 // fixed values for the count, sum, and bucket counts. As those parameters
 // cannot be changed, the returned value does not implement the Histogram

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -678,14 +678,15 @@ func NewConstHistogramWithExemplar(
 	if err := validateLabelValues(labelValues, len(desc.variableLabels)); err != nil {
 		return nil, err
 	}
-	return &constHistogram{
-		desc:       desc,
-		count:      count,
-		sum:        sum,
-		buckets:    buckets,
-		exemplars:  exemplars,
-		labelPairs: MakeLabelPairs(desc, labelValues),
-	}, nil
+
+	h, err := NewConstHistogram(desc, count, sum, buckets, labelValues...)
+	if err != nil {
+		return nil, err
+	}
+
+	h.(*constHistogram).exemplars = exemplars
+
+	return h, nil
 }
 
 // MustNewConstHistogram is a version of NewConstHistogram that panics where
@@ -698,11 +699,9 @@ func MustNewConstHistogramWithExemplar(
 	exemplars []*dto.Exemplar,
 	labelValues ...string,
 ) Metric {
-	m, err := NewConstHistogramWithExemplar(desc, count, sum, buckets, exemplars, labelValues...)
-	if err != nil {
-		panic(err)
-	}
-	return m
+	h := MustNewConstHistogram(desc, count, sum, buckets, labelValues...)
+	h.(*constHistogram).exemplars = exemplars
+	return h
 }
 
 type buckSort []*dto.Bucket

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -604,7 +604,8 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 
 	if len(h.exemplars) > 0 {
 		r := len(buckets)
-		for i := 0; i < r; i++ {
+		l := len(h.exemplars)
+		for i := 0; i < r && i < l; i++ {
 			bound := sort.SearchFloat64s(bounds, *h.exemplars[i].Value)
 			// Only append the exemplar if it's within the bounds defined in the
 			// buckets.

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -584,7 +584,7 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 	his := &dto.Histogram{}
 	// h.buckets, buckets and bounds are all the same length
 	buckets := make([]*dto.Bucket, 0, len(h.buckets))
-	bounds := make([]float64, 0)
+	bounds := make([]float64, 0, len(h.buckets))
 
 	his.SampleCount = proto.Uint64(h.count)
 	his.SampleSum = proto.Float64(h.sum)
@@ -599,8 +599,8 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 	// make sure that both bounds and buckets have the same ordering
 	if len(buckets) > 0 {
 		sort.Sort(buckSort(buckets))
+		sort.Float64s(bounds)
 	}
-	sort.Float64s(bounds)
 
 	if len(h.exemplars) > 0 {
 		r := len(buckets)

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -424,24 +424,24 @@ func TestHistogramExemplar(t *testing.T) {
 	}
 	expectedExemplars := []*dto.Exemplar{
 		nil,
-		&dto.Exemplar{
+		{
 			Label: []*dto.LabelPair{
-				&dto.LabelPair{Name: proto.String("id"), Value: proto.String("2")},
+				{Name: proto.String("id"), Value: proto.String("2")},
 			},
 			Value:     proto.Float64(1.6),
 			Timestamp: ts,
 		},
 		nil,
-		&dto.Exemplar{
+		{
 			Label: []*dto.LabelPair{
-				&dto.LabelPair{Name: proto.String("id"), Value: proto.String("3")},
+				{Name: proto.String("id"), Value: proto.String("3")},
 			},
 			Value:     proto.Float64(4),
 			Timestamp: ts,
 		},
-		&dto.Exemplar{
+		{
 			Label: []*dto.LabelPair{
-				&dto.LabelPair{Name: proto.String("id"), Value: proto.String("4")},
+				{Name: proto.String("id"), Value: proto.String("4")},
 			},
 			Value:     proto.Float64(4.5),
 			Timestamp: ts,

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -13,7 +13,12 @@
 
 package prometheus
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	dto "github.com/prometheus/client_model/go"
+)
 
 func TestBuildFQName(t *testing.T) {
 	scenarios := []struct{ namespace, subsystem, name, result string }{
@@ -32,4 +37,42 @@ func TestBuildFQName(t *testing.T) {
 			t.Errorf("%d. want %s, got %s", i, want, got)
 		}
 	}
+}
+
+func TestWithExemplarsMetric(t *testing.T) {
+	t.Run("histogram", func(t *testing.T) {
+		// Create a constant histogram from values we got from a 3rd party telemetry system.
+		h := MustNewConstHistogram(
+			NewDesc("http_request_duration_seconds", "A histogram of the HTTP request durations.", nil, nil),
+			4711, 403.34,
+			map[float64]uint64{25: 121, 50: 2403, 100: 3221, 200: 4233},
+		)
+
+		m := &withExemplarsMetric{Metric: h, exemplars: []*dto.Exemplar{
+			{Value: proto.Float64(24.0)},
+			{Value: proto.Float64(25.1)},
+			{Value: proto.Float64(42.0)},
+			{Value: proto.Float64(89.0)},
+			{Value: proto.Float64(100.0)},
+			{Value: proto.Float64(157.0)},
+		}}
+		metric := dto.Metric{}
+		if err := m.Write(&metric); err != nil {
+			t.Fatal(err)
+		}
+		if want, got := 4, len(metric.GetHistogram().Bucket); want != got {
+			t.Errorf("want %v, got %v", want, got)
+		}
+
+		expectedExemplarVals := []float64{24.0, 42.0, 100.0, 157.0}
+		for i, b := range metric.GetHistogram().Bucket {
+			if b.Exemplar == nil {
+				t.Errorf("Expected exemplar for bucket %v, got nil", i)
+			}
+			if want, got := expectedExemplarVals[i], *metric.GetHistogram().Bucket[i].Exemplar.Value; want != got {
+				t.Errorf("%v: want %v, got %v", i, want, got)
+			}
+		}
+	})
+
 }


### PR DESCRIPTION
Relates to #868. We're looking to add support for exemplars on OpenTelemetry's collector contrib's `prometheusexporter` which uses the `constHistogram` internally. This change solves the case where metrics coming from another system (in our case the otel collector) need to be converted to the Prometheus format and retain their exemplars. Right now we've only implemented exemplars on the const histogram, I'm more than happy to do all the necessary adjustments.