### PR TITLE
explicitly add +inf bucket in withExemplarsMetric

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -184,7 +184,8 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 			})
 			if i < len(pb.Histogram.Bucket) {
 				pb.Histogram.Bucket[i].Exemplar = e
-			} else { // +inf bucket should be explicitly added if there is an exemplar for it.
+			} else { 
+			    // The +Inf bucket should be explicitly added if there is an exemplar for it, similar to non-const histogram logic in https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L357-L365.
 				b := &dto.Bucket{
 					CumulativeCount: proto.Uint64(pb.Histogram.Bucket[len(pb.Histogram.GetBucket())-1].GetCumulativeCount()),
 					UpperBound:      proto.Float64(math.Inf(1)),

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -15,6 +15,7 @@ package prometheus
 
 import (
 	"errors"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -183,9 +184,16 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 			})
 			if i < len(pb.Histogram.Bucket) {
 				pb.Histogram.Bucket[i].Exemplar = e
-			} else {
-				// This is not possible as last bucket is Inf.
-				panic("no bucket was found for given exemplar value")
+			} else { // +inf bucket should be explicitly added if there is an exemplar for it.
+				b := &dto.Bucket{
+					CumulativeCount: proto.Uint64(pb.Histogram.Bucket[len(pb.Histogram.GetBucket())-1].GetCumulativeCount()),
+					UpperBound:      proto.Float64(math.Inf(1)),
+					Exemplar:        e,
+				}
+				pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
+				break
+				// end looping after creating +inf bucket and adding one exemplar.
+				// there could be other exemplars that are in the "inf" range but those will be ignored.
 			}
 		}
 	default:

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -184,8 +184,8 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 			})
 			if i < len(pb.Histogram.Bucket) {
 				pb.Histogram.Bucket[i].Exemplar = e
-			} else { 
-			    // The +Inf bucket should be explicitly added if there is an exemplar for it, similar to non-const histogram logic in https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L357-L365.
+			} else {
+				// The +Inf bucket should be explicitly added if there is an exemplar for it, similar to non-const histogram logic in https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L357-L365.
 				b := &dto.Bucket{
 					CumulativeCount: proto.Uint64(pb.Histogram.Bucket[len(pb.Histogram.GetBucket())-1].GetCumulativeCount()),
 					UpperBound:      proto.Float64(math.Inf(1)),
@@ -193,8 +193,7 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 				}
 				pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
 				break
-				// end looping after creating +inf bucket and adding one exemplar.
-				// there could be other exemplars that are in the "inf" range but those will be ignored.
+				// Terminating the loop after creating the +Inf bucket and adding one exemplar, if there are other exemplars in the +Inf bucket range they will be ignored.
 			}
 		}
 	default:

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -68,7 +68,7 @@ func TestWithExemplarsMetric(t *testing.T) {
 			t.Errorf("want %v, got %v", want, got)
 		}
 
-		// when there are more exemplars than there are buckets, a +inf bucket will be created and the last exemplar value will be added to the +inf bucket.
+		// When there are more exemplars than there are buckets, a +Inf bucket will be created and the last exemplar value will be added.
 		expectedExemplarVals := []float64{24.0, 42.0, 100.0, 157.0, 500.0}
 		for i, b := range metric.GetHistogram().Bucket {
 			if b.Exemplar == nil {

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -84,11 +84,5 @@ func TestWithExemplarsMetric(t *testing.T) {
 		if infBucket != math.Inf(1) {
 			t.Errorf("want %v, got %v", math.Inf(1), infBucket)
 		}
-
-		infBucketValue := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1].GetExemplar().GetValue()
-
-		if infBucketValue != 500.0 {
-			t.Errorf("want %v, got %v", 500.0, infBucketValue)
-		}
 	})
 }

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -14,6 +14,7 @@
 package prometheus
 
 import (
+	"math"
 	"testing"
 
 	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
@@ -56,16 +57,19 @@ func TestWithExemplarsMetric(t *testing.T) {
 			{Value: proto.Float64(89.0)},
 			{Value: proto.Float64(100.0)},
 			{Value: proto.Float64(157.0)},
+			{Value: proto.Float64(500.0)},
+			{Value: proto.Float64(2000.0)},
 		}}
 		metric := dto.Metric{}
 		if err := m.Write(&metric); err != nil {
 			t.Fatal(err)
 		}
-		if want, got := 4, len(metric.GetHistogram().Bucket); want != got {
+		if want, got := 5, len(metric.GetHistogram().Bucket); want != got {
 			t.Errorf("want %v, got %v", want, got)
 		}
 
-		expectedExemplarVals := []float64{24.0, 42.0, 100.0, 157.0}
+		// when there are more exemplars than there are buckets, a +inf bucket will be created and the last exemplar value will be added to the +inf bucket.
+		expectedExemplarVals := []float64{24.0, 42.0, 100.0, 157.0, 500.0}
 		for i, b := range metric.GetHistogram().Bucket {
 			if b.Exemplar == nil {
 				t.Errorf("Expected exemplar for bucket %v, got nil", i)
@@ -73,6 +77,18 @@ func TestWithExemplarsMetric(t *testing.T) {
 			if want, got := expectedExemplarVals[i], *metric.GetHistogram().Bucket[i].Exemplar.Value; want != got {
 				t.Errorf("%v: want %v, got %v", i, want, got)
 			}
+		}
+
+		infBucket := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1].GetUpperBound()
+
+		if infBucket != math.Inf(1) {
+			t.Errorf("want %v, got %v", math.Inf(1), infBucket)
+		}
+
+		infBucketValue := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1].GetExemplar().GetValue()
+
+		if infBucketValue != 500.0 {
+			t.Errorf("want %v, got %v", 500.0, infBucketValue)
 		}
 	})
 }


### PR DESCRIPTION
### Problem:
Currently if there are exemplar values that are outside the maximum bucket bounds for a histogram metric, client_go lang will panic https://github.com/prometheus/client_golang/blob/main/prometheus/metric.go#L186-L189

When using this client in [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector), this panic leads to a crash and therefore we are unable to use client_golang in [prometheus exporter](https://github.com/Shopify/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter) in Open Telemetry Collector. There is a discussion about this issue in our [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9945) in that repository.

### Proposed solution:

In this PR we are proposing a solution to this issue by explicitly adding `+inf` bucket when there are exemplar values outside the max bucket bound and picking one of the exemplars if there are more than one in that range. 

@bwplotka @kakkoyun