### PR TITLE
gocollector: Add regex option to allow collection of debug runtime metrics

### DIFF
--- a/prometheus/collectors/gen_go_collector_set.go
+++ b/prometheus/collectors/gen_go_collector_set.go
@@ -128,7 +128,7 @@ func rm2prom(d metrics.Description) string {
 func groupMetrics(metricsList []string) []metricGroup {
 	var groupedMetrics []metricGroup
 	for _, group := range metricGroups {
-		var matchedMetrics []string
+		matchedMetrics := make([]string, 0)
 		for _, metric := range metricsList {
 			if group.Regex == nil || group.Regex.MatchString(metric) {
 				matchedMetrics = append(matchedMetrics, metric)
@@ -136,13 +136,11 @@ func groupMetrics(metricsList []string) []metricGroup {
 		}
 
 		sort.Strings(matchedMetrics)
-		if len(matchedMetrics) > 0 {
-			groupedMetrics = append(groupedMetrics, metricGroup{
-				Name:    group.Name,
-				Regex:   group.Regex,
-				Metrics: matchedMetrics,
-			})
-		}
+		groupedMetrics = append(groupedMetrics, metricGroup{
+			Name:    group.Name,
+			Regex:   group.Regex,
+			Metrics: matchedMetrics,
+		})
 	}
 	return groupedMetrics
 }

--- a/prometheus/collectors/go_collector_go117_test.go
+++ b/prometheus/collectors/go_collector_go117_test.go
@@ -98,3 +98,7 @@ func withSchedulerMetrics() []string {
 		"go_threads",
 	}
 }
+
+func withDebugMetrics() []string {
+	return withBaseMetrics([]string{})
+}

--- a/prometheus/collectors/go_collector_go119_test.go
+++ b/prometheus/collectors/go_collector_go119_test.go
@@ -105,3 +105,7 @@ func withSchedulerMetrics() []string {
 		"go_threads",
 	}
 }
+
+func withDebugMetrics() []string {
+	return withBaseMetrics([]string{})
+}

--- a/prometheus/collectors/go_collector_go120_test.go
+++ b/prometheus/collectors/go_collector_go120_test.go
@@ -112,3 +112,7 @@ func withSchedulerMetrics() []string {
 		"go_sched_latencies_seconds",
 	})
 }
+
+func withDebugMetrics() []string {
+	return withBaseMetrics([]string{})
+}

--- a/prometheus/collectors/go_collector_latest.go
+++ b/prometheus/collectors/go_collector_latest.go
@@ -37,6 +37,9 @@ var (
 	// MetricsScheduler allows only scheduler metrics to be collected from Go runtime.
 	// e.g. go_sched_goroutines_goroutines
 	MetricsScheduler = GoRuntimeMetricsRule{regexp.MustCompile(`^/sched/.*`)}
+	// MetricsDebug allows only debug metrics to be collected from Go runtime.
+	// e.g. go_godebug_non_default_behavior_gocachetest_events_total
+	MetricsDebug = GoRuntimeMetricsRule{regexp.MustCompile(`^/godebug/.*`)}
 )
 
 // WithGoCollectorMemStatsMetricsDisabled disables metrics that is gathered in runtime.MemStats structure such as:

--- a/prometheus/collectors/go_collector_latest_test.go
+++ b/prometheus/collectors/go_collector_latest_test.go
@@ -105,6 +105,11 @@ func TestGoCollectorAllowList(t *testing.T) {
 			rules:    []GoRuntimeMetricsRule{MetricsScheduler},
 			expected: withSchedulerMetrics(),
 		},
+		{
+			name:     "allow debug",
+			rules:    []GoRuntimeMetricsRule{MetricsDebug},
+			expected: withDebugMetrics(),
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			reg := prometheus.NewRegistry()


### PR DESCRIPTION
At the same time, it also solves the linting problem we're getting on main
