### PR TITLE
Update examples to use custom registry

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -18,7 +18,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
-	
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -18,7 +18,8 @@ import (
 	"flag"
 	"log"
 	"net/http"
-
+	
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -26,6 +27,11 @@ var addr = flag.String("listen-address", ":8080", "The address to listen on for 
 
 func main() {
 	flag.Parse()
-	http.Handle("/metrics", promhttp.Handler())
+
+	// Create non-global registry.
+	reg := prometheus.NewRegistry()
+
+	// Expose /metrics HTTP endpoint using the created custom registry.
+	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/prometheus/doc.go
+++ b/prometheus/doc.go
@@ -35,39 +35,51 @@
 //    	"github.com/prometheus/client_golang/prometheus/promhttp"
 //    )
 //
-//    var (
-//    	cpuTemp = prometheus.NewGauge(prometheus.GaugeOpts{
-//    		Name: "cpu_temperature_celsius",
-//    		Help: "Current temperature of the CPU.",
-//    	})
-//    	hdFailures = prometheus.NewCounterVec(
-//    		prometheus.CounterOpts{
-//    			Name: "hd_errors_total",
-//    			Help: "Number of hard-disk errors.",
-//    		},
-//    		[]string{"device"},
-//    	)
-//    )
+//    type metrics struct {
+//    	cpuTemp  prometheus.Gauge
+//      hdFailures *prometheus.CounterVec
+//    }
 //
-//    func init() {
-//    	// Metrics have to be registered to be exposed:
-//    	prometheus.MustRegister(cpuTemp)
-//    	prometheus.MustRegister(hdFailures)
+//    func NewMetrics(reg prometheus.Registerer) *metrics {
+//      m := &metrics{
+//        cpuTemp: prometheus.NewGauge(prometheus.GaugeOpts{
+//          Name: "cpu_temperature_celsius",
+//          Help: "Current temperature of the CPU.",
+//        }),
+//        hdFailures: prometheus.NewCounterVec(
+//          prometheus.CounterOpts{
+//            Name: "hd_errors_total",
+//            Help: "Number of hard-disk errors.",
+//          },
+//          []string{"device"},
+//        ),
+//      }
+//      reg.MustRegister(m.cpuTemp)
+//      reg.MustRegister(m.hdFailures)
+//      return m
 //    }
 //
 //    func main() {
-//    	cpuTemp.Set(65.3)
-//    	hdFailures.With(prometheus.Labels{"device":"/dev/sda"}).Inc()
+//      // Create a non-global registry.
+//      reg := prometheus.NewRegistry()
 //
-//    	// The Handler function provides a default handler to expose metrics
-//    	// via an HTTP server. "/metrics" is the usual endpoint for that.
-//    	http.Handle("/metrics", promhttp.Handler())
+//      // Create new metrics and register them using the custom registry.
+//      m := NewMetrics(reg)
+//      // Set values for the new created metrics.
+//    	m.cpuTemp.Set(65.3)
+//    	m.hdFailures.With(prometheus.Labels{"device":"/dev/sda"}).Inc()
+//
+//    	// Expose metrics and custom registry via an HTTP server
+//    	// using the HandleFor function. "/metrics" is the usual endpoint for that.
+//    	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
 //    	log.Fatal(http.ListenAndServe(":8080", nil))
 //    }
 //
 //
 // This is a complete program that exports two metrics, a Gauge and a Counter,
 // the latter with a label attached to turn it into a (one-dimensional) vector.
+// It register the metrics using a custom registry and exposes them via an HTTP server
+// on the /metrics endpoint.
 //
 // Metrics
 //


### PR DESCRIPTION
I've updated the current examples under `/examples` to use a custom registry instead of the default one, in order to address https://github.com/prometheus/client_golang/issues/1101. 
I've changed also the basic example in https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#hdr-A_Basic_Example

I haven't updated yet the tests (e.g [here](https://github.com/prometheus/client_golang/blob/main/prometheus/examples_test.go#L42)) - maybe I can add them in a separate PR? 

cc @kakkoyun @bwplotka 