### PR TITLE
Indent example in godoc consistently

### DIFF
--- a/prometheus/doc.go
+++ b/prometheus/doc.go
@@ -37,35 +37,35 @@
 //
 //	type metrics struct {
 //		cpuTemp  prometheus.Gauge
-//	  hdFailures *prometheus.CounterVec
+//		hdFailures *prometheus.CounterVec
 //	}
 //
 //	func NewMetrics(reg prometheus.Registerer) *metrics {
-//	  m := &metrics{
-//	    cpuTemp: prometheus.NewGauge(prometheus.GaugeOpts{
-//	      Name: "cpu_temperature_celsius",
-//	      Help: "Current temperature of the CPU.",
-//	    }),
-//	    hdFailures: prometheus.NewCounterVec(
-//	      prometheus.CounterOpts{
-//	        Name: "hd_errors_total",
-//	        Help: "Number of hard-disk errors.",
-//	      },
-//	      []string{"device"},
-//	    ),
-//	  }
-//	  reg.MustRegister(m.cpuTemp)
-//	  reg.MustRegister(m.hdFailures)
-//	  return m
+//		m := &metrics{
+//			cpuTemp: prometheus.NewGauge(prometheus.GaugeOpts{
+//				Name: "cpu_temperature_celsius",
+//				Help: "Current temperature of the CPU.",
+//			}),
+//			hdFailures: prometheus.NewCounterVec(
+//				prometheus.CounterOpts{
+//					Name: "hd_errors_total",
+//					Help: "Number of hard-disk errors.",
+//				},
+//				[]string{"device"},
+//			),
+//		}
+//		reg.MustRegister(m.cpuTemp)
+//		reg.MustRegister(m.hdFailures)
+//		return m
 //	}
 //
 //	func main() {
-//	  // Create a non-global registry.
-//	  reg := prometheus.NewRegistry()
+//		// Create a non-global registry.
+//		reg := prometheus.NewRegistry()
 //
-//	  // Create new metrics and register them using the custom registry.
-//	  m := NewMetrics(reg)
-//	  // Set values for the new created metrics.
+//		// Create new metrics and register them using the custom registry.
+//		m := NewMetrics(reg)
+//		// Set values for the new created metrics.
 //		m.cpuTemp.Set(65.3)
 //		m.hdFailures.With(prometheus.Labels{"device":"/dev/sda"}).Inc()
 //

--- a/prometheus/promauto/auto.go
+++ b/prometheus/promauto/auto.go
@@ -44,7 +44,7 @@
 //
 //	func Random() {
 //		for {
-//	    	histogram.Observe(rand.NormFloat64())
+//			histogram.Observe(rand.NormFloat64())
 //		}
 //	}
 //

--- a/prometheus/promauto/auto.go
+++ b/prometheus/promauto/auto.go
@@ -28,30 +28,30 @@
 //	package main
 //
 //	import (
-//	        "math/rand"
-//	        "net/http"
+//		"math/rand"
+//		"net/http"
 //
-//	        "github.com/prometheus/client_golang/prometheus"
-//	        "github.com/prometheus/client_golang/prometheus/promauto"
-//	        "github.com/prometheus/client_golang/prometheus/promhttp"
+//		"github.com/prometheus/client_golang/prometheus"
+//		"github.com/prometheus/client_golang/prometheus/promauto"
+//		"github.com/prometheus/client_golang/prometheus/promhttp"
 //	)
 //
 //	var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
-//	        Name:    "random_numbers",
-//	        Help:    "A histogram of normally distributed random numbers.",
-//	        Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//		Name:    "random_numbers",
+//		Help:    "A histogram of normally distributed random numbers.",
+//		Buckets: prometheus.LinearBuckets(-3, .1, 61),
 //	})
 //
 //	func Random() {
-//	        for {
-//	                histogram.Observe(rand.NormFloat64())
-//	        }
+//		for {
+//	    	histogram.Observe(rand.NormFloat64())
+//		}
 //	}
 //
 //	func main() {
-//	        go Random()
-//	        http.Handle("/metrics", promhttp.Handler())
-//	        http.ListenAndServe(":1971", nil)
+//		go Random()
+//		http.Handle("/metrics", promhttp.Handler())
+//		http.ListenAndServe(":1971", nil)
 //	}
 //
 // Prometheus's version of a minimal hello-world program:


### PR DESCRIPTION
As in the title. This change will render example code indentation in godoc to be more consistent and then, therefore, make the code examples looks better.