### PR TITLE
Deprecated comment should begin with "Deprecated:"

### DIFF
--- a/prometheus/collectors/go_collector_latest.go
+++ b/prometheus/collectors/go_collector_latest.go
@@ -132,16 +132,19 @@ type GoCollectionOption uint32
 
 const (
 	// GoRuntimeMemStatsCollection represents the metrics represented by runtime.MemStats structure.
-	// Deprecated. Use WithGoCollectorMemStatsMetricsDisabled() function to disable those metrics in the collector.
+	//
+	// Deprecated: Use WithGoCollectorMemStatsMetricsDisabled() function to disable those metrics in the collector.
 	GoRuntimeMemStatsCollection GoCollectionOption = 1 << iota
 	// GoRuntimeMetricsCollection is the new set of metrics represented by runtime/metrics package.
-	// Deprecated. Use WithGoCollectorRuntimeMetrics(GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")})
+	//
+	// Deprecated: Use WithGoCollectorRuntimeMetrics(GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")})
 	// function to enable those metrics in the collector.
 	GoRuntimeMetricsCollection
 )
 
 // WithGoCollections allows enabling different collections for Go collector on top of base metrics.
-// Deprecated. Use WithGoCollectorRuntimeMetrics() and WithGoCollectorMemStatsMetricsDisabled() instead to control metrics.
+//
+// Deprecated: Use WithGoCollectorRuntimeMetrics() and WithGoCollectorMemStatsMetricsDisabled() instead to control metrics.
 func WithGoCollections(flags GoCollectionOption) func(options *internal.GoCollectorOptions) {
 	return func(options *internal.GoCollectorOptions) {
 		if flags&GoRuntimeMemStatsCollection == 0 {


### PR DESCRIPTION
This PR changes comments for deprecated functions and consts. From the https://go.dev/blog/godoc:

> To signal that an identifier should not be used, add a paragraph to its doc comment that begins with “Deprecated:” followed by some information about the deprecation.

Without PR's change:
<img width="945" alt="image" src="https://github.com/prometheus/client_golang/assets/3228886/343807b1-980f-46c4-ad3c-057f8462407f">

With change:

<img width="1042" alt="image" src="https://github.com/prometheus/client_golang/assets/3228886/e2838352-25ee-49fd-a87f-cf859ca6f061">
