### PR TITLE
Add context to "duplicate label names" to enable debugging

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -14,7 +14,6 @@
 package prometheus
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -127,7 +127,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 		labelNameSet[labelName] = struct{}{}
 	}
 	if len(labelNames) != len(labelNameSet) {
-		d.err = errors.New("duplicate label names")
+		d.err = fmt.Errorf("duplicate label names in constant and variable labels for metric %q", fqName)
 		return d
 	}
 


### PR DESCRIPTION
This error is really hard to debug as it provides no dynamic context, and "duplicate label names" on it's own can provide confusion as to what the error is. I tried to include a little more context on "what the source of duplication was" as well as "what metric caused this" to help in debugging.