### PR TITLE
Filter expected metrics as well in CollectAndCompare

### DIFF
--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -238,6 +238,7 @@ func convertReaderToMetricFamily(reader io.Reader) ([]*dto.MetricFamily, error) 
 func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...string) error {
 	if metricNames != nil {
 		got = filterMetrics(got, metricNames)
+		expected = filterMetrics(expected, metricNames)
 	}
 
 	return compare(got, expected)

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -331,6 +331,31 @@ func TestScrapeAndCompare(t *testing.T) {
 	}
 }
 
+func TestScrapeAndCompareWithMultipleExpected(t *testing.T) {
+	const expected = `
+		# HELP some_total A value that represents a counter.
+		# TYPE some_total counter
+
+		some_total{ label1 = "value1" } 1
+
+		# HELP some_total2 A value that represents a counter.
+		# TYPE some_total2 counter
+
+		some_total2{ label1 = "value1" } 1
+	`
+
+	expectedReader := strings.NewReader(expected)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, expected)
+	}))
+	defer ts.Close()
+
+	if err := ScrapeAndCompare(ts.URL, expectedReader, "some_total2"); err != nil {
+		t.Errorf("unexpected scraping result:\n%s", err)
+	}
+}
+
 func TestScrapeAndCompareFetchingFail(t *testing.T) {
 	err := ScrapeAndCompare("some_url", strings.NewReader("some expectation"), "some_total")
 	if err == nil {

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -341,7 +341,7 @@ func TestScrapeAndCompareWithMultipleExpected(t *testing.T) {
 		# HELP some_total2 A value that represents a counter.
 		# TYPE some_total2 counter
 
-		some_total2{ label1 = "value1" } 1
+		some_total2{ label2 = "value2" } 1
 	`
 
 	expectedReader := strings.NewReader(expected)


### PR DESCRIPTION
**Problem**:
Implementation for GatherAndCompare does not match documentation. Documentation says that if you provide any metricNames it filters both provided and expected metrics. But only provided metrics are filtered in `compareMetricFamilies` function.

Here is my **usecase**: https://github.com/fluxninja/aperture/blob/main/pkg/otelcollector/metricsprocessor/processor_test.go#L154

I manually add `<split>` in the expectedMetrics string so I don't have to provide multiple expectedMetrics variables.