### PR TITLE
Extend Counters, Summaries and Histograms with creation timestamp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/json-iterator/go v1.1.12
-	github.com/prometheus/client_model v0.4.0
+	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16
 	github.com/prometheus/common v0.44.0
 	github.com/prometheus/procfs v0.11.1
 	golang.org/x/sys v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus/client_model v0.4.0 h1:5lQXD3cAg1OXBf4Wq03gTrXHeaV0TQvGfUooCfx1yqY=
-github.com/prometheus/client_model v0.4.0/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
+github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 h1:v7DLqVdK4VrYkVD5diGdl4sxJurKJEMnODWRJlxV9oM=
+github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
 github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdOOfY=
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -298,3 +298,40 @@ func TestCounterExemplar(t *testing.T) {
 		t.Error("adding exemplar with oversized labels succeeded")
 	}
 }
+
+func TestCounterCreatedTimestamp(t *testing.T) {
+	now := time.Now()
+	counter := NewCounter(CounterOpts{
+		Name: "test",
+		Help: "test help",
+		now:  func() time.Time { return now },
+	})
+
+	var metric dto.Metric
+	if err := counter.Write(&metric); err != nil {
+		t.Fatal(err)
+	}
+
+	if metric.Counter.CreatedTimestamp.AsTime().Unix() != now.Unix() {
+		t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Counter.CreatedTimestamp.AsTime().Unix())
+	}
+}
+
+func TestCounterVecCreatedTimestamp(t *testing.T) {
+	now := time.Now()
+	counterVec := NewCounterVec(CounterOpts{
+		Name: "test",
+		Help: "test help",
+		now:  func() time.Time { return now },
+	}, []string{"label"})
+	counter := counterVec.WithLabelValues("value")
+
+	var metric dto.Metric
+	if err := counter.Write(&metric); err != nil {
+		t.Fatal(err)
+	}
+
+	if metric.Counter.CreatedTimestamp.AsTime().Unix() != now.Unix() {
+		t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Counter.CreatedTimestamp.AsTime().Unix())
+	}
+}

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -382,7 +382,7 @@ func expectCTsForMetricVecValues(t testing.TB, vec *MetricVec, typ dto.MetricTyp
 		}
 
 		if !gotTs.Equal(ct) {
-			t.Errorf("expected created timestamp for counter with label value %q: %s, got %s", val, ct, gotTs)
+			t.Errorf("expected created timestamp for %s with label value %q: %s, got %s", typ, val, ct, gotTs)
 		}
 	}
 }

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -26,10 +26,13 @@ import (
 )
 
 func TestCounterAdd(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
 	counter := NewCounter(CounterOpts{
 		Name:        "test",
 		Help:        "test help",
 		ConstLabels: Labels{"a": "1", "b": "2"},
+		now:         nowFn,
 	}).(*counter)
 	counter.Inc()
 	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
@@ -66,7 +69,10 @@ func TestCounterAdd(t *testing.T) {
 			{Name: proto.String("a"), Value: proto.String("1")},
 			{Name: proto.String("b"), Value: proto.String("2")},
 		},
-		Counter: &dto.Counter{Value: proto.Float64(67.42)},
+		Counter: &dto.Counter{
+			Value:            proto.Float64(67.42),
+			CreatedTimestamp: timestamppb.New(nowFn()),
+		},
 	}
 	if !proto.Equal(expected, m) {
 		t.Errorf("expected %q, got %q", expected, m)
@@ -139,9 +145,12 @@ func expectPanic(t *testing.T, op func(), errorMsg string) {
 }
 
 func TestCounterAddInf(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
 	counter := NewCounter(CounterOpts{
 		Name: "test",
 		Help: "test help",
+		now:  nowFn,
 	}).(*counter)
 
 	counter.Inc()
@@ -173,7 +182,8 @@ func TestCounterAddInf(t *testing.T) {
 
 	expected := &dto.Metric{
 		Counter: &dto.Counter{
-			Value: proto.Float64(math.Inf(1)),
+			Value:            proto.Float64(math.Inf(1)),
+			CreatedTimestamp: timestamppb.New(nowFn()),
 		},
 	}
 
@@ -183,9 +193,12 @@ func TestCounterAddInf(t *testing.T) {
 }
 
 func TestCounterAddLarge(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
 	counter := NewCounter(CounterOpts{
 		Name: "test",
 		Help: "test help",
+		now:  nowFn,
 	}).(*counter)
 
 	// large overflows the underlying type and should therefore be stored in valBits.
@@ -203,7 +216,8 @@ func TestCounterAddLarge(t *testing.T) {
 
 	expected := &dto.Metric{
 		Counter: &dto.Counter{
-			Value: proto.Float64(large),
+			Value:            proto.Float64(large),
+			CreatedTimestamp: timestamppb.New(nowFn()),
 		},
 	}
 
@@ -213,9 +227,12 @@ func TestCounterAddLarge(t *testing.T) {
 }
 
 func TestCounterAddSmall(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
 	counter := NewCounter(CounterOpts{
 		Name: "test",
 		Help: "test help",
+		now:  nowFn,
 	}).(*counter)
 	small := 0.000000000001
 	counter.Add(small)
@@ -231,7 +248,8 @@ func TestCounterAddSmall(t *testing.T) {
 
 	expected := &dto.Metric{
 		Counter: &dto.Counter{
-			Value: proto.Float64(small),
+			Value:            proto.Float64(small),
+			CreatedTimestamp: timestamppb.New(nowFn()),
 		},
 	}
 

--- a/prometheus/example_metricvec_test.go
+++ b/prometheus/example_metricvec_test.go
@@ -14,6 +14,8 @@
 package prometheus_test
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
@@ -124,7 +126,7 @@ func ExampleMetricVec() {
 	if err != nil || len(metricFamilies) != 1 {
 		panic("unexpected behavior of custom test registry")
 	}
-	printlnNormalized(metricFamilies[0])
+	fmt.Println(toNormalizedJSON(metricFamilies[0]))
 
 	// Output:
 	// {"name":"library_version_info","help":"Versions of the libraries used in this binary.","type":"GAUGE","metric":[{"label":[{"name":"library","value":"k8s.io/client-go"},{"name":"version","value":"0.18.8"}],"gauge":{"value":1}},{"label":[{"name":"library","value":"prometheus/client_golang"},{"name":"version","value":"1.7.1"}],"gauge":{"value":1}}]}

--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -319,6 +319,8 @@ func ExampleSummary() {
 	// internally).
 	metric := &dto.Metric{}
 	temps.Write(metric)
+	// We remove CreatedTimestamp just to make sure the assert below works.
+	metric.Summary.CreatedTimestamp = nil
 
 	printlnNormalized(metric)
 
@@ -355,6 +357,11 @@ func ExampleSummaryVec() {
 	if err != nil || len(metricFamilies) != 1 {
 		panic("unexpected behavior of custom test registry")
 	}
+	// We remove CreatedTimestamp just to make sure the assert below works.
+	for _, m := range metricFamilies[0].Metric {
+		m.Summary.CreatedTimestamp = nil
+	}
+
 	printlnNormalized(metricFamilies[0])
 
 	// Output:
@@ -405,6 +412,9 @@ func ExampleHistogram() {
 	// internally).
 	metric := &dto.Metric{}
 	temps.Write(metric)
+	// We remove CreatedTimestamp just to make sure the assert below works.
+	metric.Histogram.CreatedTimestamp = nil
+
 	printlnNormalized(metric)
 
 	// Output:

--- a/prometheus/expvar_collector_test.go
+++ b/prometheus/expvar_collector_test.go
@@ -81,7 +81,7 @@ func ExampleNewExpvarCollector() {
 		if !strings.Contains(m.Desc().String(), "expvar_memstats") {
 			metric.Reset()
 			m.Write(&metric)
-			metricStrings = append(metricStrings, protoToNormalizedJSON(&metric))
+			metricStrings = append(metricStrings, toNormalizedJSON(&metric))
 		}
 	}
 	sort.Strings(metricStrings)

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -135,7 +135,7 @@ func (g *gauge) Sub(val float64) {
 
 func (g *gauge) Write(out *dto.Metric) error {
 	val := math.Float64frombits(atomic.LoadUint64(&g.valBits))
-	return populateMetric(GaugeValue, val, g.labelPairs, nil, out)
+	return populateMetric(GaugeValue, val, g.labelPairs, nil, out, nil)
 }
 
 // GaugeVec is a Collector that bundles a set of Gauges that all share the same

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -469,6 +469,8 @@ func TestHistogramExemplar(t *testing.T) {
 }
 
 func TestNativeHistogram(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
 	scenarios := []struct {
 		name             string
 		observations     []float64 // With simulated interval of 1m.
@@ -499,17 +501,19 @@ func TestNativeHistogram(t *testing.T) {
 					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(5)},
 					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(10)},
 				},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
 			name:   "no observations",
 			factor: 1.1,
 			want: &dto.Histogram{
-				SampleCount:   proto.Uint64(0),
-				SampleSum:     proto.Float64(0),
-				Schema:        proto.Int32(3),
-				ZeroThreshold: proto.Float64(2.938735877055719e-39),
-				ZeroCount:     proto.Uint64(0),
+				SampleCount:      proto.Uint64(0),
+				SampleSum:        proto.Float64(0),
+				Schema:           proto.Int32(3),
+				ZeroThreshold:    proto.Float64(2.938735877055719e-39),
+				ZeroCount:        proto.Uint64(0),
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -525,6 +529,7 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(0)},
 				},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -542,7 +547,8 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(1)},
 					{Offset: proto.Int32(4), Length: proto.Uint32(1)},
 				},
-				PositiveDelta: []int64{1, 0, 0},
+				PositiveDelta:    []int64{1, 0, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -558,7 +564,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				PositiveDelta: []int64{1, -1, 2, -2, 2},
+				PositiveDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -581,7 +588,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(-2), Length: proto.Uint32(6)},
 				},
-				PositiveDelta: []int64{2, 0, 0, 2, -1, -2},
+				PositiveDelta:    []int64{2, 0, 0, 2, -1, -2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -602,7 +610,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(-1), Length: proto.Uint32(4)},
 				},
-				PositiveDelta: []int64{2, 2, 3, -6},
+				PositiveDelta:    []int64{2, 2, 3, -6},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -618,7 +627,8 @@ func TestNativeHistogram(t *testing.T) {
 				NegativeSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				NegativeDelta: []int64{1, -1, 2, -2, 2},
+				NegativeDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -638,7 +648,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				PositiveDelta: []int64{1, -1, 2, -2, 2},
+				PositiveDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -659,7 +670,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(4), Length: proto.Uint32(1)},
 				},
-				PositiveDelta: []int64{2},
+				PositiveDelta:    []int64{2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -675,7 +687,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				PositiveDelta: []int64{1, -1, 2, -2, 2},
+				PositiveDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -692,7 +705,8 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 					{Offset: proto.Int32(4092), Length: proto.Uint32(1)},
 				},
-				PositiveDelta: []int64{1, -1, 2, -2, 2, -1},
+				PositiveDelta:    []int64{1, -1, 2, -2, 2, -1},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -712,7 +726,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				PositiveDelta: []int64{1, -1, 2, -2, 2},
+				PositiveDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -729,7 +744,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				PositiveDelta: []int64{1, -1, 2, -2, 2},
+				PositiveDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -746,7 +762,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				PositiveDelta: []int64{1, 2, -1, -2, 1},
+				PositiveDelta:    []int64{1, 2, -1, -2, 1},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -764,7 +781,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(1), Length: proto.Uint32(7)},
 				},
-				PositiveDelta: []int64{1, 1, -2, 2, -2, 0, 1},
+				PositiveDelta:    []int64{1, 1, -2, 2, -2, 0, 1},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -782,7 +800,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(2), Length: proto.Uint32(7)},
 				},
-				PositiveDelta: []int64{2, -2, 2, -2, 0, 1, 0},
+				PositiveDelta:    []int64{2, -2, 2, -2, 0, 1, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -801,7 +820,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
-				PositiveDelta: []int64{1, 0},
+				PositiveDelta:    []int64{1, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -818,7 +838,8 @@ func TestNativeHistogram(t *testing.T) {
 				NegativeSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				NegativeDelta: []int64{1, -1, 2, -2, 2},
+				NegativeDelta:    []int64{1, -1, 2, -2, 2},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -835,7 +856,8 @@ func TestNativeHistogram(t *testing.T) {
 				NegativeSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
-				NegativeDelta: []int64{1, 2, -1, -2, 1},
+				NegativeDelta:    []int64{1, 2, -1, -2, 1},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -853,7 +875,8 @@ func TestNativeHistogram(t *testing.T) {
 				NegativeSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(1), Length: proto.Uint32(7)},
 				},
-				NegativeDelta: []int64{1, 1, -2, 2, -2, 0, 1},
+				NegativeDelta:    []int64{1, 1, -2, 2, -2, 0, 1},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -871,7 +894,8 @@ func TestNativeHistogram(t *testing.T) {
 				NegativeSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(2), Length: proto.Uint32(7)},
 				},
-				NegativeDelta: []int64{2, -2, 2, -2, 0, 1, 0},
+				NegativeDelta:    []int64{2, -2, 2, -2, 0, 1, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -890,7 +914,8 @@ func TestNativeHistogram(t *testing.T) {
 				NegativeSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
-				NegativeDelta: []int64{1, 0},
+				NegativeDelta:    []int64{1, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -908,7 +933,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
-				PositiveDelta: []int64{1, 0},
+				PositiveDelta:    []int64{1, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 		{
@@ -927,7 +953,8 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
-				PositiveDelta: []int64{1, 0},
+				PositiveDelta:    []int64{1, 0},
+				CreatedTimestamp: timestamppb.New(nowFn()),
 			},
 		},
 	}
@@ -942,6 +969,7 @@ func TestNativeHistogram(t *testing.T) {
 				NativeHistogramMaxBucketNumber:  s.maxBuckets,
 				NativeHistogramMinResetDuration: s.minResetDuration,
 				NativeHistogramMaxZeroThreshold: s.maxZeroThreshold,
+				now:                             nowFn,
 			})
 			ts := time.Now().Add(30 * time.Second)
 			now := func() time.Time {

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -1152,3 +1152,44 @@ func TestGetLe(t *testing.T) {
 		}
 	}
 }
+
+func TestHistogramCreatedTimestamp(t *testing.T) {
+	now := time.Now()
+
+	histogram := NewHistogram(HistogramOpts{
+		Name:    "test",
+		Help:    "test help",
+		Buckets: []float64{1, 2, 3, 4},
+		now:     func() time.Time { return now },
+	})
+
+	var metric dto.Metric
+	if err := histogram.Write(&metric); err != nil {
+		t.Fatal(err)
+	}
+
+	if metric.Histogram.CreatedTimestamp.AsTime().Unix() != now.Unix() {
+		t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Histogram.CreatedTimestamp.AsTime().Unix())
+	}
+}
+
+func TestHistogramVecCreatedTimestamp(t *testing.T) {
+	now := time.Now()
+
+	histogramVec := NewHistogramVec(HistogramOpts{
+		Name:    "test",
+		Help:    "test help",
+		Buckets: []float64{1, 2, 3, 4},
+		now:     func() time.Time { return now },
+	}, []string{"label"})
+	histogram := histogramVec.WithLabelValues("value").(Histogram)
+
+	var metric dto.Metric
+	if err := histogram.Write(&metric); err != nil {
+		t.Fatal(err)
+	}
+
+	if metric.Histogram.CreatedTimestamp.AsTime().Unix() != now.Unix() {
+		t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Histogram.CreatedTimestamp.AsTime().Unix())
+	}
+}

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -416,8 +416,8 @@ func TestHistogramExemplar(t *testing.T) {
 		Name:    "test",
 		Help:    "test help",
 		Buckets: []float64{1, 2, 3, 4},
+		now:     func() time.Time { return now },
 	}).(*histogram)
-	histogram.now = func() time.Time { return now }
 
 	ts := timestamppb.New(now)
 	if err := ts.CheckValid(); err != nil {
@@ -470,7 +470,7 @@ func TestHistogramExemplar(t *testing.T) {
 
 func TestNativeHistogram(t *testing.T) {
 	now := time.Now()
-	nowFn := func() time.Time { return now }
+
 	scenarios := []struct {
 		name             string
 		observations     []float64 // With simulated interval of 1m.
@@ -501,7 +501,7 @@ func TestNativeHistogram(t *testing.T) {
 					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(5)},
 					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(10)},
 				},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -513,7 +513,7 @@ func TestNativeHistogram(t *testing.T) {
 				Schema:           proto.Int32(3),
 				ZeroThreshold:    proto.Float64(2.938735877055719e-39),
 				ZeroCount:        proto.Uint64(0),
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -529,7 +529,7 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(0)},
 				},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -548,7 +548,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(4), Length: proto.Uint32(1)},
 				},
 				PositiveDelta:    []int64{1, 0, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -565,7 +565,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -589,7 +589,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(-2), Length: proto.Uint32(6)},
 				},
 				PositiveDelta:    []int64{2, 0, 0, 2, -1, -2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -611,7 +611,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(-1), Length: proto.Uint32(4)},
 				},
 				PositiveDelta:    []int64{2, 2, 3, -6},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -628,7 +628,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				NegativeDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -649,7 +649,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -671,7 +671,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(4), Length: proto.Uint32(1)},
 				},
 				PositiveDelta:    []int64{2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -688,7 +688,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -706,7 +706,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(4092), Length: proto.Uint32(1)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2, -1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -727,7 +727,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -745,7 +745,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -763,7 +763,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, 2, -1, -2, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -782,7 +782,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(1), Length: proto.Uint32(7)},
 				},
 				PositiveDelta:    []int64{1, 1, -2, 2, -2, 0, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -801,7 +801,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(2), Length: proto.Uint32(7)},
 				},
 				PositiveDelta:    []int64{2, -2, 2, -2, 0, 1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -821,7 +821,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				PositiveDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(8 * time.Minute)), // We expect reset to happen after 8 observations.
 			},
 		},
 		{
@@ -839,7 +839,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				NegativeDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -857,7 +857,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				NegativeDelta:    []int64{1, 2, -1, -2, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -876,7 +876,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(1), Length: proto.Uint32(7)},
 				},
 				NegativeDelta:    []int64{1, 1, -2, 2, -2, 0, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -895,7 +895,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(2), Length: proto.Uint32(7)},
 				},
 				NegativeDelta:    []int64{2, -2, 2, -2, 0, 1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -915,7 +915,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				NegativeDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(8 * time.Minute)), // We expect reset to happen after 8 observations.
 			},
 		},
 		{
@@ -934,7 +934,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				PositiveDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(10 * time.Minute)), // We expect reset to happen after 9 minutes.
 			},
 		},
 		{
@@ -954,13 +954,15 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				PositiveDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(10 * time.Minute)), // We expect reset to happen after 9 minutes.
 			},
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
+			ts := now
+
 			his := NewHistogram(HistogramOpts{
 				Name:                            "name",
 				Help:                            "help",
@@ -969,13 +971,10 @@ func TestNativeHistogram(t *testing.T) {
 				NativeHistogramMaxBucketNumber:  s.maxBuckets,
 				NativeHistogramMinResetDuration: s.minResetDuration,
 				NativeHistogramMaxZeroThreshold: s.maxZeroThreshold,
-				now:                             nowFn,
+				now:                             func() time.Time { return ts },
 			})
-			ts := time.Now().Add(30 * time.Second)
-			now := func() time.Time {
-				return ts
-			}
-			his.(*histogram).now = now
+
+			ts = ts.Add(time.Minute)
 			for _, o := range s.observations {
 				his.Observe(o)
 				ts = ts.Add(time.Minute)
@@ -1000,6 +999,8 @@ func TestNativeHistogramConcurrency(t *testing.T) {
 	rand.Seed(42)
 
 	it := func(n uint32) bool {
+		ts := time.Now().Add(30 * time.Second).Unix()
+
 		mutations := int(n%1e4 + 1e4)
 		concLevel := int(n%5 + 1)
 		total := mutations * concLevel
@@ -1016,13 +1017,10 @@ func TestNativeHistogramConcurrency(t *testing.T) {
 			NativeHistogramMaxBucketNumber:  50,
 			NativeHistogramMinResetDuration: time.Hour, // Comment out to test for totals below.
 			NativeHistogramMaxZeroThreshold: 0.001,
+			now: func() time.Time {
+				return time.Unix(atomic.LoadInt64(&ts), 0)
+			},
 		})
-
-		ts := time.Now().Add(30 * time.Second).Unix()
-		now := func() time.Time {
-			return time.Unix(atomic.LoadInt64(&ts), 0)
-		}
-		his.(*histogram).now = now
 
 		allVars := make([]float64, total)
 		var sampleSum float64
@@ -1220,4 +1218,42 @@ func TestHistogramVecCreatedTimestamp(t *testing.T) {
 	if metric.Histogram.CreatedTimestamp.AsTime().Unix() != now.Unix() {
 		t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Histogram.CreatedTimestamp.AsTime().Unix())
 	}
+}
+
+func TestHistogramVecCreatedTimestampWithDeletes(t *testing.T) {
+	now := time.Now()
+
+	histogramVec := NewHistogramVec(HistogramOpts{
+		Name:    "test",
+		Help:    "test help",
+		Buckets: []float64{1, 2, 3, 4},
+		now:     func() time.Time { return now },
+	}, []string{"label"})
+
+	// First use of "With" should populate CT.
+	histogramVec.WithLabelValues("1")
+	expected := map[string]time.Time{"1": now}
+
+	now = now.Add(1 * time.Hour)
+	expectCTsForMetricVecValues(t, histogramVec.MetricVec, dto.MetricType_HISTOGRAM, expected)
+
+	// Two more labels at different times.
+	histogramVec.WithLabelValues("2")
+	expected["2"] = now
+
+	now = now.Add(1 * time.Hour)
+
+	histogramVec.WithLabelValues("3")
+	expected["3"] = now
+
+	now = now.Add(1 * time.Hour)
+	expectCTsForMetricVecValues(t, histogramVec.MetricVec, dto.MetricType_HISTOGRAM, expected)
+
+	// Recreate metric instance should reset created timestamp to now.
+	histogramVec.DeleteLabelValues("1")
+	histogramVec.WithLabelValues("1")
+	expected["1"] = now
+
+	now = now.Add(1 * time.Hour)
+	expectCTsForMetricVecValues(t, histogramVec.MetricVec, dto.MetricType_HISTOGRAM, expected)
 }

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -93,7 +93,8 @@ type Opts struct {
 	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels
 	ConstLabels Labels
 
-	now func() time.Time // For testing, all constructors put time.Now() here.
+	// now is for testing purposes, by default it's time.Now.
+	now func() time.Time
 }
 
 // BuildFQName joins the given three name components by "_". Empty name

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -92,6 +92,8 @@ type Opts struct {
 	// machine_role metric). See also
 	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels
 	ConstLabels Labels
+
+	now func() time.Time // For testing, all constructors put time.Now() here.
 }
 
 // BuildFQName joins the given three name components by "_". Empty name

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -37,6 +37,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // uncheckedCollector wraps a Collector but its Describe method yields no Desc.
@@ -138,7 +139,8 @@ metric: <
 					},
 				},
 				Counter: &dto.Counter{
-					Value: proto.Float64(1),
+					Value:            proto.Float64(1),
+					CreatedTimestamp: timestamppb.New(time.Now()),
 				},
 			},
 			{
@@ -153,7 +155,8 @@ metric: <
 					},
 				},
 				Counter: &dto.Counter{
-					Value: proto.Float64(1),
+					Value:            proto.Float64(1),
+					CreatedTimestamp: timestamppb.New(time.Now()),
 				},
 			},
 		},

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -147,7 +147,8 @@ type SummaryOpts struct {
 	// "github.com/bmizerany/perks/quantile").
 	BufCap uint32
 
-	now func() time.Time // For testing, all constructors put time.Now() here.
+	// now is for testing purposes, by default it's time.Now.
+	now func() time.Time
 }
 
 // SummaryVecOpts bundles the options to create a SummaryVec metric.
@@ -252,7 +253,7 @@ func newSummary(desc *Desc, opts SummaryOpts, labelValues ...string) Summary {
 		coldBuf:        make([]float64, 0, opts.BufCap),
 		streamDuration: opts.MaxAge / time.Duration(opts.AgeBuckets),
 	}
-	s.headStreamExpTime = time.Now().Add(s.streamDuration)
+	s.headStreamExpTime = opts.now().Add(s.streamDuration)
 	s.hotBufExpTime = s.headStreamExpTime
 
 	for i := uint32(0); i < opts.AgeBuckets; i++ {

--- a/prometheus/summary_test.go
+++ b/prometheus/summary_test.go
@@ -420,3 +420,78 @@ func getBounds(vars []float64, q, ε float64) (min, max float64) {
 	}
 	return
 }
+
+func TestSummaryCreatedTimestamp(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		objectives map[float64]float64
+	}{
+		{
+			desc: "summary with objectives",
+			objectives: map[float64]float64{
+				1.0: 1.0,
+			},
+		},
+		{
+			desc:       "no objectives summary",
+			objectives: nil,
+		},
+	}
+	now := time.Now()
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			summary := NewSummary(SummaryOpts{
+				Name:       "test",
+				Help:       "test help",
+				Objectives: test.objectives,
+				now:        func() time.Time { return now },
+			})
+
+			var metric dto.Metric
+			summary.Write(&metric)
+
+			if metric.Summary.CreatedTimestamp.AsTime().Unix() != now.Unix() {
+				t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Summary.CreatedTimestamp.AsTime().Unix())
+			}
+		})
+	}
+}
+
+func TestSummaryVecCreatedTimestamp(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		objectives map[float64]float64
+	}{
+		{
+			desc: "summary with objectives",
+			objectives: map[float64]float64{
+				1.0: 1.0,
+			},
+		},
+		{
+			desc:       "no objectives summary",
+			objectives: nil,
+		},
+	}
+	now := time.Now()
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			summaryVec := NewSummaryVec(SummaryOpts{
+				Name:       "test",
+				Help:       "test help",
+				Objectives: test.objectives,
+				now:        func() time.Time { return now },
+			},
+				[]string{"label"})
+			summary := summaryVec.WithLabelValues("value").(Summary)
+			var metric dto.Metric
+			summary.Write(&metric)
+
+			if metric.Summary.CreatedTimestamp.AsTime().Unix() != now.Unix() {
+				t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Summary.CreatedTimestamp.AsTime().Unix())
+			}
+		})
+	}
+}

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -144,11 +144,11 @@ func NewConstMetricWithCreatedTimestamp(desc *Desc, valueType ValueType, value f
 	case CounterValue:
 		break
 	default:
-		return nil, errors.New("Created timestamps are only supported for counters")
+		return nil, errors.New("created timestamps are only supported for counters")
 	}
 
 	metric := &dto.Metric{}
-	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric, &ct); err != nil {
+	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric, timestamppb.New(ct)); err != nil {
 		return nil, err
 	}
 
@@ -191,15 +191,11 @@ func populateMetric(
 	labelPairs []*dto.LabelPair,
 	e *dto.Exemplar,
 	m *dto.Metric,
-	createdTimestamp *time.Time,
+	ct *timestamppb.Timestamp,
 ) error {
 	m.Label = labelPairs
 	switch t {
 	case CounterValue:
-		var ct *timestamppb.Timestamp
-		if createdTimestamp != nil {
-			ct = timestamppb.New(*createdTimestamp)
-		}
 		m.Counter = &dto.Counter{Value: proto.Float64(v), Exemplar: e, CreatedTimestamp: ct}
 	case GaugeValue:
 		m.Gauge = &dto.Gauge{Value: proto.Float64(v)}

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -14,6 +14,7 @@
 package prometheus
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -91,7 +92,7 @@ func (v *valueFunc) Desc() *Desc {
 }
 
 func (v *valueFunc) Write(out *dto.Metric) error {
-	return populateMetric(v.valType, v.function(), v.labelPairs, nil, out)
+	return populateMetric(v.valType, v.function(), v.labelPairs, nil, out, nil)
 }
 
 // NewConstMetric returns a metric with one fixed value that cannot be
@@ -110,7 +111,7 @@ func NewConstMetric(desc *Desc, valueType ValueType, value float64, labelValues 
 	}
 
 	metric := &dto.Metric{}
-	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric); err != nil {
+	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric, nil); err != nil {
 		return nil, err
 	}
 
@@ -124,6 +125,43 @@ func NewConstMetric(desc *Desc, valueType ValueType, value float64, labelValues 
 // NewConstMetric would have returned an error.
 func MustNewConstMetric(desc *Desc, valueType ValueType, value float64, labelValues ...string) Metric {
 	m, err := NewConstMetric(desc, valueType, value, labelValues...)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// NewConstMetricWithCreatedTimestamp does the same thing as NewConstMetric, but generates Counters
+// with created timestamp set and returns an error for other metric types.
+func NewConstMetricWithCreatedTimestamp(desc *Desc, valueType ValueType, value float64, ct time.Time, labelValues ...string) (Metric, error) {
+	if desc.err != nil {
+		return nil, desc.err
+	}
+	if err := validateLabelValues(labelValues, len(desc.variableLabels.names)); err != nil {
+		return nil, err
+	}
+	switch valueType {
+	case CounterValue:
+		break
+	default:
+		return nil, errors.New("Created timestamps are only supported for counters")
+	}
+
+	metric := &dto.Metric{}
+	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric, &ct); err != nil {
+		return nil, err
+	}
+
+	return &constMetric{
+		desc:   desc,
+		metric: metric,
+	}, nil
+}
+
+// MustNewConstMetricWithCreatedTimestamp is a version of NewConstMetricWithCreatedTimestamp that panics where
+// NewConstMetricWithCreatedTimestamp would have returned an error.
+func MustNewConstMetricWithCreatedTimestamp(desc *Desc, valueType ValueType, value float64, ct time.Time, labelValues ...string) Metric {
+	m, err := NewConstMetricWithCreatedTimestamp(desc, valueType, value, ct, labelValues...)
 	if err != nil {
 		panic(err)
 	}
@@ -153,11 +191,16 @@ func populateMetric(
 	labelPairs []*dto.LabelPair,
 	e *dto.Exemplar,
 	m *dto.Metric,
+	createdTimestamp *time.Time,
 ) error {
 	m.Label = labelPairs
 	switch t {
 	case CounterValue:
-		m.Counter = &dto.Counter{Value: proto.Float64(v), Exemplar: e}
+		var ct *timestamppb.Timestamp
+		if createdTimestamp != nil {
+			ct = timestamppb.New(*createdTimestamp)
+		}
+		m.Counter = &dto.Counter{Value: proto.Float64(v), Exemplar: e, CreatedTimestamp: ct}
 	case GaugeValue:
 		m.Gauge = &dto.Gauge{Value: proto.Float64(v)}
 	case UntypedValue:

--- a/prometheus/value_test.go
+++ b/prometheus/value_test.go
@@ -61,7 +61,8 @@ func TestNewConstMetricInvalidLabelValues(t *testing.T) {
 
 func TestNewConstMetricWithCreatedTimestamp(t *testing.T) {
 	now := time.Now()
-	testCases := []struct {
+
+	for _, tcase := range []struct {
 		desc             string
 		metricType       ValueType
 		createdTimestamp time.Time
@@ -82,30 +83,27 @@ func TestNewConstMetricWithCreatedTimestamp(t *testing.T) {
 			expecErr:         false,
 			expectedCt:       timestamppb.New(now),
 		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
+	} {
+		t.Run(tcase.desc, func(t *testing.T) {
 			metricDesc := NewDesc(
 				"sample_value",
 				"sample value",
 				nil,
 				nil,
 			)
-			m, err := NewConstMetricWithCreatedTimestamp(metricDesc, test.metricType, float64(1), test.createdTimestamp)
-			if test.expecErr && err == nil {
-				t.Errorf("Expected error is test %s, got no err", test.desc)
+			m, err := NewConstMetricWithCreatedTimestamp(metricDesc, tcase.metricType, float64(1), tcase.createdTimestamp)
+			if tcase.expecErr && err == nil {
+				t.Errorf("Expected error is test %s, got no err", tcase.desc)
 			}
-			if !test.expecErr && err != nil {
-				t.Errorf("Didn't expect error in test %s, got %s", test.desc, err.Error())
+			if !tcase.expecErr && err != nil {
+				t.Errorf("Didn't expect error in test %s, got %s", tcase.desc, err.Error())
 			}
 
-			if test.expectedCt != nil {
+			if tcase.expectedCt != nil {
 				var metric dto.Metric
 				m.Write(&metric)
-				if metric.Counter.CreatedTimestamp.AsTime() != test.expectedCt.AsTime() {
-					t.Errorf("Expected timestamp %v, got %v", test.expectedCt, &metric.Counter.CreatedTimestamp)
+				if metric.Counter.CreatedTimestamp.AsTime() != tcase.expectedCt.AsTime() {
+					t.Errorf("Expected timestamp %v, got %v", tcase.expectedCt, &metric.Counter.CreatedTimestamp)
 				}
 			}
 		})

--- a/prometheus/wrap_test.go
+++ b/prometheus/wrap_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
@@ -43,9 +44,12 @@ func toMetricFamilies(cs ...Collector) []*dto.MetricFamily {
 }
 
 func TestWrap(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
 	simpleCnt := NewCounter(CounterOpts{
 		Name: "simpleCnt",
 		Help: "helpSimpleCnt",
+		now:  nowFn,
 	})
 	simpleCnt.Inc()
 
@@ -58,6 +62,7 @@ func TestWrap(t *testing.T) {
 	preCnt := NewCounter(CounterOpts{
 		Name: "pre_simpleCnt",
 		Help: "helpSimpleCnt",
+		now:  nowFn,
 	})
 	preCnt.Inc()
 
@@ -65,6 +70,7 @@ func TestWrap(t *testing.T) {
 		Name:        "simpleCnt",
 		Help:        "helpSimpleCnt",
 		ConstLabels: Labels{"foo": "bar"},
+		now:         nowFn,
 	})
 	barLabeledCnt.Inc()
 
@@ -72,6 +78,7 @@ func TestWrap(t *testing.T) {
 		Name:        "simpleCnt",
 		Help:        "helpSimpleCnt",
 		ConstLabels: Labels{"foo": "baz"},
+		now:         nowFn,
 	})
 	bazLabeledCnt.Inc()
 
@@ -79,6 +86,7 @@ func TestWrap(t *testing.T) {
 		Name:        "pre_simpleCnt",
 		Help:        "helpSimpleCnt",
 		ConstLabels: Labels{"foo": "bar"},
+		now:         nowFn,
 	})
 	labeledPreCnt.Inc()
 
@@ -86,6 +94,7 @@ func TestWrap(t *testing.T) {
 		Name:        "pre_simpleCnt",
 		Help:        "helpSimpleCnt",
 		ConstLabels: Labels{"foo": "bar", "dings": "bums"},
+		now:         nowFn,
 	})
 	twiceLabeledPreCnt.Inc()
 


### PR DESCRIPTION
Following our [design doc](https://docs.google.com/document/d/1kakDVn8aP1JerimLeazuMfy2jaB14W2kZDHMRokPcv4/edit), this PR aims to add created timestamp to counters, summaries, and histograms when using Prometheus protobuf.

