### PR TITLE
Fixed promhttp Instrument* handlers.

### DIFF
--- a/prometheus/promhttp/instrument_client.go
+++ b/prometheus/promhttp/instrument_client.go
@@ -78,7 +78,7 @@ func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.Rou
 			for label, resolve := range rtOpts.extraLabelsFromCtx {
 				l[label] = resolve(resp.Request.Context())
 			}
-			counter.With(l).(prometheus.ExemplarAdder).AddWithExemplar(1, rtOpts.getExemplarFn(r.Context()))
+			addWithExemplar(counter.With(l), 1, rtOpts.getExemplarFn(r.Context()))
 		}
 		return resp, err
 	}
@@ -122,7 +122,7 @@ func InstrumentRoundTripperDuration(obs prometheus.ObserverVec, next http.RoundT
 			for label, resolve := range rtOpts.extraLabelsFromCtx {
 				l[label] = resolve(resp.Request.Context())
 			}
-			obs.With(l).(prometheus.ExemplarObserver).ObserveWithExemplar(time.Since(start).Seconds(), rtOpts.getExemplarFn(r.Context()))
+			observeWithExemplar(obs.With(l), time.Since(start).Seconds(), rtOpts.getExemplarFn(r.Context()))
 		}
 		return resp, err
 	}

--- a/prometheus/promhttp/option.go
+++ b/prometheus/promhttp/option.go
@@ -66,9 +66,9 @@ func WithExtraMethods(methods ...string) Option {
 	})
 }
 
-// WithExemplarFromContext adds allows to put a hook to all counter and histogram metrics.
-// If the hook function returns non-nil labels, exemplars will be added for that request, otherwise metric
-// will get instrumented without exemplar.
+// WithExemplarFromContext allows to inject function that will get exemplar from context that will be put to counter and histogram metrics.
+// If the function returns nil labels or the metric does not support exemplars, no exemplar will be added (noop), but
+// metric will continue to observe/increment.
 func WithExemplarFromContext(getExemplarFn func(requestCtx context.Context) prometheus.Labels) Option {
 	return optionApplyFunc(func(o *options) {
 		o.getExemplarFn = getExemplarFn


### PR DESCRIPTION
Unfortunately optionality is important as not every e.g. ObserverVec implements exemplar (e.g. summary).

For counters this is not that needed - but changed for consistency and readability.