### PR TITLE
add process start time header to client_golang prometheus

### DIFF
--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -42,8 +42,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -376,7 +377,7 @@ type HandlerOpts struct {
 	// counters (e.g. OpenTelemetry) or generally _created timestamp estimation per
 	// scrape target.
 	// NOTE: This feature is experimental and not covered by OpenMetrics or Prometheus
-	//       exposition format.
+	// exposition format.
 	ProcessStartTime time.Time
 }
 

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -53,12 +53,6 @@ const (
 	processStartTimeHeader = "Process-Start-Time-Unix"
 )
 
-var processStartTime time.Time
-
-func init() {
-	processStartTime = time.Now()
-}
-
 var gzipPool = sync.Pool{
 	New: func() interface{} {
 		return gzip.NewWriter(nil)
@@ -128,8 +122,8 @@ func HandlerForTransactional(reg prometheus.TransactionalGatherer, opts HandlerO
 	}
 
 	h := http.HandlerFunc(func(rsp http.ResponseWriter, req *http.Request) {
-		if opts.EnableProcessStartTimeHeader {
-			rsp.Header().Set(processStartTimeHeader, strconv.FormatInt(processStartTime.Unix(), 10))
+		if !opts.ProcessStartTime.IsZero() {
+			rsp.Header().Set(processStartTimeHeader, strconv.FormatInt(opts.ProcessStartTime.Unix(), 10))
 		}
 		if inFlightSem != nil {
 			select {
@@ -376,12 +370,14 @@ type HandlerOpts struct {
 	// (which changes the identity of the resulting series on the Prometheus
 	// server).
 	EnableOpenMetrics bool
-	// ProcessUnixTime allows setting process start time (unix timestamp integer) value that will be
-	// exposed with "Process-Start-Time-Unix" response header along with the metrics payload. 
-	// This allow callers to have efficient transformations to cumulative counters (e.g. OpenTelemetry) or
-	// generally _created timestamp estimation per scrape target.
-	// NOTE: This feature is experimental and not covered by OpenMetrics or Prometheus exposition format.
-	ProcessStartTimeUnix int64
+	// ProcessStartTime allows setting process start timevalue that will be exposed
+	// with "Process-Start-Time-Unix" response header along with the metrics
+	// payload. This allow callers to have efficient transformations to cumulative
+	// counters (e.g. OpenTelemetry) or generally _created timestamp estimation per
+	// scrape target.
+	// NOTE: This feature is experimental and not covered by OpenMetrics or Prometheus
+	//       exposition format.
+	ProcessStartTime time.Time
 }
 
 // gzipAccepted returns whether the client will accept gzip-encoded content.

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -50,7 +50,7 @@ const (
 	contentTypeHeader      = "Content-Type"
 	contentEncodingHeader  = "Content-Encoding"
 	acceptEncodingHeader   = "Accept-Encoding"
-	processStartTimeHeader = "Process-Start-Time"
+	processStartTimeHeader = "Process-Start-Time-Unix"
 )
 
 var processStartTime time.Time
@@ -376,15 +376,12 @@ type HandlerOpts struct {
 	// (which changes the identity of the resulting series on the Prometheus
 	// server).
 	EnableOpenMetrics bool
-	// If true, a process start time header is added to the response along
-	// with the metrics payload. This is useful because you receive the headers
-	// prior to the response body, and for large responses, this allows the
-	// scraping agent to stream metrics using the process start time to
-	// correctly offset counter metrics. The alternative is to use the metric
-	// process_start_time_seconds, which unfortunately tends to fall at the end
-	// of the response body, requiring the scraping agent to buffer the entire
-	// body in memory until process_start_time_seconds is reached.
-	EnableProcessStartTimeHeader bool
+	// ProcessUnixTime allows setting process start time (unix timestamp integer) value that will be
+	// exposed with "Process-Start-Time-Unix" response header along with the metrics payload. 
+	// This allow callers to have efficient transformations to cumulative counters (e.g. OpenTelemetry) or
+	// generally _created timestamp estimation per scrape target.
+	// NOTE: This feature is experimental and not covered by OpenMetrics or Prometheus exposition format.
+	ProcessStartTimeUnix int64
 }
 
 // gzipAccepted returns whether the client will accept gzip-encoded content.


### PR DESCRIPTION
This PR adds an option to enable a header to return process start time in a header.

This allows a scraping agent to avoid buffering the entire response body in memory until process_start_time_seconds is reached. 