### PR TITLE
Replace deprecated github.com/golang/protobuf package

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -20,11 +20,9 @@ import (
 	"testing"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestCounterAdd(t *testing.T) {

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -18,15 +18,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cespare/xxhash/v2"
-
 	"github.com/prometheus/client_golang/prometheus/internal"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"github.com/prometheus/common/model"
-
+	"github.com/cespare/xxhash/v2"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"google.golang.org/protobuf/proto"
 )
 
 // Desc is the descriptor used by every Prometheus Metric. It is essentially

--- a/prometheus/go_collector_latest.go
+++ b/prometheus/go_collector_latest.go
@@ -23,11 +23,10 @@ import (
 	"strings"
 	"sync"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	dto "github.com/prometheus/client_model/go"
-
 	"github.com/prometheus/client_golang/prometheus/internal"
+
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -22,10 +22,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-
 	dto "github.com/prometheus/client_model/go"
+
+	"google.golang.org/protobuf/proto"
 )
 
 // nativeHistogramBounds for the frac of observed values. Only relevant for

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -25,13 +25,11 @@ import (
 	"testing/quick"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/prometheus/client_golang/prometheus/internal"
 
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func benchmarkHistogramObserve(w int, b *testing.B) {

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -20,11 +20,9 @@ import (
 	"strings"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"github.com/prometheus/common/model"
-
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"google.golang.org/protobuf/proto"
 )
 
 var separatorByteSlice = []byte{model.SeparatorByte} // For convenient use with xxhash.

--- a/prometheus/metric_test.go
+++ b/prometheus/metric_test.go
@@ -17,9 +17,9 @@ import (
 	"math"
 	"testing"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
+
+	"google.golang.org/protobuf/proto"
 )
 
 func TestBuildFQName(t *testing.T) {

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -26,14 +26,12 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"github.com/cespare/xxhash/v2"
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"github.com/prometheus/common/expfmt"
-
-	dto "github.com/prometheus/client_model/go"
-
 	"github.com/prometheus/client_golang/prometheus/internal"
+
+	"github.com/cespare/xxhash/v2"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -31,14 +31,12 @@ import (
 	"testing"
 	"time"
 
-	dto "github.com/prometheus/client_model/go"
-
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"github.com/prometheus/common/expfmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
 )
 
 // uncheckedCollector wraps a Collector but its Describe method yields no Desc.

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -22,11 +22,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/beorn7/perks/quantile"
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-
 	dto "github.com/prometheus/client_model/go"
+
+	"github.com/beorn7/perks/quantile"
+	"google.golang.org/protobuf/proto"
 )
 
 // quantileLabel is used for the label that defines the quantile in a

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -19,13 +19,11 @@ import (
 	"time"
 	"unicode/utf8"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/prometheus/client_golang/prometheus/internal"
 
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ValueType is an enumeration of metric types that represent a simple value.

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -17,12 +17,10 @@ import (
 	"fmt"
 	"sort"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus/internal"
 
 	dto "github.com/prometheus/client_model/go"
-
-	"github.com/prometheus/client_golang/prometheus/internal"
+	"google.golang.org/protobuf/proto"
 )
 
 // WrapRegistererWith returns a Registerer wrapping the provided

--- a/prometheus/wrap_test.go
+++ b/prometheus/wrap_test.go
@@ -19,9 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	"github.com/golang/protobuf/proto"
-
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -304,10 +301,10 @@ func TestWrap(t *testing.T) {
 				var want, got []string
 
 				for i, mf := range wantMF {
-					want = append(want, fmt.Sprintf("%3d: %s", i, proto.MarshalTextString(mf)))
+					want = append(want, fmt.Sprintf("%3d: %s", i, mf))
 				}
 				for i, mf := range gotMF {
-					got = append(got, fmt.Sprintf("%3d: %s", i, proto.MarshalTextString(mf)))
+					got = append(got, fmt.Sprintf("%3d: %s", i, mf))
 				}
 
 				t.Fatalf(


### PR DESCRIPTION
This replaces usage of proto.{Float64,Int32,Int64,String,Uint32,Uint64}, which doesn't break the interface.

And remove usage of proto.MarshalTextString in wrap_test.go

Updates: #1175

Signed-off-by: Shengjing Zhu <zhsj@debian.org>