### PR TITLE
Do not allocate memory when there's no constraints

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -202,8 +202,8 @@ func (v2) NewCounterVec(opts CounterVecOpts) *CounterVec {
 	)
 	return &CounterVec{
 		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
-			if len(lvs) != len(desc.variableLabels) {
-				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.labelNames(), lvs))
+			if len(lvs) != len(desc.variableLabels.names) {
+				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, lvs))
 			}
 			result := &counter{desc: desc, labelPairs: MakeLabelPairs(desc, lvs), now: time.Now}
 			result.init(result) // Init self-collection.

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -52,7 +52,7 @@ type Desc struct {
 	constLabelPairs []*dto.LabelPair
 	// variableLabels contains names of labels and normalization function for
 	// which the metric maintains variable values.
-	variableLabels ConstrainedLabels
+	variableLabels *compiledLabels
 	// id is a hash of the values of the ConstLabels and fqName. This
 	// must be unique among all registered descriptors and can therefore be
 	// used as an identifier of the descriptor.
@@ -93,7 +93,7 @@ func (v2) NewDesc(fqName, help string, variableLabels ConstrainableLabels, const
 	d := &Desc{
 		fqName:         fqName,
 		help:           help,
-		variableLabels: variableLabels.constrainedLabels(),
+		variableLabels: variableLabels.compile(),
 	}
 	if !model.IsValidMetricName(model.LabelValue(fqName)) {
 		d.err = fmt.Errorf("%q is not a valid metric name", fqName)
@@ -103,7 +103,7 @@ func (v2) NewDesc(fqName, help string, variableLabels ConstrainableLabels, const
 	// their sorted label names) plus the fqName (at position 0).
 	labelValues := make([]string, 1, len(constLabels)+1)
 	labelValues[0] = fqName
-	labelNames := make([]string, 0, len(constLabels)+len(d.variableLabels))
+	labelNames := make([]string, 0, len(constLabels)+len(d.variableLabels.names))
 	labelNameSet := map[string]struct{}{}
 	// First add only the const label names and sort them...
 	for labelName := range constLabels {
@@ -128,13 +128,13 @@ func (v2) NewDesc(fqName, help string, variableLabels ConstrainableLabels, const
 	// Now add the variable label names, but prefix them with something that
 	// cannot be in a regular label name. That prevents matching the label
 	// dimension with a different mix between preset and variable labels.
-	for _, label := range d.variableLabels {
-		if !checkLabelName(label.Name) {
-			d.err = fmt.Errorf("%q is not a valid label name for metric %q", label.Name, fqName)
+	for _, label := range d.variableLabels.names {
+		if !checkLabelName(label) {
+			d.err = fmt.Errorf("%q is not a valid label name for metric %q", label, fqName)
 			return d
 		}
-		labelNames = append(labelNames, "$"+label.Name)
-		labelNameSet[label.Name] = struct{}{}
+		labelNames = append(labelNames, "$"+label)
+		labelNameSet[label] = struct{}{}
 	}
 	if len(labelNames) != len(labelNameSet) {
 		d.err = fmt.Errorf("duplicate label names in constant and variable labels for metric %q", fqName)
@@ -189,11 +189,19 @@ func (d *Desc) String() string {
 			fmt.Sprintf("%s=%q", lp.GetName(), lp.GetValue()),
 		)
 	}
+	vlStrings := make([]string, 0, len(d.variableLabels.names))
+	for _, vl := range d.variableLabels.names {
+		if fn, ok := d.variableLabels.labelConstraints[vl]; ok && fn != nil {
+			vlStrings = append(vlStrings, fmt.Sprintf("c(%s)", vl))
+		} else {
+			vlStrings = append(vlStrings, vl)
+		}
+	}
 	return fmt.Sprintf(
-		"Desc{fqName: %q, help: %q, constLabels: {%s}, variableLabels: %v}",
+		"Desc{fqName: %q, help: %q, constLabels: {%s}, variableLabels: {%s}}",
 		d.fqName,
 		d.help,
 		strings.Join(lpStrings, ","),
-		d.variableLabels,
+		strings.Join(vlStrings, ","),
 	)
 }

--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -292,9 +292,9 @@ func ExampleRegister() {
 
 	// Output:
 	// taskCounter registered.
-	// taskCounterVec not registered: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "worker_pool_completed_tasks_total", help: "Total number of tasks completed.", constLabels: {}, variableLabels: [{worker_id <nil>}]} has different label names or a different help string
+	// taskCounterVec not registered: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "worker_pool_completed_tasks_total", help: "Total number of tasks completed.", constLabels: {}, variableLabels: {worker_id}} has different label names or a different help string
 	// taskCounter unregistered.
-	// taskCounterVec not registered: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "worker_pool_completed_tasks_total", help: "Total number of tasks completed.", constLabels: {}, variableLabels: [{worker_id <nil>}]} has different label names or a different help string
+	// taskCounterVec not registered: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "worker_pool_completed_tasks_total", help: "Total number of tasks completed.", constLabels: {}, variableLabels: {worker_id}} has different label names or a different help string
 	// taskCounterVec registered.
 	// Worker initialization failed: inconsistent label cardinality: expected 1 label values but got 2 in []string{"42", "spurious arg"}
 	// notMyCounter is nil.

--- a/prometheus/expvar_collector.go
+++ b/prometheus/expvar_collector.go
@@ -48,7 +48,7 @@ func (e *expvarCollector) Collect(ch chan<- Metric) {
 			continue
 		}
 		var v interface{}
-		labels := make([]string, len(desc.variableLabels))
+		labels := make([]string, len(desc.variableLabels.names))
 		if err := json.Unmarshal([]byte(expVar.String()), &v); err != nil {
 			ch <- NewInvalidMetric(desc, err)
 			continue

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -166,8 +166,8 @@ func (v2) NewGaugeVec(opts GaugeVecOpts) *GaugeVec {
 	)
 	return &GaugeVec{
 		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
-			if len(lvs) != len(desc.variableLabels) {
-				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.labelNames(), lvs))
+			if len(lvs) != len(desc.variableLabels.names) {
+				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, lvs))
 			}
 			result := &gauge{desc: desc, labelPairs: MakeLabelPairs(desc, lvs)}
 			result.init(result) // Init self-collection.

--- a/prometheus/gauge_test.go
+++ b/prometheus/gauge_test.go
@@ -170,7 +170,7 @@ func TestGaugeFunc(t *testing.T) {
 		func() float64 { return 3.1415 },
 	)
 
-	if expected, got := `Desc{fqName: "test_name", help: "test help", constLabels: {a="1",b="2"}, variableLabels: []}`, gf.Desc().String(); expected != got {
+	if expected, got := `Desc{fqName: "test_name", help: "test help", constLabels: {a="1",b="2"}, variableLabels: {}}`, gf.Desc().String(); expected != got {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
 

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -499,12 +499,12 @@ func NewHistogram(opts HistogramOpts) Histogram {
 }
 
 func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogram {
-	if len(desc.variableLabels) != len(labelValues) {
-		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.labelNames(), labelValues))
+	if len(desc.variableLabels.names) != len(labelValues) {
+		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, labelValues))
 	}
 
-	for _, n := range desc.variableLabels {
-		if n.Name == bucketLabel {
+	for _, n := range desc.variableLabels.names {
+		if n == bucketLabel {
 			panic(errBucketLabelNotAllowed)
 		}
 	}
@@ -1230,7 +1230,7 @@ func NewConstHistogram(
 	if desc.err != nil {
 		return nil, desc.err
 	}
-	if err := validateLabelValues(labelValues, len(desc.variableLabels)); err != nil {
+	if err := validateLabelValues(labelValues, len(desc.variableLabels.names)); err != nil {
 		return nil, err
 	}
 	return &constHistogram{

--- a/prometheus/labels.go
+++ b/prometheus/labels.go
@@ -32,19 +32,15 @@ import (
 // create a Desc.
 type Labels map[string]string
 
+// LabelConstraint normalizes label values.
+type LabelConstraint func(string) string
+
 // ConstrainedLabels represents a label name and its constrain function
 // to normalize label values. This type is commonly used when constructing
 // metric vector Collectors.
 type ConstrainedLabel struct {
 	Name       string
-	Constraint func(string) string
-}
-
-func (cl ConstrainedLabel) Constrain(v string) string {
-	if cl.Constraint == nil {
-		return v
-	}
-	return cl.Constraint(v)
+	Constraint LabelConstraint
 }
 
 // ConstrainableLabels is an interface that allows creating of labels that can
@@ -58,7 +54,7 @@ func (cl ConstrainedLabel) Constrain(v string) string {
 //	  },
 //	})
 type ConstrainableLabels interface {
-	constrainedLabels() ConstrainedLabels
+	compile() *compiledLabels
 	labelNames() []string
 }
 
@@ -67,8 +63,20 @@ type ConstrainableLabels interface {
 // metric vector Collectors.
 type ConstrainedLabels []ConstrainedLabel
 
-func (cls ConstrainedLabels) constrainedLabels() ConstrainedLabels {
-	return cls
+func (cls ConstrainedLabels) compile() *compiledLabels {
+	compiled := &compiledLabels{
+		names:            make([]string, len(cls)),
+		labelConstraints: map[string]LabelConstraint{},
+	}
+
+	for i, label := range cls {
+		compiled.names[i] = label.Name
+		if label.Constraint != nil {
+			compiled.labelConstraints[label.Name] = label.Constraint
+		}
+	}
+
+	return compiled
 }
 
 func (cls ConstrainedLabels) labelNames() []string {
@@ -92,16 +100,34 @@ func (cls ConstrainedLabels) labelNames() []string {
 //	}
 type UnconstrainedLabels []string
 
-func (uls UnconstrainedLabels) constrainedLabels() ConstrainedLabels {
-	constrainedLabels := make([]ConstrainedLabel, len(uls))
-	for i, l := range uls {
-		constrainedLabels[i] = ConstrainedLabel{Name: l}
+func (uls UnconstrainedLabels) compile() *compiledLabels {
+	return &compiledLabels{
+		names: uls,
 	}
-	return constrainedLabels
 }
 
 func (uls UnconstrainedLabels) labelNames() []string {
 	return uls
+}
+
+type compiledLabels struct {
+	names            []string
+	labelConstraints map[string]LabelConstraint
+}
+
+func (cls *compiledLabels) compile() *compiledLabels {
+	return cls
+}
+
+func (cls *compiledLabels) labelNames() []string {
+	return cls.names
+}
+
+func (cls *compiledLabels) constrain(labelName, value string) string {
+	if fn, ok := cls.labelConstraints[labelName]; ok && fn != nil {
+		return fn(value)
+	}
+	return value
 }
 
 // reservedLabelPrefix is a prefix which is not legal in user-supplied

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -128,11 +128,11 @@ func TestHandlerErrorHandling(t *testing.T) {
 		t.Fatalf("unexpected number of done invokes, want 0, got %d", got)
 	}
 
-	wantMsg := `error gathering metrics: error collecting metric Desc{fqName: "invalid_metric", help: "not helpful", constLabels: {}, variableLabels: []}: collect error
+	wantMsg := `error gathering metrics: error collecting metric Desc{fqName: "invalid_metric", help: "not helpful", constLabels: {}, variableLabels: {}}: collect error
 `
 	wantErrorBody := `An error has occurred while serving metrics:
 
-error collecting metric Desc{fqName: "invalid_metric", help: "not helpful", constLabels: {}, variableLabels: []}: collect error
+error collecting metric Desc{fqName: "invalid_metric", help: "not helpful", constLabels: {}, variableLabels: {}}: collect error
 `
 	wantOKBody1 := `# HELP name docstring
 # TYPE name counter

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -963,9 +963,9 @@ func checkDescConsistency(
 	// Is the desc consistent with the content of the metric?
 	lpsFromDesc := make([]*dto.LabelPair, len(desc.constLabelPairs), len(dtoMetric.Label))
 	copy(lpsFromDesc, desc.constLabelPairs)
-	for _, l := range desc.variableLabels {
+	for _, l := range desc.variableLabels.names {
 		lpsFromDesc = append(lpsFromDesc, &dto.LabelPair{
-			Name: proto.String(l.Name),
+			Name: proto.String(l),
 		})
 	}
 	if len(lpsFromDesc) != len(dtoMetric.Label) {

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -188,12 +188,12 @@ func NewSummary(opts SummaryOpts) Summary {
 }
 
 func newSummary(desc *Desc, opts SummaryOpts, labelValues ...string) Summary {
-	if len(desc.variableLabels) != len(labelValues) {
-		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.labelNames(), labelValues))
+	if len(desc.variableLabels.names) != len(labelValues) {
+		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, labelValues))
 	}
 
-	for _, n := range desc.variableLabels {
-		if n.Name == quantileLabel {
+	for _, n := range desc.variableLabels.names {
+		if n == quantileLabel {
 			panic(errQuantileLabelNotAllowed)
 		}
 	}
@@ -737,7 +737,7 @@ func NewConstSummary(
 	if desc.err != nil {
 		return nil, desc.err
 	}
-	if err := validateLabelValues(labelValues, len(desc.variableLabels)); err != nil {
+	if err := validateLabelValues(labelValues, len(desc.variableLabels.names)); err != nil {
 		return nil, err
 	}
 	return &constSummary{

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -105,7 +105,7 @@ func NewConstMetric(desc *Desc, valueType ValueType, value float64, labelValues 
 	if desc.err != nil {
 		return nil, desc.err
 	}
-	if err := validateLabelValues(labelValues, len(desc.variableLabels)); err != nil {
+	if err := validateLabelValues(labelValues, len(desc.variableLabels.names)); err != nil {
 		return nil, err
 	}
 
@@ -176,19 +176,19 @@ func populateMetric(
 // This function is only needed for custom Metric implementations. See MetricVec
 // example.
 func MakeLabelPairs(desc *Desc, labelValues []string) []*dto.LabelPair {
-	totalLen := len(desc.variableLabels) + len(desc.constLabelPairs)
+	totalLen := len(desc.variableLabels.names) + len(desc.constLabelPairs)
 	if totalLen == 0 {
 		// Super fast path.
 		return nil
 	}
-	if len(desc.variableLabels) == 0 {
+	if len(desc.variableLabels.names) == 0 {
 		// Moderately fast path.
 		return desc.constLabelPairs
 	}
 	labelPairs := make([]*dto.LabelPair, 0, totalLen)
-	for i, l := range desc.variableLabels {
+	for i, l := range desc.variableLabels.names {
 		labelPairs = append(labelPairs, &dto.LabelPair{
-			Name:  proto.String(l.Name),
+			Name:  proto.String(l),
 			Value: proto.String(labelValues[i]),
 		})
 	}

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -20,24 +20,6 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-var labelsPool = &sync.Pool{
-	New: func() interface{} {
-		return make(Labels)
-	},
-}
-
-func getLabelsFromPool() Labels {
-	return labelsPool.Get().(Labels)
-}
-
-func putLabelsToPool(labels Labels) {
-	for k := range labels {
-		delete(labels, k)
-	}
-
-	labelsPool.Put(labels)
-}
-
 // MetricVec is a Collector to bundle metrics of the same name that differ in
 // their label values. MetricVec is not used directly but as a building block
 // for implementations of vectors of a given metric type, like GaugeVec,
@@ -91,6 +73,7 @@ func NewMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) *MetricVec {
 // See also the CounterVec example.
 func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 	lvs = constrainLabelValues(m.desc, lvs, m.curry)
+
 	h, err := m.hashLabelValues(lvs)
 	if err != nil {
 		return false
@@ -110,8 +93,8 @@ func (m *MetricVec) DeleteLabelValues(lvs ...string) bool {
 // This method is used for the same purpose as DeleteLabelValues(...string). See
 // there for pros and cons of the two methods.
 func (m *MetricVec) Delete(labels Labels) bool {
-	labels = constrainLabels(m.desc, labels)
-	defer putLabelsToPool(labels)
+	labels, closer := constrainLabels(m.desc, labels)
+	defer closer()
 
 	h, err := m.hashLabels(labels)
 	if err != nil {
@@ -128,8 +111,8 @@ func (m *MetricVec) Delete(labels Labels) bool {
 // Note that curried labels will never be matched if deleting from the curried vector.
 // To match curried labels with DeletePartialMatch, it must be called on the base vector.
 func (m *MetricVec) DeletePartialMatch(labels Labels) int {
-	labels = constrainLabels(m.desc, labels)
-	defer putLabelsToPool(labels)
+	labels, closer := constrainLabels(m.desc, labels)
+	defer closer()
 
 	return m.metricMap.deleteByLabels(labels, m.curry)
 }
@@ -169,11 +152,11 @@ func (m *MetricVec) CurryWith(labels Labels) (*MetricVec, error) {
 		oldCurry = m.curry
 		iCurry   int
 	)
-	for i, label := range m.desc.variableLabels {
-		val, ok := labels[label.Name]
+	for i, labelName := range m.desc.variableLabels.names {
+		val, ok := labels[labelName]
 		if iCurry < len(oldCurry) && oldCurry[iCurry].index == i {
 			if ok {
-				return nil, fmt.Errorf("label name %q is already curried", label.Name)
+				return nil, fmt.Errorf("label name %q is already curried", labelName)
 			}
 			newCurry = append(newCurry, oldCurry[iCurry])
 			iCurry++
@@ -181,7 +164,10 @@ func (m *MetricVec) CurryWith(labels Labels) (*MetricVec, error) {
 			if !ok {
 				continue // Label stays uncurried.
 			}
-			newCurry = append(newCurry, curriedLabelValue{i, label.Constrain(val)})
+			newCurry = append(newCurry, curriedLabelValue{
+				i,
+				m.desc.variableLabels.constrain(labelName, val),
+			})
 		}
 	}
 	if l := len(oldCurry) + len(labels) - len(newCurry); l > 0 {
@@ -250,8 +236,8 @@ func (m *MetricVec) GetMetricWithLabelValues(lvs ...string) (Metric, error) {
 // around MetricVec, implementing a vector for a specific Metric implementation,
 // for example GaugeVec.
 func (m *MetricVec) GetMetricWith(labels Labels) (Metric, error) {
-	labels = constrainLabels(m.desc, labels)
-	defer putLabelsToPool(labels)
+	labels, closer := constrainLabels(m.desc, labels)
+	defer closer()
 
 	h, err := m.hashLabels(labels)
 	if err != nil {
@@ -262,7 +248,7 @@ func (m *MetricVec) GetMetricWith(labels Labels) (Metric, error) {
 }
 
 func (m *MetricVec) hashLabelValues(vals []string) (uint64, error) {
-	if err := validateLabelValues(vals, len(m.desc.variableLabels)-len(m.curry)); err != nil {
+	if err := validateLabelValues(vals, len(m.desc.variableLabels.names)-len(m.curry)); err != nil {
 		return 0, err
 	}
 
@@ -271,7 +257,7 @@ func (m *MetricVec) hashLabelValues(vals []string) (uint64, error) {
 		curry         = m.curry
 		iVals, iCurry int
 	)
-	for i := 0; i < len(m.desc.variableLabels); i++ {
+	for i := 0; i < len(m.desc.variableLabels.names); i++ {
 		if iCurry < len(curry) && curry[iCurry].index == i {
 			h = m.hashAdd(h, curry[iCurry].value)
 			iCurry++
@@ -285,7 +271,7 @@ func (m *MetricVec) hashLabelValues(vals []string) (uint64, error) {
 }
 
 func (m *MetricVec) hashLabels(labels Labels) (uint64, error) {
-	if err := validateValuesInLabels(labels, len(m.desc.variableLabels)-len(m.curry)); err != nil {
+	if err := validateValuesInLabels(labels, len(m.desc.variableLabels.names)-len(m.curry)); err != nil {
 		return 0, err
 	}
 
@@ -294,17 +280,17 @@ func (m *MetricVec) hashLabels(labels Labels) (uint64, error) {
 		curry  = m.curry
 		iCurry int
 	)
-	for i, label := range m.desc.variableLabels {
-		val, ok := labels[label.Name]
+	for i, labelName := range m.desc.variableLabels.names {
+		val, ok := labels[labelName]
 		if iCurry < len(curry) && curry[iCurry].index == i {
 			if ok {
-				return 0, fmt.Errorf("label name %q is already curried", label.Name)
+				return 0, fmt.Errorf("label name %q is already curried", labelName)
 			}
 			h = m.hashAdd(h, curry[iCurry].value)
 			iCurry++
 		} else {
 			if !ok {
-				return 0, fmt.Errorf("label name %q missing in label map", label.Name)
+				return 0, fmt.Errorf("label name %q missing in label map", labelName)
 			}
 			h = m.hashAdd(h, val)
 		}
@@ -482,7 +468,7 @@ func valueMatchesVariableOrCurriedValue(targetValue string, index int, values []
 func matchPartialLabels(desc *Desc, values []string, labels Labels, curry []curriedLabelValue) bool {
 	for l, v := range labels {
 		// Check if the target label exists in our metrics and get the index.
-		varLabelIndex, validLabel := indexOf(l, desc.variableLabels.labelNames())
+		varLabelIndex, validLabel := indexOf(l, desc.variableLabels.names)
 		if validLabel {
 			// Check the value of that label against the target value.
 			// We don't consider curried values in partial matches.
@@ -626,7 +612,7 @@ func matchLabels(desc *Desc, values []string, labels Labels, curry []curriedLabe
 		return false
 	}
 	iCurry := 0
-	for i, k := range desc.variableLabels {
+	for i, k := range desc.variableLabels.names {
 		if iCurry < len(curry) && curry[iCurry].index == i {
 			if values[i] != curry[iCurry].value {
 				return false
@@ -634,7 +620,7 @@ func matchLabels(desc *Desc, values []string, labels Labels, curry []curriedLabe
 			iCurry++
 			continue
 		}
-		if values[i] != labels[k.Name] {
+		if values[i] != labels[k] {
 			return false
 		}
 	}
@@ -644,13 +630,13 @@ func matchLabels(desc *Desc, values []string, labels Labels, curry []curriedLabe
 func extractLabelValues(desc *Desc, labels Labels, curry []curriedLabelValue) []string {
 	labelValues := make([]string, len(labels)+len(curry))
 	iCurry := 0
-	for i, k := range desc.variableLabels {
+	for i, k := range desc.variableLabels.names {
 		if iCurry < len(curry) && curry[iCurry].index == i {
 			labelValues[i] = curry[iCurry].value
 			iCurry++
 			continue
 		}
-		labelValues[i] = labels[k.Name]
+		labelValues[i] = labels[k]
 	}
 	return labelValues
 }
@@ -670,20 +656,37 @@ func inlineLabelValues(lvs []string, curry []curriedLabelValue) []string {
 	return labelValues
 }
 
-func constrainLabels(desc *Desc, labels Labels) Labels {
-	constrainedLabels := getLabelsFromPool()
-	for l, v := range labels {
-		if i, ok := indexOf(l, desc.variableLabels.labelNames()); ok {
-			v = desc.variableLabels[i].Constrain(v)
-		}
+var labelsPool = &sync.Pool{
+	New: func() interface{} {
+		return make(Labels)
+	},
+}
 
-		constrainedLabels[l] = v
+func constrainLabels(desc *Desc, labels Labels) (Labels, func()) {
+	if len(desc.variableLabels.labelConstraints) == 0 {
+		// Fast path when there's no constraints
+		return labels, func() {}
 	}
 
-	return constrainedLabels
+	constrainedLabels := labelsPool.Get().(Labels)
+	for l, v := range labels {
+		constrainedLabels[l] = desc.variableLabels.constrain(l, v)
+	}
+
+	return constrainedLabels, func() {
+		for k := range constrainedLabels {
+			delete(constrainedLabels, k)
+		}
+		labelsPool.Put(constrainedLabels)
+	}
 }
 
 func constrainLabelValues(desc *Desc, lvs []string, curry []curriedLabelValue) []string {
+	if len(desc.variableLabels.labelConstraints) == 0 {
+		// Fast path when there's no constraints
+		return lvs
+	}
+
 	constrainedValues := make([]string, len(lvs))
 	var iCurry, iLVs int
 	for i := 0; i < len(lvs)+len(curry); i++ {
@@ -692,8 +695,11 @@ func constrainLabelValues(desc *Desc, lvs []string, curry []curriedLabelValue) [
 			continue
 		}
 
-		if i < len(desc.variableLabels) {
-			constrainedValues[iLVs] = desc.variableLabels[i].Constrain(lvs[iLVs])
+		if i < len(desc.variableLabels.names) {
+			constrainedValues[iLVs] = desc.variableLabels.constrain(
+				desc.variableLabels.names[i],
+				lvs[iLVs],
+			)
 		} else {
 			constrainedValues[iLVs] = lvs[iLVs]
 		}


### PR DESCRIPTION
Implementing a fast path when there's no constrained label should limit a lot the number of allocations.

Closes #1276 