### PR TITLE
Bump minimum required Go version to 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,6 @@ workflows:
     jobs:
       # Refer to README.md for the currently supported versions.
       - test:
-          name: go-1-15
-          go_version: "1.15"
-          run_lint: true
-      - test:
           name: go-1-16
           go_version: "1.16"
           run_lint: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [CHANGE] Minimum required Go version is now 1.16.
+
 ## 1.12.1 / 2022-01-29
 
 * [BUGFIX] Make the Go 1.17 collector concurrency-safe #969

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the [Go](http://golang.org) client library for
 instrumenting application code, and one for creating clients that talk to the
 Prometheus HTTP API.
 
-__This library requires Go1.15 or later.__
+__This library requires Go1.16 or later.__
 
 ## Important note about releases and stability
 

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 	google.golang.org/protobuf v1.28.0
 )
 
-go 1.15
+go 1.16

--- a/prometheus/collectors/dbstats_collector_test.go
+++ b/prometheus/collectors/dbstats_collector_test.go
@@ -15,7 +15,6 @@ package collectors
 
 import (
 	"database/sql"
-	"runtime"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,9 +49,7 @@ func TestDBStatsCollector(t *testing.T) {
 		"go_sql_wait_duration_seconds_total",
 		"go_sql_max_idle_closed_total",
 		"go_sql_max_lifetime_closed_total",
-	}
-	if runtime.Version() >= "go1.15" {
-		names = append(names, "go_sql_max_idle_time_closed_total")
+		"go_sql_max_idle_time_closed_total",
 	}
 	type result struct {
 		found bool


### PR DESCRIPTION
Based on request here by @kakkoyun https://github.com/prometheus/client_golang/pull/1027#pullrequestreview-939361219

@bwplotka One thing I saw was that the comment here says, this is supported since go 1.15, should we remove it as well? https://github.com/prometheus/client_golang/blob/main/prometheus/collectors/go_collector_go116.go#L45