### PR TITLE
Merge commit tagged as v1.12.2 into the release branch

### DIFF
--- a/prometheus/gen_go_collector_metrics_set.go
+++ b/prometheus/gen_go_collector_metrics_set.go
@@ -38,15 +38,8 @@ func main() {
 		log.Fatal("requires Go version (e.g. go1.17) as an argument")
 	}
 	toolVersion := runtime.Version()
-<<<<<<< HEAD
 	if majorVersion := toolVersion[:strings.LastIndexByte(toolVersion, '.')]; majorVersion != os.Args[1] {
 		log.Fatalf("using Go version %q but expected Go version %q", majorVersion, os.Args[1])
-=======
-	mtv := majorVersion(toolVersion)
-	mv := majorVersion(os.Args[1])
-	if mtv != mv {
-		log.Fatalf("using Go version %q but expected Go version %q", mtv, mv)
->>>>>>> f251146 (prometheus: Fix convention violating names for generated collector metrics (#1048))
 	}
 	version, err := parseVersion(mv)
 	if err != nil {


### PR DESCRIPTION
This also removes leftovers from merge conflicts that somehow made it into the release branch (but were never released, because the released commit wasn't in the release branch in the first place ;).