### PR TITLE
Fixed support for unordered input of exemplars.

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -192,8 +192,6 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 					Exemplar:        e,
 				}
 				pb.Histogram.Bucket = append(pb.Histogram.Bucket, b)
-				break
-				// Terminating the loop after creating the +Inf bucket and adding one exemplar, if there are other exemplars in the +Inf bucket range they will be ignored.
 			}
 		}
 	default:


### PR DESCRIPTION
Additional fix on top of  https://github.com/prometheus/client_golang/pull/1094 see https://github.com/prometheus/client_golang/pull/1094#discussion_r931228577

Signed-off-by: bwplotka <bwplotka@gmail.com>