### PR TITLE
Check metric uniqueness against timestamp

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -931,6 +932,10 @@ func checkMetricConsistency(
 		h.WriteString(lp.GetName())
 		h.Write(separatorByteSlice)
 		h.WriteString(lp.GetValue())
+		h.Write(separatorByteSlice)
+	}
+	if dtoMetric.TimestampMs != nil {
+		h.WriteString(strconv.FormatInt(*(dtoMetric.TimestampMs), 10))
 		h.Write(separatorByteSlice)
 	}
 	hSum := h.Sum64()


### PR DESCRIPTION
It is possible to pass multiple value-timestamp pairs of the same metric name and same labels to Prometheus. If its not something horrible to do, then maybe we could add some kind of check for that.
Possible fix for (#1137) 