### PR TITLE
Fix deprecated `NewBuildInfoCollector` API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 # This Dockerfile builds an image for a client_golang example.
 #
 # Use as (from the root for the client_golang repository):
-#    docker build -f examples/$name/Dockerfile -t prometheus/golang-example-$name .
+#    docker build -f Dockerfile -t prometheus/golang-example .
+
+# Run as
+#    docker run -P prometheus/golang-example /random
+# or
+#    docker run -P prometheus/golang-example /simple
+
+# Test as
+#    curl $ip:$port/metrics
 
 # Builder image, where we build the example.
 FROM golang:1 AS builder

--- a/examples/random/main.go
+++ b/examples/random/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -67,7 +68,7 @@ func main() {
 	prometheus.MustRegister(rpcDurations)
 	prometheus.MustRegister(rpcDurationsHistogram)
 	// Add Go module build info.
-	prometheus.MustRegister(prometheus.NewBuildInfoCollector())
+	prometheus.MustRegister(collectors.NewBuildInfoCollector())
 
 	start := time.Now()
 


### PR DESCRIPTION
1. Update `examples/random/main.go`: `prometheus.NewBuildInfoCollector` is deprecated. Use `collectors.NewBuildInfoCollector` instead.