### PR TITLE
Get variable label names from metric descriptors

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -205,3 +205,12 @@ func (d *Desc) String() string {
 		strings.Join(vlStrings, ","),
 	)
 }
+
+// VariableLabelNames returns the names of all variable labels of the descriptor.
+func (d *Desc) VariableLabelNames() []string {
+	if d.err != nil {
+		return []string{}
+	}
+
+	return append([]string{}, d.variableLabels.labelNames()...)
+}

--- a/prometheus/desc_test.go
+++ b/prometheus/desc_test.go
@@ -28,3 +28,26 @@ func TestNewDescInvalidLabelValues(t *testing.T) {
 		t.Errorf("NewDesc: expected error because: %s", desc.err)
 	}
 }
+
+func TestDescGetVariableLabels(t *testing.T) {
+	desc := NewDesc(
+		"sample_label",
+		"sample label",
+		[]string{"a", "b"},
+		nil,
+	)
+
+	labels := desc.VariableLabelNames()
+
+	if len(labels) != 2 {
+		t.Errorf("Desc.VariableLabelNames: expected 2 variable label, got %d", len(labels))
+	}
+	if labels[0] != "a" {
+		t.Errorf("Desc.VariableLabelNames: expected variable label 'a', got %s", labels[0])
+	}
+
+	labels[0] = "c"
+	if desc.variableLabels.labelNames()[0] != "a" {
+		t.Errorf("Desc.VariableLabelNames: returned slice can mutate Desc properties")
+	}
+}


### PR DESCRIPTION
This change introduces the `*Desc.VariableLabelNames()` function to fetch a slice with the names of all Variable Labels.