### PR TITLE
Clarify documentation around what constructors do

### DIFF
--- a/prometheus/promauto/auto.go
+++ b/prometheus/promauto/auto.go
@@ -14,13 +14,13 @@
 // Package promauto provides alternative constructors for the fundamental
 // Prometheus metric types and their …Vec and …Func variants. The difference to
 // their counterparts in the prometheus package is that the promauto
-// constructors return Collectors that are already registered with a
-// registry. There are two sets of constructors. The constructors in the first
-// set are top-level functions, while the constructors in the other set are
-// methods of the Factory type. The top-level function return Collectors
-// registered with the global registry (prometheus.DefaultRegisterer), while the
-// methods return Collectors registered with the registry the Factory was
-// constructed with. All constructors panic if the registration fails.
+// constructors register the Collectors with a registry before returning them.
+// There are two sets of constructors. The constructors in the first set are
+// top-level functions, while the constructors in the other set are methods of
+// the Factory type. The top-level function return Collectors registered with
+// the global registry (prometheus.DefaultRegisterer), while the methods return
+// Collectors registered with the registry the Factory was constructed with. All
+// constructors panic if the registration fails.
 //
 // The following example is a complete program to create a histogram of normally
 // distributed random numbers from the math/rand package:


### PR DESCRIPTION
The wording of the documentation is slightly misleading. Before this
commit, it says that the returned collectors are "already registered".
This could be interpreted in two ways, one could think that promauto
keeps some sort of cache of already registered Collectors that are
returned by this package, and the other way is that the Collectors
constructed are registered before being returned. What is actually
happening is the latter, and the wording after this PR leaves no room to
think that the former could be the case.