### PR TITLE
Raise exemplar labels limit from 64 to 128

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -16,6 +16,7 @@ package prometheus
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -262,10 +263,11 @@ func TestCounterExemplar(t *testing.T) {
 				err = e.(error)
 			}
 		}()
-		// Should panic because of 65 runes.
+		// Should panic because of 129 runes.
 		counter.AddWithExemplar(42, Labels{
 			"abcdefghijklmnopqrstuvwxyz": "26+16 characters",
 			"x1234567":                   "8+15 characters",
+			"z":                          strings.Repeat("x", 63),
 		})
 		return nil
 	}

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -200,7 +200,7 @@ func MakeLabelPairs(desc *Desc, labelValues []string) []*dto.LabelPair {
 }
 
 // ExemplarMaxRunes is the max total number of runes allowed in exemplar labels.
-const ExemplarMaxRunes = 64
+const ExemplarMaxRunes = 128
 
 // newExemplar creates a new dto.Exemplar from the provided values. An error is
 // returned if any of the label names or values are invalid or if the total


### PR DESCRIPTION
In line with the OpenMetrics spec:
> The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 character code points

https://github.com/OpenObservability/OpenMetrics/blob/98ae26c87b/specification/OpenMetrics.md#exemplars

I suspect this number changed since the discussion in #706, but I can't see that change in the git history of the spec.