### PR TITLE
Adding +inf bucket exemplar

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -186,12 +186,14 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 			if i < len(pb.Histogram.Bucket) {
 				pb.Histogram.Bucket[i].Exemplar = e
 			} else {
-				b := &dto.Bucket{
-					CumulativeCount: proto.Uint64(pb.Histogram.Bucket[i].GetCumulativeCount()),
-					UpperBound:      proto.Float64(math.Inf(1)),
-					Exemplar:        e,
+				if i < len(pb.Histogram.Bucket)-1 {
+					b := &dto.Bucket{
+						CumulativeCount: proto.Uint64(pb.Histogram.Bucket[i].GetCumulativeCount()),
+						UpperBound:      proto.Float64(math.Inf(1)),
+						Exemplar:        e,
+					}
+					pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
 				}
-				pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
 			}
 		}
 	default:

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -186,14 +186,13 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 			if i < len(pb.Histogram.Bucket) {
 				pb.Histogram.Bucket[i].Exemplar = e
 			} else {
-				if i < len(pb.Histogram.Bucket)-1 {
-					b := &dto.Bucket{
-						CumulativeCount: proto.Uint64(pb.Histogram.Bucket[i].GetCumulativeCount()),
-						UpperBound:      proto.Float64(math.Inf(1)),
-						Exemplar:        e,
-					}
-					pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
+				b := &dto.Bucket{
+					CumulativeCount: proto.Uint64(pb.Histogram.Bucket[len(pb.Histogram.GetBucket())-1].GetCumulativeCount()),
+					UpperBound:      proto.Float64(math.Inf(1)),
+					Exemplar:        e,
 				}
+				pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
+
 			}
 		}
 	default:

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -56,6 +56,8 @@ func TestWithExemplarsMetric(t *testing.T) {
 			{Value: proto.Float64(89.0)},
 			{Value: proto.Float64(100.0)},
 			{Value: proto.Float64(157.0)},
+			{Value: proto.Float64(500.0)},
+			{Value: proto.Float64(600.0)},
 		}}
 		metric := dto.Metric{}
 		if err := m.Write(&metric); err != nil {


### PR DESCRIPTION
- explicitly add +inf bucket, if there is an exemplar for it.
- If there are multiple exemplars outside of the max bucket bound, choose one for the +inf bucket and end the loop.