### PR TITLE
proccess_collector: add wasip1 stub

### DIFF
--- a/prometheus/process_collector_other.go
+++ b/prometheus/process_collector_other.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !js
-// +build !windows,!js
+//go:build !windows && !js && !wasip1
+// +build !windows,!js,!wasip1
 
 package prometheus
 

--- a/prometheus/process_collector_wasip1.go
+++ b/prometheus/process_collector_wasip1.go
@@ -1,0 +1,23 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+func canCollectProcess() bool {
+	return false
+}
+
+func (*processCollector) processCollect(chan<- Metric) {
+	// noop on this platform
+	return
+}

--- a/prometheus/process_collector_wasip1.go
+++ b/prometheus/process_collector_wasip1.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasip1
+// +build wasip1
+
 package prometheus
 
 func canCollectProcess() bool {


### PR DESCRIPTION
This resolves build failures like this when using the wasip1 support:

    # github.com/prometheus/procfs
    ../../../go/pkg/mod/github.com/prometheus/procfs@v0.11.1/fs_statfs_type.go:25:18: undefined: syscall.Statfs_t
    ../../../go/pkg/mod/github.com/prometheus/procfs@v0.11.1/fs_statfs_type.go:26:17: undefined: syscall.Statfs

See https://go.dev/blog/wasi.