### PR TITLE
docs: trivial grammar fixes to improve readability in promauto Godoc

### DIFF
--- a/prometheus/promauto/auto.go
+++ b/prometheus/promauto/auto.go
@@ -17,7 +17,7 @@
 // constructors register the Collectors with a registry before returning them.
 // There are two sets of constructors. The constructors in the first set are
 // top-level functions, while the constructors in the other set are methods of
-// the Factory type. The top-level function return Collectors registered with
+// the Factory type. The top-level functions return Collectors registered with
 // the global registry (prometheus.DefaultRegisterer), while the methods return
 // Collectors registered with the registry the Factory was constructed with. All
 // constructors panic if the registration fails.
@@ -85,7 +85,7 @@
 //	}
 //
 // A Factory is created with the With(prometheus.Registerer) function, which
-// enables two usage pattern. With(prometheus.Registerer) can be called once per
+// enables two usage patterns. With(prometheus.Registerer) can be called once per
 // line:
 //
 //	var (
@@ -153,7 +153,7 @@
 // importing a package.
 //
 // A separate package allows conservative users to entirely ignore it. And
-// whoever wants to use it, will do so explicitly, with an opportunity to read
+// whoever wants to use it will do so explicitly, with an opportunity to read
 // this warning.
 //
 // Enjoy promauto responsibly!


### PR DESCRIPTION
Fix a few typos / grammatical errors in the Godoc comments for promauto. Only trivial stuff but slightly helps readability of the docs.

@bwplotka