### PR TITLE
Cleanup golangci-lint errcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,11 @@ linters-settings:
         #- pkg: "regexp"
         #  desc: "Use github.com/grafana/regexp instead of regexp"
   errcheck:
-    exclude: scripts/errcheck_excludes.txt
+    exclude-functions:
+      # The following 2 methods always return nil as the error
+      - (*github.com/cespare/xxhash/v2.Digest).Write
+      - (*github.com/cespare/xxhash/v2.Digest).WriteString
+      - (*bufio.Writer).WriteRune
   goimports:
     local-prefixes: github.com/prometheus/client_golang
   gofumpt:

--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -1,5 +1,0 @@
-// The following 2 methods always return nil as the error
-(*github.com/cespare/xxhash/v2.Digest).Write
-(*github.com/cespare/xxhash/v2.Digest).WriteString
-
-(*bufio.Writer).WriteRune


### PR DESCRIPTION
Move the errcheck excludes list from an external file to inline in the golangci-lint config file.