### PR TITLE
change api http.client to interface

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -36,14 +36,18 @@ var DefaultRoundTripper http.RoundTripper = &http.Transport{
 	TLSHandshakeTimeout: 10 * time.Second,
 }
 
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Config defines configuration parameters for a new client.
 type Config struct {
 	// The address of the Prometheus to connect to.
 	Address string
 
 	// Client is used by the Client to drive HTTP requests. If not provided,
-	// a new one based on the provided RoundTripper (or DefaultRoundTripper) will be used.
-	Client *http.Client
+	// a new http.Client based on the provided RoundTripper (or DefaultRoundTripper) will be used.
+	Client HttpClient
 
 	// RoundTripper is used by the Client to drive HTTP requests. If not
 	// provided, DefaultRoundTripper will be used.
@@ -57,13 +61,13 @@ func (cfg *Config) roundTripper() http.RoundTripper {
 	return cfg.RoundTripper
 }
 
-func (cfg *Config) client() http.Client {
+func (cfg *Config) client() HttpClient {
 	if cfg.Client == nil {
-		return http.Client{
+		return &http.Client{
 			Transport: cfg.roundTripper(),
 		}
 	}
-	return *cfg.Client
+	return cfg.Client
 }
 
 func (cfg *Config) validate() error {
@@ -101,7 +105,7 @@ func NewClient(cfg Config) (Client, error) {
 
 type httpClient struct {
 	endpoint *url.URL
-	client   http.Client
+	client   HttpClient
 }
 
 func (c *httpClient) URL(ep string, args map[string]string) *url.URL {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -105,7 +105,7 @@ func TestClientURL(t *testing.T) {
 
 		hclient := &httpClient{
 			endpoint: ep,
-			client:   http.Client{Transport: DefaultRoundTripper},
+			client:   &http.Client{Transport: DefaultRoundTripper},
 		}
 
 		u := hclient.URL(test.endpoint, test.args)


### PR DESCRIPTION
Hi there,
The current implementation uses http.Client
The only function which is called for it is `Do(req *http.Request) (*http.Response, error)`
It is desirable to allow other Client implementations, e.g. `github.com/hashicorp/go-retryablehttp/Client` which allows retries on various HTTP status codes like 429 (it has its own `Request` struct but it's easy to wrap it in another struct that will implement the above-mentioned interface). Many commercial solutions implementing Prometheus API (e.g. Grafana Cloud) have rate limiting. Thank you.