### PR TITLE
Improve metricUnits runtime

### DIFF
--- a/prometheus/testutil/promlint/promlint.go
+++ b/prometheus/testutil/promlint/promlint.go
@@ -287,17 +287,15 @@ func lintUnitAbbreviations(mf *dto.MetricFamily) []Problem {
 func metricUnits(m string) (unit, base string, ok bool) {
 	ss := strings.Split(m, "_")
 
-	for unit, base := range units {
-		// Also check for "no prefix".
-		for _, p := range append(unitPrefixes, "") {
-			for _, s := range ss {
-				// Attempt to explicitly match a known unit with a known prefix,
-				// as some words may look like "units" when matching suffix.
-				//
-				// As an example, "thermometers" should not match "meters", but
-				// "kilometers" should.
-				if s == p+unit {
-					return p + unit, base, true
+	for _, s := range ss {
+		if base, found := units[s]; found {
+			return s, base, true
+		}
+
+		for _, p := range unitPrefixes {
+			if strings.HasPrefix(s, p) {
+				if base, found := units[s[len(p):]]; found {
+					return s, base, true
 				}
 			}
 		}


### PR DESCRIPTION
This linter was implemented in the ci test for kubevirt operators, see:https://github.com/kubevirt/monitoring/tree/main/test/metrics/prom-metrics-linter. 
As part of this implementation we found (we think) a better way for the metricUnits function.

We tested this function runtime in both cases using "testing", and the runtime for this pr is much shorter. we're using random access to query the map, instead of looping over it again and again. see:

current version named `metricUnits` and the suggested version named `metricUnits2`
```
BenchmarkMetricUnits
BenchmarkMetricUnits/metricUnits
BenchmarkMetricUnits/metricUnits-16         	  106170	     11550 ns/op
BenchmarkMetricUnits/metricUnits2
BenchmarkMetricUnits/metricUnits2-16        	 7445168	       160.4 ns/op
BenchmarkMetricUnits2
BenchmarkMetricUnits2/metricUnits
BenchmarkMetricUnits2/metricUnits-16        	   91159	     12500 ns/op
BenchmarkMetricUnits2/metricUnits2
BenchmarkMetricUnits2/metricUnits2-16       	 8676104	       137.2 ns/op
BenchmarkMetricUnitsNotFound
BenchmarkMetricUnitsNotFound/metricUnits
BenchmarkMetricUnitsNotFound/metricUnits-16 	   46909	     27690 ns/op
BenchmarkMetricUnitsNotFound/metricUnits2
BenchmarkMetricUnitsNotFound/metricUnits2-16         	 9049458	       133.5 ns/op
PASS
```
* I can share the test files if needed.