### PR TITLE
Add WithQueryStats option

### DIFF
--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -1300,6 +1300,28 @@ func TestAPIs(t *testing.T) {
 				},
 			},
 		},
+		{
+			do: doQuery("2", testTime, WithQueryStats(nil, true)),
+			inRes: &queryResult{
+				Type: model.ValScalar,
+				Result: &model.Scalar{
+					Value:     2,
+					Timestamp: model.TimeFromUnix(testTime.Unix()),
+				},
+			},
+
+			reqMethod: "POST",
+			reqPath:   "/api/v1/query",
+			reqParam: url.Values{
+				"query": []string{"2"},
+				"time":  []string{testTime.Format(time.RFC3339Nano)},
+				"stats": []string{"all"},
+			},
+			res: &model.Scalar{
+				Value:     2,
+				Timestamp: model.TimeFromUnix(testTime.Unix()),
+			},
+		},
 	}
 
 	var tests []apiTest

--- a/api/prometheus/v1/example_test.go
+++ b/api/prometheus/v1/example_test.go
@@ -218,3 +218,30 @@ func ExampleAPI_series() {
 		fmt.Println(lbl)
 	}
 }
+
+func ExampleAPI_queryWithStats() {
+	client, err := api.NewClient(api.Config{
+		Address: "http://demo.robustperception.io:9090",
+	})
+	if err != nil {
+		fmt.Printf("Error creating client: %v\n", err)
+		os.Exit(1)
+	}
+
+	v1api := v1.NewAPI(client)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stats := v1.QueryStats{}
+	result, warnings, err := v1api.Query(ctx, "up", time.Now(),
+		v1.WithTimeout(5*time.Second),
+		v1.WithQueryStats(&stats, true))
+	if err != nil {
+		fmt.Printf("Error querying Prometheus: %v\n", err)
+		os.Exit(1)
+	}
+	if len(warnings) > 0 {
+		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	fmt.Printf("Result:\n%v\n", result)
+	fmt.Printf("Stats:\n%v\n", stats)
+}


### PR DESCRIPTION
https://github.com/prometheus/prometheus/pull/10369 was part of v2.35.0 release and it exposes more stats.
There's currently no way to access those stats since Query() and RangeQuery() returns only a subset of Prometheus API response.
To avoid bloating Query() return values I'm adding this as a new Option where you can pass a pointer to a QueryStats struct that will hold all recorded stats,
instead of adding another return value.

Signed-off-by: Lukasz Mierzwa <l.mierzwa@gmail.com>