### PR TITLE
Fix bug in bucket key calculation

### DIFF
--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -639,8 +639,8 @@ func (hc *histogramCounts) observe(v float64, bucket int, doSparse bool) {
 			if frac == 0.5 {
 				key--
 			}
-			div := 1 << -schema
-			key = (key + div - 1) / div
+			offset := (1 << -schema) - 1
+			key = (key + offset) >> -schema
 		}
 		if isInf {
 			key++

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -500,23 +500,26 @@ func TestNativeHistogram(t *testing.T) {
 		{
 			name: "factor 4 results in schema -1",
 			observations: []float64{
+				0.0156251, 0.0625, // Bucket -2: (0.015625, 0.0625)
+				0.1, 0.25, // Bucket -1: (0.0625, 0.25]
 				0.5, 1, // Bucket 0: (0.25, 1]
 				1.5, 2, 3, 3.5, // Bucket 1: (1, 4]
 				5, 6, 7, // Bucket 2: (4, 16]
 				33.33, // Bucket 3: (16, 64]
 			},
 			factor: 4,
-			want:   `sample_count:10 sample_sum:62.83 schema:-1 zero_threshold:2.938735877055719e-39 zero_count:0 positive_span:<offset:0 length:4 > positive_delta:2 positive_delta:2 positive_delta:-1 positive_delta:-2 `,
+			want:   `sample_count:14 sample_sum:63.2581251 schema:-1 zero_threshold:2.938735877055719e-39 zero_count:0 positive_span:<offset:-2 length:6 > positive_delta:2 positive_delta:0 positive_delta:0 positive_delta:2 positive_delta:-1 positive_delta:-2 `,
 		},
 		{
 			name: "factor 17 results in schema -2",
 			observations: []float64{
+				0.0156251, 0.0625, 0.1, 0.25, // Bucket -1: (0.015625, 0.25]
 				0.5, 1, // Bucket 0: (0.0625, 1]
 				1.5, 2, 3, 3.5, 5, 6, 7, // Bucket 1: (1, 16]
 				33.33, // Bucket 2: (16, 256]
 			},
 			factor: 17,
-			want:   `sample_count:10 sample_sum:62.83 schema:-2 zero_threshold:2.938735877055719e-39 zero_count:0 positive_span:<offset:0 length:3 > positive_delta:2 positive_delta:5 positive_delta:-6 `,
+			want:   `sample_count:14 sample_sum:63.2581251 schema:-2 zero_threshold:2.938735877055719e-39 zero_count:0 positive_span:<offset:-1 length:4 > positive_delta:4 positive_delta:-2 positive_delta:5 positive_delta:-6 `,
 		},
 		{
 			name:         "negative buckets",

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -513,13 +513,13 @@ func TestNativeHistogram(t *testing.T) {
 		{
 			name: "factor 17 results in schema -2",
 			observations: []float64{
-				0.0156251, 0.0625, 0.1, 0.25, // Bucket -1: (0.015625, 0.25]
-				0.5, 1, // Bucket 0: (0.0625, 1]
+				0.0156251, 0.0625, // Bucket -1: (0.015625, 0.0625]
+				0.1, 0.25, 0.5, 1, // Bucket 0: (0.0625, 1]
 				1.5, 2, 3, 3.5, 5, 6, 7, // Bucket 1: (1, 16]
 				33.33, // Bucket 2: (16, 256]
 			},
 			factor: 17,
-			want:   `sample_count:14 sample_sum:63.2581251 schema:-2 zero_threshold:2.938735877055719e-39 zero_count:0 positive_span:<offset:-1 length:4 > positive_delta:4 positive_delta:-2 positive_delta:5 positive_delta:-6 `,
+			want:   `sample_count:14 sample_sum:63.2581251 schema:-2 zero_threshold:2.938735877055719e-39 zero_count:0 positive_span:<offset:-1 length:4 > positive_delta:2 positive_delta:2 positive_delta:3 positive_delta:-6 `,
 		},
 		{
 			name:         "negative buckets",


### PR DESCRIPTION
The current code doesn't work fork negative schemas if the observed
value should go into a bucket with a non-positive key.

In the 1st commit, tests are added to expose the bug.

In the 2st commit, the bug is fixed. The expression smells a bit like it should be possible to simplify. But I couldn't come up with a simpler form. Let me know if you have any ideas. 