### PR TITLE
Make Query requests idempotent

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1138,8 +1138,13 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 		return nil, nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// Underlying `net.http` library automatically retries` idempotent requests when connectivity issues are hit.
-	// POST requests are not considered idempotent by default, so we need to explicitly mark them as such.
+	// Following comment originates from https://pkg.go.dev/net/http#Transport
+	// Transport only retries a request upon encountering a network error if the request is
+	// idempotent and either has no body or has its Request.GetBody defined. HTTP requests
+	// are considered idempotent if they have HTTP methods GET, HEAD, OPTIONS, or TRACE; or
+	// if their Header map contains an "Idempotency-Key" or "X-Idempotency-Key" entry. If the
+	// idempotency key value is a zero-length slice, the request is treated as idempotent but
+	// the header is not sent on the wire.
 	req.Header["Idempotency-Key"] = nil
 
 	resp, body, warnings, err := h.Do(ctx, req)

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1140,7 +1140,7 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	// Underlying `net.http` library automatically retries` idempotent requests when connectivity issues are hit.
 	// POST requests are not considered idempotent by default, so we need to explicitly mark them as such.
-	req.Header.Set("Idempotency-Key", "TODO")
+	req.Header["Idempotency-Key"] = nil
 
 	resp, body, warnings, err := h.Do(ctx, req)
 	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1138,6 +1138,9 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 		return nil, nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Underlying `net.http` library automatically retries` idempotent requests when connectivity issues are hit.
+	// POST requests are not considered idempotent by default, so we need to explicitly mark them as such.
+	req.Header.Set("Idempotency-Key", "TODO")
 
 	resp, body, warnings, err := h.Do(ctx, req)
 	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {


### PR DESCRIPTION
Address #1020.

Signed-off-by: Tomáš Dohnálek <dohnto@gmail.com>

This was challenging to test. I used [toxiproxy](https://github.com/Shopify/toxiproxy) to inject connectivity issues. I build a [custom Toxic](https://github.com/Shopify/toxiproxy/blob/master/CREATING_TOXICS.md) which counts HTTP requests a closes every even request.

Without the header set, the conversation was following and my range query ended with
> Error querying Prometheus: Post "http://localhost:8080/api/v1/query_range": EOF

![Screenshot from 2022-04-07 13-51-44](https://user-images.githubusercontent.com/2655598/162192478-78630608-65ef-4df8-a072-81d415d463ee.png)

When I set the idempotency header, the conversation was equal to the case when GET is used - the connection is reopen and the request is retried.

![Screenshot from 2022-04-07 13-53-40](https://user-images.githubusercontent.com/2655598/162192822-30892018-46b6-4c63-a1f3-002178620eb7.png)

