### PR TITLE
Support for multiple samples within same metric

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -931,6 +932,10 @@ func checkMetricConsistency(
 		h.WriteString(lp.GetName())
 		h.Write(separatorByteSlice)
 		h.WriteString(lp.GetValue())
+		h.Write(separatorByteSlice)
+	}
+	if dtoMetric.TimestampMs != nil {
+		h.WriteString(strconv.FormatInt(*(dtoMetric.TimestampMs), 10))
 		h.Write(separatorByteSlice)
 	}
 	hSum := h.Sum64()


### PR DESCRIPTION
Fixes #1137

- adds the metrics timestamp to the metric repetition validation hash
- adds a unit test for metric consistency check

Signed-off-by: João Vilaça <jvilaca@redhat.com>