### PR TITLE
Fix float64 comparison test failure on archs using FMA

### DIFF
--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -355,13 +355,12 @@ func TestBuckets(t *testing.T) {
 
 	got = ExponentialBucketsRange(1, 100, 10)
 	want = []float64{
-		1.0, 1.6681005372000588, 2.782559402207125,
-		4.641588833612779, 7.742636826811273, 12.915496650148842,
-		21.544346900318846, 35.93813663804629, 59.94842503189414,
-		100.00000000000007,
+		1.0, 1.6681, 2.7825, 4.6415, 7.7426, 12.9154, 21.5443,
+		35.9381, 59.9484, 100.0000,
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("exponential buckets range: got %v, want %v", got, want)
+	const tolerance = 0.0001
+	if !equalFloat64s(got, want, 0.0001) {
+		t.Errorf("exponential buckets range: got %v, want %v (tolerance %f)", got, want, tolerance)
 	}
 }
 
@@ -466,4 +465,24 @@ func TestHistogramExemplar(t *testing.T) {
 			t.Errorf("expected exemplar %s, got %s.", expected, got)
 		}
 	}
+}
+
+// equalFloat64 returns true if a and b are within the tolerance. We have this
+// because float comparison varies on different architectures. For example,
+// architectures which do FMA yield slightly different results.
+// https://github.com/prometheus/client_golang/pull/899#issuecomment-1244506390
+func equalFloat64(a, b, tolerance float64) bool {
+	return math.Abs(a-b) < tolerance
+}
+
+func equalFloat64s(a, b []float64, tolerance float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalFloat64(a[i], b[i], tolerance) {
+			return false
+		}
+	}
+	return true
 }

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -359,7 +359,7 @@ func TestBuckets(t *testing.T) {
 		35.9381, 59.9484, 100.0000,
 	}
 	const tolerance = 0.0001
-	if !equalFloat64s(got, want, 0.0001) {
+	if !equalFloat64s(got, want, tolerance) {
 		t.Errorf("exponential buckets range: got %v, want %v (tolerance %f)", got, want, tolerance)
 	}
 }

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/prometheus/client_golang/prometheus/internal"
+
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -358,9 +360,9 @@ func TestBuckets(t *testing.T) {
 		1.0, 1.6681, 2.7825, 4.6415, 7.7426, 12.9154, 21.5443,
 		35.9381, 59.9484, 100.0000,
 	}
-	const tolerance = 0.0001
-	if !equalFloat64s(got, want, tolerance) {
-		t.Errorf("exponential buckets range: got %v, want %v (tolerance %f)", got, want, tolerance)
+	const epsilon = 0.0001
+	if !internal.AlmostEqualFloat64s(got, want, epsilon) {
+		t.Errorf("exponential buckets range: got %v, want %v (epsilon %f)", got, want, epsilon)
 	}
 }
 
@@ -465,24 +467,4 @@ func TestHistogramExemplar(t *testing.T) {
 			t.Errorf("expected exemplar %s, got %s.", expected, got)
 		}
 	}
-}
-
-// equalFloat64 returns true if a and b are within the tolerance. We have this
-// because float comparison varies on different architectures. For example,
-// architectures which do FMA yield slightly different results.
-// https://github.com/prometheus/client_golang/pull/899#issuecomment-1244506390
-func equalFloat64(a, b, tolerance float64) bool {
-	return math.Abs(a-b) < tolerance
-}
-
-func equalFloat64s(a, b []float64, tolerance float64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !equalFloat64(a[i], b[i], tolerance) {
-			return false
-		}
-	}
-	return true
 }

--- a/prometheus/internal/almost_equal.go
+++ b/prometheus/internal/almost_equal.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015 Björn Rabenstein
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// The code in this package is copy/paste to avoid a dependency. Hence this file
+// carries the copyright of the original repo.
+// https://github.com/beorn7/floats
+package internal
+
+import (
+	"math"
+)
+
+// minNormalFloat64 is the smallest positive normal value of type float64.
+var minNormalFloat64 = math.Float64frombits(0x0010000000000000)
+
+// AlmostEqualFloat64 returns true if a and b are equal within a relative error
+// of epsilon. See http://floating-point-gui.de/errors/comparison/ for the
+// details of the applied method.
+func AlmostEqualFloat64(a, b, epsilon float64) bool {
+	if a == b {
+		return true
+	}
+	absA := math.Abs(a)
+	absB := math.Abs(b)
+	diff := math.Abs(a - b)
+	if a == 0 || b == 0 || absA+absB < minNormalFloat64 {
+		return diff < epsilon*minNormalFloat64
+	}
+	return diff/math.Min(absA+absB, math.MaxFloat64) < epsilon
+}
+
+// AlmostEqualFloat64s is the slice form of AlmostEqualFloat64.
+func AlmostEqualFloat64s(a, b []float64, epsilon float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !AlmostEqualFloat64(a[i], b[i], epsilon) {
+			return false
+		}
+	}
+	return true
+}

--- a/prometheus/internal/difflib.go
+++ b/prometheus/internal/difflib.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 )
 
@@ -45,97 +44,6 @@ func calculateRatio(matches, length int) float64 {
 		return 2.0 * float64(matches) / float64(length)
 	}
 	return 1.0
-}
-
-var (
-	// minNormalFloat64 is the smallest positive normal value of type float64.
-	minNormalFloat64 = math.Float64frombits(0x0010000000000000)
-
-	// minNormalFloat32 is the smallest positive normal value of type float32.
-	minNormalFloat32 = math.Float32frombits(0x00800000)
-)
-
-// AlmostEqualFloat64 returns true if a and b are equal within a relative error
-// of epsilon. See http://floating-point-gui.de/errors/comparison/ for the
-// details of the applied method.
-//
-// This function is copy/paste to avoid a dependency.
-// https://github.com/beorn7/floats
-func AlmostEqualFloat64(a, b, epsilon float64) bool {
-	if a == b {
-		return true
-	}
-	absA := math.Abs(a)
-	absB := math.Abs(b)
-	diff := math.Abs(a - b)
-	if a == 0 || b == 0 || absA+absB < minNormalFloat64 {
-		return diff < epsilon*minNormalFloat64
-	}
-	return diff/math.Min(absA+absB, math.MaxFloat64) < epsilon
-}
-
-// AlmostEqualFloat64s is the slice form of AlmostEqualFloat64.
-func AlmostEqualFloat64s(a, b []float64, epsilon float64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !AlmostEqualFloat64(a[i], b[i], epsilon) {
-			return false
-		}
-	}
-	return true
-}
-
-// AlmostEqualFloat32 returns true if a and b are equal within a relative error
-// of epsilon. See http://floating-point-gui.de/errors/comparison/ for the
-// details of the applied method.
-//
-// This function is copy/paste to avoid a dependency.
-// https://github.com/beorn7/floats
-func AlmostEqualFloat32(a, b, epsilon float32) bool {
-	if a == b {
-		return true
-	}
-	absA := AbsFloat32(a)
-	absB := AbsFloat32(b)
-	diff := AbsFloat32(a - b)
-	if a == 0 || b == 0 || absA+absB < minNormalFloat32 {
-		return diff < epsilon*minNormalFloat32
-	}
-	return diff/MinFloat32(absA+absB, math.MaxFloat32) < epsilon
-}
-
-// AlmostEqualFloat32s is the slice form of AlmostEqualFloat32.
-func AlmostEqualFloat32s(a, b []float32, epsilon float32) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !AlmostEqualFloat32(a[i], b[i], epsilon) {
-			return false
-		}
-	}
-	return true
-}
-
-// AbsFloat32 works like math.Abs, but for float32.
-func AbsFloat32(x float32) float32 {
-	switch {
-	case x < 0:
-		return -x
-	case x == 0:
-		return 0 // return correctly abs(-0)
-	}
-	return x
-}
-
-// MinFloat32 works like math.Min, but for float32.
-func MinFloat32(x, y float32) float32 {
-	if x < y {
-		return x
-	}
-	return y
 }
 
 type Match struct {

--- a/prometheus/internal/difflib.go
+++ b/prometheus/internal/difflib.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 )
 
@@ -44,6 +45,97 @@ func calculateRatio(matches, length int) float64 {
 		return 2.0 * float64(matches) / float64(length)
 	}
 	return 1.0
+}
+
+var (
+	// minNormalFloat64 is the smallest positive normal value of type float64.
+	minNormalFloat64 = math.Float64frombits(0x0010000000000000)
+
+	// minNormalFloat32 is the smallest positive normal value of type float32.
+	minNormalFloat32 = math.Float32frombits(0x00800000)
+)
+
+// AlmostEqualFloat64 returns true if a and b are equal within a relative error
+// of epsilon. See http://floating-point-gui.de/errors/comparison/ for the
+// details of the applied method.
+//
+// This function is copy/paste to avoid a dependency.
+// https://github.com/beorn7/floats
+func AlmostEqualFloat64(a, b, epsilon float64) bool {
+	if a == b {
+		return true
+	}
+	absA := math.Abs(a)
+	absB := math.Abs(b)
+	diff := math.Abs(a - b)
+	if a == 0 || b == 0 || absA+absB < minNormalFloat64 {
+		return diff < epsilon*minNormalFloat64
+	}
+	return diff/math.Min(absA+absB, math.MaxFloat64) < epsilon
+}
+
+// AlmostEqualFloat64s is the slice form of AlmostEqualFloat64.
+func AlmostEqualFloat64s(a, b []float64, epsilon float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !AlmostEqualFloat64(a[i], b[i], epsilon) {
+			return false
+		}
+	}
+	return true
+}
+
+// AlmostEqualFloat32 returns true if a and b are equal within a relative error
+// of epsilon. See http://floating-point-gui.de/errors/comparison/ for the
+// details of the applied method.
+//
+// This function is copy/paste to avoid a dependency.
+// https://github.com/beorn7/floats
+func AlmostEqualFloat32(a, b, epsilon float32) bool {
+	if a == b {
+		return true
+	}
+	absA := AbsFloat32(a)
+	absB := AbsFloat32(b)
+	diff := AbsFloat32(a - b)
+	if a == 0 || b == 0 || absA+absB < minNormalFloat32 {
+		return diff < epsilon*minNormalFloat32
+	}
+	return diff/MinFloat32(absA+absB, math.MaxFloat32) < epsilon
+}
+
+// AlmostEqualFloat32s is the slice form of AlmostEqualFloat32.
+func AlmostEqualFloat32s(a, b []float32, epsilon float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !AlmostEqualFloat32(a[i], b[i], epsilon) {
+			return false
+		}
+	}
+	return true
+}
+
+// AbsFloat32 works like math.Abs, but for float32.
+func AbsFloat32(x float32) float32 {
+	switch {
+	case x < 0:
+		return -x
+	case x == 0:
+		return 0 // return correctly abs(-0)
+	}
+	return x
+}
+
+// MinFloat32 works like math.Min, but for float32.
+func MinFloat32(x, y float32) float32 {
+	if x < y {
+		return x
+	}
+	return y
 }
 
 type Match struct {


### PR DESCRIPTION
Background
=========
Architectures using FMA optimization yield slightly different results so we cannot assume floating point values will be precisely the same across different architectures.
https://github.com/prometheus/client_golang/pull/899#issuecomment-1244506390

Change
======
The solution in this change is to check "abs(a-b) < tolerance" instead of comparing the exact values. This will give us confidence that the histogram buckets are near identical.

Testing
=====
I have not tested this change on one of the previously failing architectures. Help from someone with access to one of these architectures would be appreciated.