### PR TITLE
Implement deletion based on partially matching labels

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -80,7 +80,7 @@ func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 	return m.metricMap.deleteByHashWithLabelValues(h, lvs, m.curry)
 }
 
-// DeletePartialMatchLabelValues removes the metric where the variable labels
+// DeletePartialMatchLabelValues deletes all metrics where the variable labels
 // contain all of the values passed. The order of the passed values does not matter.
 // It returns the number of metrics deleted.
 
@@ -109,7 +109,7 @@ func (m *MetricVec) Delete(labels Labels) bool {
 	return m.metricMap.deleteByHashWithLabels(h, labels, m.curry)
 }
 
-// DeletePartialMatch deletes the metric where the variable labels contains all of those
+// DeletePartialMatch deletes all metrics where the variable labels contain all of those
 // passed in as labels. The order of the labels does not matter.
 // It returns the number of metrics deleted.
 

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -82,11 +82,11 @@ func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 
 // DeletePartialMatchLabelValues removes the metric where the variable labels
 // contain all of the values passed. The order of the passed values does not matter.
-// It returns true if a metric was deleted.
+// It returns the number of metrics deleted.
 
 // This method deletes a metric if the given value is present for any label.
 // To delete a metric based on a partial match for a particular label, use DeletePartialMatch().
-func (m *MetricVec) DeletePartialMatchLabelValues(lvs ...string) bool {
+func (m *MetricVec) DeletePartialMatchLabelValues(lvs ...string) int {
 	return m.metricMap.deleteByLabelValues(lvs)
 }
 
@@ -111,11 +111,11 @@ func (m *MetricVec) Delete(labels Labels) bool {
 
 // DeletePartialMatch deletes the metric where the variable labels contains all of those
 // passed in as labels. The order of the labels does not matter.
-// It returns true if a metric was deleted.
+// It returns the number of metrics deleted.
 
 // This method deletes a metric if the given label: value pair is found in that metric.
 // To delete a metric if a particular value is found associated with any label, use DeletePartialMatchLabelValues().
-func (m *MetricVec) DeletePartialMatch(labels Labels) bool {
+func (m *MetricVec) DeletePartialMatch(labels Labels) int {
 	return m.metricMap.deleteByLabels(labels)
 }
 
@@ -374,9 +374,11 @@ func (m *metricMap) deleteByHashWithLabelValues(
 }
 
 // deleteByLabelValues deletes a metric if the given values (lvs) are present in the metric.
-func (m *metricMap) deleteByLabelValues(lvs []string) bool {
+func (m *metricMap) deleteByLabelValues(lvs []string) int {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
+
+	var numDeleted int
 
 	for h, metrics := range m.metrics {
 		i := findMetricWithPartialLabelValues(metrics, lvs)
@@ -385,10 +387,10 @@ func (m *metricMap) deleteByLabelValues(lvs []string) bool {
 			continue
 		}
 		delete(m.metrics, h)
-		return true
+		numDeleted++
 	}
 
-	return false
+	return numDeleted
 }
 
 // findMetricWithPartialLabelValues returns the index of the matching metric or
@@ -445,9 +447,11 @@ func (m *metricMap) deleteByHashWithLabels(
 }
 
 // deleteByLabels deletes a metric if the given labels are present in the metric.
-func (m *metricMap) deleteByLabels(labels Labels) bool {
+func (m *metricMap) deleteByLabels(labels Labels) int {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
+
+	var numDeleted int
 
 	for h, metrics := range m.metrics {
 		i := findMetricWithPartialLabels(m.desc, metrics, labels)
@@ -456,10 +460,10 @@ func (m *metricMap) deleteByLabels(labels Labels) bool {
 			continue
 		}
 		delete(m.metrics, h)
-		return true
+		numDeleted++
 	}
 
-	return false
+	return numDeleted
 }
 
 // findMetricWithPartialLabel returns the index of the matching metric or

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -80,6 +80,12 @@ func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 	return m.metricMap.deleteByHashWithLabelValues(h, lvs, m.curry)
 }
 
+// DeletePartialMatchLabelValues removes the metric where the variable labels
+// contain all of the values passed. The order of the passed values does not matter.
+// It returns true if a metric was deleted.
+
+// This method deletes a metric if the given value is present for any label.
+// To delete a metric based on a partial match for a particular label, use DeletePartialMatch().
 func (m *MetricVec) DeletePartialMatchLabelValues(lvs ...string) bool {
 	return m.metricMap.deleteByLabelValues(lvs)
 }
@@ -103,6 +109,12 @@ func (m *MetricVec) Delete(labels Labels) bool {
 	return m.metricMap.deleteByHashWithLabels(h, labels, m.curry)
 }
 
+// DeletePartialMatch deletes the metric where the variable labels contains all of those
+// passed in as labels. The order of the labels does not matter.
+// It returns true if a metric was deleted.
+
+// This method deletes a metric if the given label: value pair is found in that metric.
+// To delete a metric if a particular value is found associated with any label, use DeletePartialMatchLabelValues().
 func (m *MetricVec) DeletePartialMatch(labels Labels) bool {
 	return m.metricMap.deleteByLabels(labels)
 }
@@ -361,6 +373,7 @@ func (m *metricMap) deleteByHashWithLabelValues(
 	return true
 }
 
+// deleteByLabelValues deletes a metric if the given values (lvs) are present in the metric.
 func (m *metricMap) deleteByLabelValues(lvs []string) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
@@ -431,6 +444,7 @@ func (m *metricMap) deleteByHashWithLabels(
 	return true
 }
 
+// deleteByLabels deletes a metric if the given labels are present in the metric.
 func (m *metricMap) deleteByLabels(labels Labels) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -102,6 +102,9 @@ func (m *MetricVec) Delete(labels Labels) bool {
 // DeletePartialMatch deletes all metrics where the variable labels contain all of those
 // passed in as labels. The order of the labels does not matter.
 // It returns the number of metrics deleted.
+//
+// Note that curried labels will never be matched if deleting from the curried vector.
+// To match curried labels with DeletePartialMatch, it must be called on the base vector.
 func (m *MetricVec) DeletePartialMatch(labels Labels) int {
 	return m.metricMap.deleteByLabels(labels, m.curry)
 }

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -453,14 +453,14 @@ func matchPartialLabels(desc *Desc, values []string, labels Labels, curry []curr
 		varLabelIndex, validLabel := indexOf(l, desc.variableLabels)
 		if validLabel {
 			// Check the value of that label against the target value.
-			if valueOrCurriedValue(varLabelIndex, values, curry) == v {
-				continue
-			}
-
-			// if values[varLabelIndex] == v {
+			// if valueOrCurriedValue(varLabelIndex, values, curry) == v {
 			// 	continue
-
 			// }
+
+			if values[varLabelIndex] == v {
+				continue
+
+			}
 		}
 		return false
 	}

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -441,8 +441,8 @@ func indexOf(target string, items []string) (int, bool) {
 func valueMatchesVariableOrCurriedValue(targetValue string, index int, values []string, curry []curriedLabelValue) (bool, bool) {
 	for _, curriedValue := range curry {
 		if curriedValue.index == index {
-			// This label was curried. See if the value in this metric matches the curry value as well as our target.
-			return curriedValue.value == targetValue && values[index] == targetValue, true
+			// This label was curried. See if the curried value matches our target.
+			return curriedValue.value == targetValue, true
 		}
 	}
 	// This label was not curried. See if the current value matches our target label.

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -81,7 +81,7 @@ func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 }
 
 func (m *MetricVec) DeletePartialMatchLabelValues(lvs ...string) bool {
-	return m.metricMap.deleteByLabelValues(lvs, m.curry)
+	return m.metricMap.deleteByLabelValues(lvs)
 }
 
 // Delete deletes the metric where the variable labels are the same as those
@@ -104,7 +104,7 @@ func (m *MetricVec) Delete(labels Labels) bool {
 }
 
 func (m *MetricVec) DeletePartialMatch(labels Labels) bool {
-	return m.metricMap.deleteByLabels(labels, m.curry)
+	return m.metricMap.deleteByLabels(labels)
 }
 
 // Without explicit forwarding of Describe, Collect, Reset, those methods won't
@@ -361,14 +361,12 @@ func (m *metricMap) deleteByHashWithLabelValues(
 	return true
 }
 
-func (m *metricMap) deleteByLabelValues(
-	lvs []string, curry []curriedLabelValue,
-) bool {
+func (m *metricMap) deleteByLabelValues(lvs []string) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
 	for h, metrics := range m.metrics {
-		i := findMetricWithPartialLabelValues(metrics, lvs, curry)
+		i := findMetricWithPartialLabelValues(metrics, lvs)
 		if i >= len(metrics) {
 			// Didn't find matching label values in this metric slice.
 			continue
@@ -383,58 +381,24 @@ func (m *metricMap) deleteByLabelValues(
 // findMetricWithPartialLabelValues returns the index of the matching metric or
 // len(metrics) if not found.
 func findMetricWithPartialLabelValues(
-	metrics []metricWithLabelValues, lvs []string, curry []curriedLabelValue,
+	metrics []metricWithLabelValues, lvs []string,
 ) int {
 	for i, metric := range metrics {
-		if matchPartialLabelValues(metric.values, lvs, curry) {
+		if matchPartialLabelValues(metric.values, lvs) {
 			return i
 		}
 	}
 	return len(metrics)
 }
 
-func matchPartialLabelValues(values []string, lvs []string, curry []curriedLabelValue) bool {
+// matchPartialLabelValues searches the current metric values and returns whether all of the target values are present.
+func matchPartialLabelValues(values []string, lvs []string) bool {
 	for _, v := range lvs {
 		// Check if the target value exists in our metrics and get the index.
-		if _, validValue := indexOfLabel(v, values); validValue {
+		if _, validValue := indexOf(v, values); validValue {
 			continue
 		}
 		return false
-	}
-	return true
-}
-
-func xmatchPartialLabelValues(values []string, lvs []string, curry []curriedLabelValue) bool {
-	// if len(values) != len(lvs)+len(curry) {
-	// 	return false
-	// }
-
-	for i, v := range values {
-		fmt.Printf("%d, %v", i, v)
-		// See if the value was previously curried
-		for _, vCurry := range curry {
-			if vCurry.value == v {
-				continue
-			}
-		}
-		// for _, vMetric := range values {
-		// 	if vMetric
-		// }
-	}
-
-	var iLVs, iCurry int
-	for i, v := range values {
-		if iCurry < len(curry) && curry[iCurry].index == i {
-			if v != curry[iCurry].value {
-				return false
-			}
-			iCurry++
-			continue
-		}
-		if v != lvs[iLVs] {
-			return false
-		}
-		iLVs++
 	}
 	return true
 }
@@ -466,15 +430,15 @@ func (m *metricMap) deleteByHashWithLabels(
 	}
 	return true
 }
-func (m *metricMap) deleteByLabels(
-	labels Labels, curry []curriedLabelValue,
-) bool {
+
+func (m *metricMap) deleteByLabels(labels Labels) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
 	for h, metrics := range m.metrics {
-		i := findMetricWithPartialLabels(m.desc, metrics, labels, curry)
+		i := findMetricWithPartialLabels(m.desc, metrics, labels)
 		if i >= len(metrics) {
+			// Didn't find matching labels in this metric slice.
 			continue
 		}
 		delete(m.metrics, h)
@@ -484,47 +448,35 @@ func (m *metricMap) deleteByLabels(
 	return false
 }
 
+// findMetricWithPartialLabel returns the index of the matching metric or
+// len(metrics) if not found.
 func findMetricWithPartialLabels(
-	desc *Desc, metrics []metricWithLabelValues, labels Labels, curry []curriedLabelValue,
+	desc *Desc, metrics []metricWithLabelValues, labels Labels,
 ) int {
 	for i, metric := range metrics {
-		if matchPartialLabels(desc, metric.values, labels, curry) {
+		if matchPartialLabels(desc, metric.values, labels) {
 			return i
 		}
 	}
 	return len(metrics)
 }
 
-// TODO: This is untested and might not work
-func getCurriedLabelValue(desc *Desc, values []string, targetLabel string, curry []curriedLabelValue) (string, bool) {
-	iCurry := 0
-	for i, k := range desc.variableLabels {
-		if iCurry < len(curry) && curry[iCurry].index == i {
-			if k == targetLabel {
-				return curry[iCurry].value, true
-			}
-			iCurry++
-			continue
-		}
-	}
-	return "", false
-}
-
-// indexOfLabel searches the given list of labels for the target string and returns
-// the index or len(labels) as well as a boolean whether the search succeeded.
-func indexOfLabel(target string, labels []string) (int, bool) {
-	for i, l := range labels {
+// indexOf searches the given slice of strings for the target string and returns
+// the index or len(items) as well as a boolean whether the search succeeded.
+func indexOf(target string, items []string) (int, bool) {
+	for i, l := range items {
 		if l == target {
 			return i, true
 		}
 	}
-	return len(labels), false
+	return len(items), false
 }
 
-func matchPartialLabels(desc *Desc, values []string, labels Labels, curry []curriedLabelValue) bool {
+// matchPartialLabels searches the current metric and returns whether all of the target label:value pairs are present.
+func matchPartialLabels(desc *Desc, values []string, labels Labels) bool {
 	for l, v := range labels {
 		// Check if the target label exists in our metrics and get the index.
-		varLabelIndex, validLabel := indexOfLabel(l, desc.variableLabels)
+		varLabelIndex, validLabel := indexOf(l, desc.variableLabels)
 		if validLabel {
 			// Check the value of that label against the target value.
 			if values[varLabelIndex] == v {
@@ -535,69 +487,6 @@ func matchPartialLabels(desc *Desc, values []string, labels Labels, curry []curr
 		return false
 	}
 	return true
-}
-
-func xmatchPartialLabels(desc *Desc, values []string, labels Labels, curry []curriedLabelValue) bool {
-
-	// for label, value := range labels {
-	// 	// Check if the label was previously curried, and check the value if so.
-	// 	curriedValue, ok := getCurriedLabelValue(desc, values, label, curry)
-	// 	if ok {
-	// 		if curriedValue == value {
-	// 			continue
-	// 		}
-	// 	}
-
-	// 	// See if the target label is among the remaining labels in this metric, and get the index if so.
-
-	// }
-
-	iCurry := 0
-	for i, k := range desc.variableLabels {
-		// Check if the label was previously curried, and check the value if so.
-
-		if iCurry < len(curry) && curry[iCurry].index == i {
-			if values[i] != curry[iCurry].value {
-				return false
-			}
-			iCurry++
-			continue
-		}
-		if targetValue, ok := labels[k]; ok {
-			if values[i] != targetValue {
-				return false
-			}
-			continue
-		}
-
-		// }
-		// Check the value at the index. Abort if it doesn't match our value. Continue if it does.
-
-		// See if the target label is among the remaining labels in this metric, and get the index if so.
-
-		// Check the value at the index. Abort if it doesn't match our value. Continue if it does.
-
-		// If we haven't continued, the target label or the target value for a label did not exist. Abort.
-		return false
-	}
-
-	// If we get through all the labels, we've got a match.
-	return true
-
-	// iCurry := 0
-	// for i, k := range desc.variableLabels {
-	// 	if iCurry < len(curry) && curry[iCurry].index == i {
-	// 		if values[i] != curry[iCurry].value {
-	// 			return false
-	// 		}
-	// 		iCurry++
-	// 		continue
-	// 	}
-	// 	if values[i] != labels[k] {
-	// 		return false
-	// 	}
-	// }
-	// return true
 }
 
 // getOrCreateMetricWithLabelValues retrieves the metric by hash and label value

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -102,9 +102,6 @@ func (m *MetricVec) Delete(labels Labels) bool {
 // DeletePartialMatch deletes all metrics where the variable labels contain all of those
 // passed in as labels. The order of the labels does not matter.
 // It returns the number of metrics deleted.
-
-// This method deletes a metric if the given label: value pair is found in that metric.
-// To delete a metric if a particular value is found associated with any label, use DeletePartialMatchLabelValues().
 func (m *MetricVec) DeletePartialMatch(labels Labels) int {
 	return m.metricMap.deleteByLabels(labels, m.curry)
 }
@@ -435,17 +432,6 @@ func indexOf(target string, items []string) (int, bool) {
 	return len(items), false
 }
 
-// valueOrCurriedValue determines if a value was previously curried,
-// and returns either the "base" value or the curried value accordingly.
-func valueOrCurriedValue(index int, values []string, curry []curriedLabelValue) string {
-	for _, curriedValue := range curry {
-		if curriedValue.index == index {
-			return curriedValue.value
-		}
-	}
-	return values[index]
-}
-
 // matchPartialLabels searches the current metric and returns whether all of the target label:value pairs are present.
 func matchPartialLabels(desc *Desc, values []string, labels Labels, curry []curriedLabelValue) bool {
 	for l, v := range labels {
@@ -453,10 +439,6 @@ func matchPartialLabels(desc *Desc, values []string, labels Labels, curry []curr
 		varLabelIndex, validLabel := indexOf(l, desc.variableLabels)
 		if validLabel {
 			// Check the value of that label against the target value.
-			// if valueOrCurriedValue(varLabelIndex, values, curry) == v {
-			// 	continue
-			// }
-
 			if values[varLabelIndex] == v {
 				continue
 

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -126,30 +126,25 @@ func testDeleteLabelValues(t *testing.T, vec *GaugeVec) {
 }
 
 func TestDeletePartialMatch(t *testing.T) {
-	vec := NewGaugeVec(
+	baseVec := NewGaugeVec(
 		GaugeOpts{
 			Name: "test",
 			Help: "helpless",
 		},
 		[]string{"l1", "l2", "l3"},
 	)
-	testDeletePartialMatch(t, vec)
-}
-
-func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 
 	assertNoMetric := func(t *testing.T) {
-		if n := len(vec.metricMap.metrics); n != 0 {
+		if n := len(baseVec.metricMap.metrics); n != 0 {
 			t.Error("expected no metrics, got", n)
 		}
 	}
 
 	// No metric value is set.
-	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1", "l2": "v2"}), 0; got != want {
+	if got, want := baseVec.DeletePartialMatch(Labels{"l1": "v1", "l2": "v2"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	baseVec := vec
 	baseVec.With(Labels{"l1": "baseValue1", "l2": "baseValue2", "l3": "baseValue3"}).Inc()
 	baseVec.With(Labels{"l1": "multiDeleteV1", "l2": "diff1BaseValue2", "l3": "v3"}).(Gauge).Set(42)
 	baseVec.With(Labels{"l1": "multiDeleteV1", "l2": "diff2BaseValue2", "l3": "v3"}).(Gauge).Set(84)
@@ -170,14 +165,12 @@ func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// TODO: Error
 	// Try to delete from a curried vector based on labels which were curried.
 	// This operation succeeds when run against the base vector below.
 	if got, want := curriedVec.DeletePartialMatch(Labels{"l2": "curriedValue2"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// TODO: Error
 	// Try to delete from a curried vector based on labels which were curried,
 	// but the value actually exists in the base vector.
 	if got, want := curriedVec.DeletePartialMatch(Labels{"l2": "baseValue2"}), 0; got != want {
@@ -200,7 +193,7 @@ func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 	}
 
 	// Delete from the base vector based on values which were curried.
-	// This operation fails when run against a curried vector below.
+	// This operation fails when run against a curried vector above.
 	if got, want := baseVec.DeletePartialMatch(Labels{"l2": "curriedValue2"}), 1; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -150,14 +150,14 @@ func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Delete valid pair l1: v1.
+	// Delete with valid pair l1: v1.
 	if got, want := c1.DeletePartialMatch(Labels{"l1": "v1"}), true; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	c2 := vec.MustCurryWith(Labels{"l2": "l2CurriedValue"})
 	c2.With(Labels{"l1": "11"}).Inc()
-	// Delete valid curried pair l2: l2CurriedValue.
+	// Delete with valid curried pair l2: l2CurriedValue.
 	if got, want := c2.DeletePartialMatch(Labels{"l2": "l2CurriedValue"}), true; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -167,26 +167,6 @@ func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1"}), true; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-
-	// vec.With(Labels{"l1": "v1", "l2": "v3"}).(Gauge).Set(42) // Add junk data for collision.
-	// if got, want := vec.DeleteLabelValues("v1", "v2"), true; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-	// if got, want := vec.DeleteLabelValues("v1", "v2"), false; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-	// if got, want := vec.DeleteLabelValues("v1", "v3"), true; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-
-	// vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
-	// // Delete out of order.
-	// if got, want := vec.DeleteLabelValues("v2", "v1"), false; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-	// if got, want := vec.DeleteLabelValues("v1"), false; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
 }
 
 func TestDeletePartialMatchLabelValues(t *testing.T) {
@@ -201,34 +181,35 @@ func TestDeletePartialMatchLabelValues(t *testing.T) {
 }
 
 func testDeletePartialMatchLabelValues(t *testing.T, vec *GaugeVec) {
+	// No metric value is set.
 	if got, want := vec.DeletePartialMatchLabelValues("v1", "v2"), false; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
+	// Try to delete with a single valid value.
 	vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
 	if got, want := vec.DeletePartialMatchLabelValues("v1"), true; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// vec.With(Labels{"l1": "v1", "l2": "v3"}).(Gauge).Set(42) // Add junk data for collision.
-	// if got, want := vec.DeleteLabelValues("v1", "v2"), true; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-	// if got, want := vec.DeleteLabelValues("v1", "v2"), false; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-	// if got, want := vec.DeleteLabelValues("v1", "v3"), true; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
+	// Try to delete with partially invalid values.
+	vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
+	if got, want := vec.DeletePartialMatchLabelValues("v1", "xv2"), false; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
 
-	// vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
-	// // Delete out of order.
-	// if got, want := vec.DeleteLabelValues("v2", "v1"), false; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
-	// if got, want := vec.DeleteLabelValues("v1"), false; got != want {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
+	c1 := vec.MustCurryWith(Labels{"l1": "cv1"})
+	c1.WithLabelValues("2").Inc()
+
+	// Try to delete with nonexistent value z1.
+	if got, want := c1.DeletePartialMatchLabelValues("z1"), false; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// Delete with valid curried value cv1.
+	if got, want := c1.DeletePartialMatchLabelValues("cv1"), true; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
 }
 
 func TestMetricVec(t *testing.T) {

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -194,6 +194,11 @@ func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
+	// Try to delete with a label value from before currying.
+	if got, want := c2.DeletePartialMatch(Labels{"l2": "v3"}), 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
 	// Same labels, value matches.
 	vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
 	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1"}), 1; got != want {

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -182,10 +182,6 @@ func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
 	if got, want := c2.DeletePartialMatch(Labels{"l2": "l2CurriedValue"}), 1; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-	// Try to delete with a label value from before currying.
-	if got, want := c2.DeletePartialMatch(Labels{"l2": "v3"}), 0; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
 
 	c3.With(Labels{"l1": "11"}).Inc()
 

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -131,79 +131,92 @@ func TestDeletePartialMatch(t *testing.T) {
 			Name: "test",
 			Help: "helpless",
 		},
-		[]string{"l1", "l2"},
+		[]string{"l1", "l2", "l3"},
 	)
 	testDeletePartialMatch(t, vec)
 }
 
 func testDeletePartialMatch(t *testing.T, vec *GaugeVec) {
+
+	assertNoMetric := func(t *testing.T) {
+		if n := len(vec.metricMap.metrics); n != 0 {
+			t.Error("expected no metrics, got", n)
+		}
+	}
+
 	// No metric value is set.
 	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1", "l2": "v2"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	c1 := vec.MustCurryWith(Labels{"l1": "v1"})
-	c1.WithLabelValues("2").Inc()
+	baseVec := vec
+	baseVec.With(Labels{"l1": "baseValue1", "l2": "baseValue2", "l3": "baseValue3"}).Inc()
+	baseVec.With(Labels{"l1": "multiDeleteV1", "l2": "diff1BaseValue2", "l3": "v3"}).(Gauge).Set(42)
+	baseVec.With(Labels{"l1": "multiDeleteV1", "l2": "diff2BaseValue2", "l3": "v3"}).(Gauge).Set(84)
+	baseVec.With(Labels{"l1": "multiDeleteV1", "l2": "diff3BaseValue2", "l3": "v3"}).(Gauge).Set(168)
 
-	// Try to delete nonexistent label lx with existent value v1.
-	if got, want := c1.DeletePartialMatch(Labels{"lx": "v1"}), 0; got != want {
+	curriedVec := baseVec.MustCurryWith(Labels{"l2": "curriedValue2"})
+	curriedVec.WithLabelValues("curriedValue1", "curriedValue3").Inc()
+	curriedVec.WithLabelValues("curriedValue1", "differentCurriedValue3").Inc()
+	curriedVec.WithLabelValues("differentCurriedValue1", "differentCurriedValue3").Inc()
+
+	// Try to delete nonexistent label with existent value from curried vector.
+	if got, want := curriedVec.DeletePartialMatch(Labels{"lx": "curriedValue1"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Delete with valid pair l1: v1.
-	if got, want := c1.DeletePartialMatch(Labels{"l1": "v1"}), 1; got != want {
+	// Try to delete valid label with nonexistent value from curried vector.
+	if got, want := curriedVec.DeletePartialMatch(Labels{"l1": "badValue1"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Try to delete with partially invalid labels.
-	vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
-	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1", "l2": "xv2"}), 0; got != want {
+	// TODO: Error
+	// Try to delete from a curried vector based on labels which were curried.
+	// This operation succeeds when run against the base vector below.
+	if got, want := curriedVec.DeletePartialMatch(Labels{"l2": "curriedValue2"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Try to delete with a single valid label which matches multiple metrics.
-	vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
-	vec.With(Labels{"l1": "v1", "l2": "vv22"}).(Gauge).Set(84)
-	c3 := vec.MustCurryWith(Labels{"l2": "l2C3CurriedValue"}) // Used below
-	vec.With(Labels{"l1": "v3", "l2": "v3"}).(Gauge).Set(168)
-	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1"}), 2; got != want {
+	// TODO: Error
+	// Try to delete from a curried vector based on labels which were curried,
+	// but the value actually exists in the base vector.
+	if got, want := curriedVec.DeletePartialMatch(Labels{"l2": "baseValue2"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Try to delete a value which shouldn't be in our base vector (only the curried one c3).
-	if got, want := vec.DeletePartialMatch(Labels{"l2": "l2C3CurriedValue"}), 0; got != want {
+	// Delete multiple matching metrics from a curried vector based on partial values.
+	if got, want := curriedVec.DeletePartialMatch(Labels{"l1": "curriedValue1"}), 2; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	c2 := vec.MustCurryWith(Labels{"l2": "l2CurriedValue"})
-	c2.With(Labels{"l1": "11"}).Inc()
-
-	// Delete with valid curried pair l2: l2CurriedValue.
-	if got, want := c2.DeletePartialMatch(Labels{"l2": "l2CurriedValue"}), 1; got != want {
+	// Try to delete nonexistent label with existent value from base vector.
+	if got, want := baseVec.DeletePartialMatch(Labels{"lx": "curriedValue1"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	c3.With(Labels{"l1": "11"}).Inc()
-
-	// Try to delete with invalid curried pair l1: v1.
-	if got, want := c3.DeletePartialMatch(Labels{"l1": "v1"}), 0; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	// Delete valid curried pair l2: l2C3CurriedValue.
-	if got, want := c3.DeletePartialMatch(Labels{"l2": "l2C3CurriedValue"}), 1; got != want {
+	// Try to delete partially invalid labels from base vector.
+	if got, want := baseVec.DeletePartialMatch(Labels{"l1": "baseValue1", "l2": "badValue2"}), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Try to delete with a label value from before currying.
-	if got, want := c2.DeletePartialMatch(Labels{"l2": "v3"}), 0; got != want {
+	// Delete from the base vector based on values which were curried.
+	// This operation fails when run against a curried vector below.
+	if got, want := baseVec.DeletePartialMatch(Labels{"l2": "curriedValue2"}), 1; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	// Same labels, value matches.
-	vec.With(Labels{"l1": "v1", "l2": "v2"}).(Gauge).Set(42)
-	if got, want := vec.DeletePartialMatch(Labels{"l1": "v1"}), 1; got != want {
+	// Delete multiple metrics from the base vector based on a single valid label.
+	if got, want := baseVec.DeletePartialMatch(Labels{"l1": "multiDeleteV1"}), 3; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	// Delete from the base vector based on values which were not curried.
+	if got, want := baseVec.DeletePartialMatch(Labels{"l3": "baseValue3"}), 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// All metrics should have been deleted now.
+	assertNoMetric(t)
 }
 
 func TestMetricVec(t *testing.T) {


### PR DESCRIPTION
Towards https://github.com/prometheus/client_golang/issues/834. This is an approach which I think feels user-friendly and accomplishes what folks were asking for. Open to suggestions of course, I'm new here.

This PR introduces a new deletion method:
- `DeletePartialMatch(labels Labels)` - deletes a metric if all of the given labels and associated values are present in that metric.

It returns the number of metrics which were deleted.