### PR TITLE
promhttp: Gracefully instrument nil RoundTrippers

### DIFF
--- a/prometheus/promhttp/instrument_client.go
+++ b/prometheus/promhttp/instrument_client.go
@@ -63,6 +63,10 @@ func InstrumentRoundTripperInFlight(gauge prometheus.Gauge, next http.RoundTripp
 //
 // See the example for ExampleInstrumentRoundTripperDuration for example usage.
 func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
 	rtOpts := defaultOptions()
 	for _, o := range opts {
 		o.apply(rtOpts)
@@ -105,6 +109,10 @@ func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.Rou
 // Note that this method is only guaranteed to never observe negative durations
 // if used with Go1.9+.
 func InstrumentRoundTripperDuration(obs prometheus.ObserverVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
 	rtOpts := defaultOptions()
 	for _, o := range opts {
 		o.apply(rtOpts)
@@ -161,6 +169,10 @@ type InstrumentTrace struct {
 //
 // See the example for ExampleInstrumentRoundTripperDuration for example usage.
 func InstrumentRoundTripperTrace(it *InstrumentTrace, next http.RoundTripper) RoundTripperFunc {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
 	return func(r *http.Request) (*http.Response, error) {
 		start := time.Now()
 

--- a/prometheus/promhttp/instrument_client_test.go
+++ b/prometheus/promhttp/instrument_client_test.go
@@ -97,7 +97,7 @@ func makeInstrumentedClient(opts ...Option) (*http.Client, *prometheus.Registry)
 	client.Transport = InstrumentRoundTripperInFlight(inFlightGauge,
 		InstrumentRoundTripperCounter(counter,
 			InstrumentRoundTripperTrace(trace,
-				InstrumentRoundTripperDuration(histVec, http.DefaultTransport, opts...),
+				InstrumentRoundTripperDuration(histVec, client.Transport, opts...),
 			),
 			opts...),
 	)
@@ -369,17 +369,14 @@ func ExampleInstrumentRoundTripperDuration() {
 		},
 	}
 
-	// Wrap the default RoundTripper with middleware.
-	roundTripper := InstrumentRoundTripperInFlight(inFlightGauge,
+	// Wrap the client's RoundTripper with middleware.
+	client.Transport = InstrumentRoundTripperInFlight(inFlightGauge,
 		InstrumentRoundTripperCounter(counter,
 			InstrumentRoundTripperTrace(trace,
-				InstrumentRoundTripperDuration(histVec, http.DefaultTransport),
+				InstrumentRoundTripperDuration(histVec, client.Transport),
 			),
 		),
 	)
-
-	// Set the RoundTripper on our client.
-	client.Transport = roundTripper
 
 	resp, err := client.Get("http://google.com")
 	if err != nil {


### PR DESCRIPTION
When a caller of the InstrumentRoundTripper methods has other
middlewares in their stack, the way the provided examples wrap
`http.DefaultTransport` don't quite work, and you have to do something
like this whenever you call it

```go
if httpClient.Transport == nil {
	httpClient.Transport = http.DefaultTransport
}
httpClient.Transport = promhttp.InstrumentRoundTripperDuration(httpClient.Transport)
```

This change checks for and handles a nil `next` round-tripper, meaning
the nil check in this example isn't needed. This means callers can use
a passed-in HTTP client without having to worry about whether its
transport has been set already.

Signed-off-by: Eli Treuherz <et@arenko.group>

@bwplotka  @kakkoyun 
