### PR TITLE
Examples: replace deprecated WithGoCollections with WithGoCollectorRuntimeMetrics

### DIFF
--- a/examples/gocollector/main.go
+++ b/examples/gocollector/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -39,7 +40,7 @@ func main() {
 	// Add Go module build info.
 	reg.MustRegister(collectors.NewBuildInfoCollector())
 	reg.MustRegister(collectors.NewGoCollector(
-		collectors.WithGoCollections(collectors.GoRuntimeMemStatsCollection | collectors.GoRuntimeMetricsCollection),
+		collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
 	))
 
 	// Expose the registered metrics via HTTP.


### PR DESCRIPTION
Replace deprecated WithGoCollections with WithGoCollectorRuntimeMetrics in examples/gocollector folder

Signed-off-by: rogerogers <rogers@rogerogers.com>