### PR TITLE
Fix `CumulativeCount` value of `+Inf` bucket created from exemplar

### DIFF
--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -613,7 +613,7 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 // to send it to Prometheus in the Collect method.
 //
 // buckets is a map of upper bounds to cumulative counts, excluding the +Inf
-// bucket.
+// bucket. The +Inf bucket is implicit, and its value is equal to the provided count.
 //
 // NewConstHistogram returns an error if the length of labelValues is not
 // consistent with the variable labels in Desc or if Desc is invalid.

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -187,7 +187,7 @@ func (m *withExemplarsMetric) Write(pb *dto.Metric) error {
 			} else {
 				// The +Inf bucket should be explicitly added if there is an exemplar for it, similar to non-const histogram logic in https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L357-L365.
 				b := &dto.Bucket{
-					CumulativeCount: proto.Uint64(pb.Histogram.Bucket[len(pb.Histogram.GetBucket())-1].GetCumulativeCount()),
+					CumulativeCount: proto.Uint64(pb.Histogram.GetSampleCount()),
 					UpperBound:      proto.Float64(math.Inf(1)),
 					Exemplar:        e,
 				}

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -81,11 +81,11 @@ func TestWithExemplarsMetric(t *testing.T) {
 
 		infBucket := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1]
 
-		if want, got := infBucket.GetUpperBound(), math.Inf(1); want != got {
+		if want, got := math.Inf(1), infBucket.GetUpperBound(); want != got {
 			t.Errorf("want %v, got %v", want, got)
 		}
 
-		if want, got := infBucket.GetCumulativeCount(), uint64(4711); want != got {
+		if want, got := uint64(4711), infBucket.GetCumulativeCount(); want != got {
 			t.Errorf("want %v, got %v", want, got)
 		}
 	})

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -79,10 +79,14 @@ func TestWithExemplarsMetric(t *testing.T) {
 			}
 		}
 
-		infBucket := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1].GetUpperBound()
+		infBucket := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1]
 
-		if infBucket != math.Inf(1) {
-			t.Errorf("want %v, got %v", math.Inf(1), infBucket)
+		if upperBound := infBucket.GetUpperBound(); upperBound != math.Inf(1) {
+			t.Errorf("want %v, got %v", math.Inf(1), upperBound)
+		}
+
+		if cumulativeCount := infBucket.GetCumulativeCount(); cumulativeCount != 4711 {
+			t.Errorf("want %v, got %v", 4711, cumulativeCount)
 		}
 	})
 }

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -81,12 +81,12 @@ func TestWithExemplarsMetric(t *testing.T) {
 
 		infBucket := metric.GetHistogram().Bucket[len(metric.GetHistogram().Bucket)-1]
 
-		if upperBound := infBucket.GetUpperBound(); upperBound != math.Inf(1) {
-			t.Errorf("want %v, got %v", math.Inf(1), upperBound)
+		if want, got := infBucket.GetUpperBound(), math.Inf(1); want != got {
+			t.Errorf("want %v, got %v", want, got)
 		}
 
-		if cumulativeCount := infBucket.GetCumulativeCount(); cumulativeCount != 4711 {
-			t.Errorf("want %v, got %v", 4711, cumulativeCount)
+		if want, got := infBucket.GetCumulativeCount(), uint64(4711); want != got {
+			t.Errorf("want %v, got %v", want, got)
 		}
 	})
 }


### PR DESCRIPTION
When writing histogram metrics, and there is an exemplar for the +Inf bucket, then the +Inf bucket is added with the value of the previous bucket.

This is incorrect, as the cumulative count of the +Inf bucket should instead be added with the total count of the histogram datapoint.

The above behaviour results in invalid values being reported for the +Inf bucket.

See issue: https://github.com/prometheus/client_golang/issues/1147

@bwplotka @kakkoyun 