### PR TITLE
Extend prometheus.Registry to implement Collector

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -255,6 +255,9 @@ func (errs MultiError) MaybeUnwrap() error {
 // them into MetricFamilies for exposition. It implements Registerer, Gatherer,
 // and Collector. The zero value is not usable. Create instances with
 // NewRegistry or NewPedanticRegistry.
+//
+// Registry implements Collector to allow it to be used for creating groups of
+// metrics. See the Grouping example for how this can be done.
 type Registry struct {
 	mtx                   sync.RWMutex
 	collectorsByID        map[uint64]Collector // ID is a hash of the descIDs.

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -252,8 +252,8 @@ func (errs MultiError) MaybeUnwrap() error {
 }
 
 // Registry registers Prometheus collectors, collects their metrics, and gathers
-// them into MetricFamilies for exposition. It implements both Registerer,
-// Gatherer, and Collector. The zero value is not usable. Create instances with
+// them into MetricFamilies for exposition. It implements Registerer, Gatherer,
+// and Collector. The zero value is not usable. Create instances with
 // NewRegistry or NewPedanticRegistry.
 type Registry struct {
 	mtx                   sync.RWMutex

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -252,9 +252,9 @@ func (errs MultiError) MaybeUnwrap() error {
 }
 
 // Registry registers Prometheus collectors, collects their metrics, and gathers
-// them into MetricFamilies for exposition. It implements both Registerer and
-// Gatherer. The zero value is not usable. Create instances with NewRegistry or
-// NewPedanticRegistry.
+// them into MetricFamilies for exposition. It implements both Registerer,
+// Gatherer, and Collector. The zero value is not usable. Create instances with
+// NewRegistry or NewPedanticRegistry.
 type Registry struct {
 	mtx                   sync.RWMutex
 	collectorsByID        map[uint64]Collector // ID is a hash of the descIDs.
@@ -554,6 +554,31 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 		}
 	}
 	return internal.NormalizeMetricFamilies(metricFamiliesByName), errs.MaybeUnwrap()
+}
+
+// Describe implements Collector.
+func (r *Registry) Describe(ch chan<- *Desc) {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	// Only report the checked Collectors; unchecked collectors don't report any
+	// Desc.
+	for _, c := range r.collectorsByID {
+		c.Describe(ch)
+	}
+}
+
+// Collect implements Collector.
+func (r *Registry) Collect(ch chan<- Metric) {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	for _, c := range r.collectorsByID {
+		c.Collect(ch)
+	}
+	for _, c := range r.uncheckedCollectors {
+		c.Collect(ch)
+	}
 }
 
 // WriteToTextfile calls Gather on the provided Gatherer, encodes the result in the


### PR DESCRIPTION
This change allows Registries to be used as Collectors.

This enables new instances of Registry to be passed to ephemeral subroutines for collecting metrics from subroutines which are still running:

```go
package main

import (
  "fmt"

  "github.com/prometheus/client_golang/prometheus"
)

func main() {
  globalReg := prometheus.NewRegistry()

  for i := 0; i < 100; i++ {
    workerReg := prometheus.WrapRegistererWith(prometheus.Labels{
      // Add an ID label so registered metrics from workers don't
      // collide.
      "worker_id": fmt.Sprintf("%d", i),
    }, prometheus.NewRegistry())

    globalReg.MustRegister(workerReg)

    go func(i int) {
      runWorker(workerReg)

      // Unregister any metrics the worker may have created.
      globalReg.Unregister(workerReg)
    }(i)
  }
}

// runWorker runs a worker, registering worker-specific metrics.
func runWorker(reg *prometheus.Registry) {
  // ... register metrics ...
  // ... do work ...
}
```

This change makes it easier to avoid leaking metrics from subroutines which do not consistently properly unregister metrics.

This would primarily make things easier for Grafana Agent, where it can spawn different subroutines throughout the process lifetime which have different sets of metrics (i.e., remote_write). Ensuring that metrics from these subroutines consistently get unregistered can be a source of bugs, and something like this would make it easier for us to avoid leaking no-longer-needed metrics.

I'm not completely sure this change works as-is (it seems reasonable), but I wanted to open it as a PR to spawn discussion about the concept. 