### PR TITLE
gocollector: Reverted client_golang v1.12 addition of runtime/metrics metrics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * [CHANGE] Minimum required Go version is now 1.16.
+* [CHANGE] Added `collectors.WithGoCollections` that allows to choose what collection of Go runtime metrics user wants: Equivalent of [`MemStats` structure](https://pkg.go.dev/runtime#MemStats) configured using `GoRuntimeMemStatsCollection`, new based on dedicated [runtime/metrics](https://pkg.go.dev/runtime/metrics) metrics represented by `GoRuntimeMetricsCollection` option, or both by specifying `GoRuntimeMemStatsCollection | GoRuntimeMetricsCollection` flag.
+* [CHANGE] :warning: Change in `collectors.NewGoCollector` metrics: Reverting addition of new ~80 runtime metrics by default. You can enable this back with `GoRuntimeMetricsCollection` option or `GoRuntimeMemStatsCollection | GoRuntimeMetricsCollection`  for smooth transition.
 
 ## 1.12.1 / 2022-01-29
 

--- a/prometheus/collectors/go_collector_latest.go
+++ b/prometheus/collectors/go_collector_latest.go
@@ -70,8 +70,8 @@ const (
 // WithGoCollections(GoRuntimeMemStatsCollection | GoRuntimeMetricsCollection) means both GoRuntimeMemStatsCollection
 // metrics and GoRuntimeMetricsCollection will be exposed.
 //
-// Use WithGoCollections(GoRuntimeMemStatsCollection) to have Go collector working in
-// the compatibility mode with client_golang pre v1.12 (move to runtime/metrics).
+// The current default is GoRuntimeMemStatsCollection, so the compatibility mode with
+// client_golang pre v1.12 (move to runtime/metrics).
 func WithGoCollections(flags uint32) goOption {
 	return func(o *goOptions) {
 		o.EnabledCollections = flags

--- a/prometheus/go_collector_latest.go
+++ b/prometheus/go_collector_latest.go
@@ -132,7 +132,7 @@ func (c GoCollectorOptions) isEnabled(flag uint32) bool {
 	return c.EnabledCollections&flag != 0
 }
 
-const defaultGoCollections = goRuntimeMemStatsCollection | goRuntimeMetricsCollection
+const defaultGoCollections = goRuntimeMemStatsCollection
 
 // NewGoCollector is the obsolete version of collectors.NewGoCollector.
 // See there for documentation.

--- a/prometheus/go_collector_latest_test.go
+++ b/prometheus/go_collector_latest_test.go
@@ -117,7 +117,7 @@ func TestGoCollector(t *testing.T) {
 var sink interface{}
 
 func TestBatchHistogram(t *testing.T) {
-	goMetrics := collectGoMetrics(t, defaultGoCollections)
+	goMetrics := collectGoMetrics(t, goRuntimeMetricsCollection)
 
 	var mhist Metric
 	for _, m := range goMetrics {


### PR DESCRIPTION


Fixes https://github.com/prometheus/client_golang/issues/967

I am not 100% sure we want this, but I would like to start this discussion.

On one hand, with @mknyszek we wanted new runtime/metrics naming and extra metrics to be exposed by default, so people can leverage it.

On the other hand:
* Honestly speaking some of those metrics are not useful for typical Go developers and SRE responsible for running Go services. They are pretty detailed for deeper debugging systems. We enabled opt-in of those in https://github.com/prometheus/client_golang/pull/1031 so anyone can use it, no need for it to be the default. We also need documentation and some learning path to even understand new naming and allow building dashboards and alerts with those.
* It adds ~80 new metrics to the total count (see https://github.com/prometheus/client_golang/issues/967). It does not matter for one service. But with whole world moving to new client_golang version the cost impact can be counted in millions of $$$ (literally) in total. Especially given common Prometheus scrape configuration is deny-list, not allow-list.
* We already replaced existing metrics to use runtime/metrics instead MemStats so under the hood it works great.
* There are still serious bugs with new runtime/metrics bugs to be solved (fixable quickly though): https://github.com/prometheus/client_golang/issues/994
https://github.com/prometheus/client_golang/issues/995
https://github.com/prometheus/client_golang/issues/1026

Let me know what you think. I would revert the default to old behaviour IMO to be safe here and save ppl from the accidental cost impact it can cause.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>