### PR TITLE
Assure we exhaust bodies of all HTTP responses.

### DIFF
--- a/internal/errcapture/errcapture.go
+++ b/internal/errcapture/errcapture.go
@@ -1,0 +1,61 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errcapture
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type doFunc func() error
+
+// Do runs function and on error return error by argument including the given error (usually
+// from caller function).
+func Do(err *error, doer doFunc, format string, a ...interface{}) {
+	derr := doer()
+	if err == nil || derr == nil {
+		return
+	}
+
+	// For os closers, it's a common case to double close.
+	// From reliability purpose this is not a problem it may only indicate surprising execution path.
+	if errors.Is(derr, os.ErrClosed) {
+		return
+	}
+
+	errs := prometheus.MultiError{}
+	errs.Append(*err)
+	errs.Append(fmt.Errorf(format+": %w", append(a, derr)...))
+	*err = errs
+}
+
+// ExhaustClose closes the io.ReadCloser with error capture but exhausts the reader before.
+func ExhaustClose(err *error, r io.ReadCloser, format string, a ...interface{}) {
+	_, copyErr := io.Copy(ioutil.Discard, r)
+
+	Do(err, r.Close, format, a...)
+	if copyErr == nil {
+		return
+	}
+
+	errs := prometheus.MultiError{}
+	errs.Append(copyErr)
+	errs.Append(*err)
+	*err = errs
+}

--- a/internal/errcapture/errcapture_test.go
+++ b/internal/errcapture/errcapture_test.go
@@ -1,0 +1,82 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errcapture
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+type testCloser struct {
+	err error
+}
+
+func (c testCloser) Close() error {
+	return c.err
+}
+
+func TestDo(t *testing.T) {
+	for _, tcase := range []struct {
+		err    error
+		closer io.Closer
+
+		expectedErrStr string
+	}{
+		{
+			err:            nil,
+			closer:         testCloser{err: nil},
+			expectedErrStr: "",
+		},
+		{
+			err:            errors.New("test"),
+			closer:         testCloser{err: nil},
+			expectedErrStr: "test",
+		},
+		{
+			err:            nil,
+			closer:         testCloser{err: errors.New("test")},
+			expectedErrStr: "1 error(s) occurred:\n* close: test",
+		},
+		{
+			err:            errors.New("test"),
+			closer:         testCloser{err: errors.New("test")},
+			expectedErrStr: "2 error(s) occurred:\n* test\n* close: test",
+		},
+	} {
+		if ok := t.Run("", func(t *testing.T) {
+			ret := tcase.err
+			Do(&ret, tcase.closer.Close, "close")
+
+			if tcase.expectedErrStr == "" {
+				if ret != nil {
+					t.Error("Expected error to be nil")
+					t.Fail()
+				}
+			} else {
+				if ret == nil {
+					t.Error("Expected error to be not nil")
+					t.Fail()
+				}
+
+				if tcase.expectedErrStr != ret.Error() {
+					t.Errorf("%s != %s", tcase.expectedErrStr, ret.Error())
+					t.Fail()
+				}
+			}
+		}); !ok {
+			return
+		}
+	}
+}


### PR DESCRIPTION
Otherwise HTTP library might not be able to reuse TCP connections.

Signed-off-by: bwplotka <bwplotka@gmail.com>