### PR TITLE
Switch to POST for LabelNames, Series, and QueryExemplars to DoGetFallback

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1031,13 +1031,7 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 		q.Add("match[]", m)
 	}
 
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	_, body, w, err := h.client.Do(ctx, req)
+	_, body, w, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return nil, w, err
 	}
@@ -1158,14 +1152,7 @@ func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTi
 		q.Set("end", formatTime(endTime))
 	}
 
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	_, body, warnings, err := h.client.Do(ctx, req)
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return nil, warnings, err
 	}
@@ -1322,14 +1309,8 @@ func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, e
 	if !endTime.IsZero() {
 		q.Set("end", formatTime(endTime))
 	}
-	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -346,7 +346,7 @@ func TestAPIs(t *testing.T) {
 		{
 			do:        doLabelNames(nil, testTime.Add(-100*time.Hour), testTime),
 			inRes:     []string{"val1", "val2"},
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/labels",
 			res:       []string{"val1", "val2"},
 		},
@@ -354,7 +354,7 @@ func TestAPIs(t *testing.T) {
 			do:         doLabelNames(nil, testTime.Add(-100*time.Hour), testTime),
 			inRes:      []string{"val1", "val2"},
 			inWarnings: []string{"a"},
-			reqMethod:  "GET",
+			reqMethod:  "POST",
 			reqPath:    "/api/v1/labels",
 			res:        []string{"val1", "val2"},
 		},
@@ -362,7 +362,7 @@ func TestAPIs(t *testing.T) {
 		{
 			do:        doLabelNames(nil, testTime.Add(-100*time.Hour), testTime),
 			inErr:     fmt.Errorf("some error"),
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/labels",
 			err:       errors.New("some error"),
 		},
@@ -370,14 +370,14 @@ func TestAPIs(t *testing.T) {
 			do:         doLabelNames(nil, testTime.Add(-100*time.Hour), testTime),
 			inErr:      fmt.Errorf("some error"),
 			inWarnings: []string{"a"},
-			reqMethod:  "GET",
+			reqMethod:  "POST",
 			reqPath:    "/api/v1/labels",
 			err:        errors.New("some error"),
 		},
 		{
 			do:        doLabelNames([]string{"up"}, testTime.Add(-100*time.Hour), testTime),
 			inRes:     []string{"val1", "val2"},
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/labels",
 			res:       []string{"val1", "val2"},
 		},
@@ -430,7 +430,7 @@ func TestAPIs(t *testing.T) {
 					"instance": "localhost:9090",
 				},
 			},
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/series",
 			res: []model.LabelSet{
 				{
@@ -451,7 +451,7 @@ func TestAPIs(t *testing.T) {
 				},
 			},
 			inWarnings: []string{"a"},
-			reqMethod:  "GET",
+			reqMethod:  "POST",
 			reqPath:    "/api/v1/series",
 			res: []model.LabelSet{
 				{
@@ -465,7 +465,7 @@ func TestAPIs(t *testing.T) {
 		{
 			do:        doSeries("up", testTime.Add(-time.Minute), testTime),
 			inErr:     fmt.Errorf("some error"),
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/series",
 			err:       errors.New("some error"),
 		},
@@ -474,7 +474,7 @@ func TestAPIs(t *testing.T) {
 			do:         doSeries("up", testTime.Add(-time.Minute), testTime),
 			inErr:      fmt.Errorf("some error"),
 			inWarnings: []string{"a"},
-			reqMethod:  "GET",
+			reqMethod:  "POST",
 			reqPath:    "/api/v1/series",
 			err:        errors.New("some error"),
 		},
@@ -1149,7 +1149,7 @@ func TestAPIs(t *testing.T) {
 
 		{
 			do:        doQueryExemplars("tns_request_duration_seconds_bucket", testTime.Add(-1*time.Minute), testTime),
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/query_exemplars",
 			inErr:     errors.New("some error"),
 			err:       errors.New("some error"),
@@ -1157,7 +1157,7 @@ func TestAPIs(t *testing.T) {
 
 		{
 			do:        doQueryExemplars("tns_request_duration_seconds_bucket", testTime.Add(-1*time.Minute), testTime),
-			reqMethod: "GET",
+			reqMethod: "POST",
 			reqPath:   "/api/v1/query_exemplars",
 			inRes: []interface{}{
 				map[string]interface{}{


### PR DESCRIPTION
The upstream prometheus HTTP API supports POSTS for these methods (the same as Query and QueryRange). Similar to the original issue (https://github.com/prometheus/client_golang/issues/428) we can hit 414 errors with these other APIs. This change simply duplicates the logic to these other endpoints

Related to: https://github.com/jacksontj/promxy/issues/588