### PR TITLE
Revert "change api http.client to interface"

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -36,18 +36,14 @@ var DefaultRoundTripper http.RoundTripper = &http.Transport{
 	TLSHandshakeTimeout: 10 * time.Second,
 }
 
-type HttpClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // Config defines configuration parameters for a new client.
 type Config struct {
 	// The address of the Prometheus to connect to.
 	Address string
 
 	// Client is used by the Client to drive HTTP requests. If not provided,
-	// a new http.Client based on the provided RoundTripper (or DefaultRoundTripper) will be used.
-	Client HttpClient
+	// a new one based on the provided RoundTripper (or DefaultRoundTripper) will be used.
+	Client *http.Client
 
 	// RoundTripper is used by the Client to drive HTTP requests. If not
 	// provided, DefaultRoundTripper will be used.
@@ -61,13 +57,13 @@ func (cfg *Config) roundTripper() http.RoundTripper {
 	return cfg.RoundTripper
 }
 
-func (cfg *Config) client() HttpClient {
+func (cfg *Config) client() http.Client {
 	if cfg.Client == nil {
-		return &http.Client{
+		return http.Client{
 			Transport: cfg.roundTripper(),
 		}
 	}
-	return cfg.Client
+	return *cfg.Client
 }
 
 func (cfg *Config) validate() error {
@@ -105,7 +101,7 @@ func NewClient(cfg Config) (Client, error) {
 
 type httpClient struct {
 	endpoint *url.URL
-	client   HttpClient
+	client   http.Client
 }
 
 func (c *httpClient) URL(ep string, args map[string]string) *url.URL {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -105,7 +105,7 @@ func TestClientURL(t *testing.T) {
 
 		hclient := &httpClient{
 			endpoint: ep,
-			client:   &http.Client{Transport: DefaultRoundTripper},
+			client:   http.Client{Transport: DefaultRoundTripper},
 		}
 
 		u := hclient.URL(test.endpoint, test.args)


### PR DESCRIPTION
Hi,

Thanks @ArthurSens and @tips for doing the work! However, I think the #1387  change might not be necessary. I explained in https://github.com/prometheus/client_golang/pull/1387#pullrequestreview-1794338682 --let me know if this makes sense. I think we could update the docs to make it more clear.

TL;DR One can achieve the use case mentioned by @tips in many ways currently

```
api.Confg{Config: retryablehttp.StandardClient(}}
```

or

```
api.Confg{Config: &http.Client{Transport: <Your method with (*Request) (*Response, error) semantics>}}
```

Let's avoid additional interfaces which looks 99.999% like standard library ones and avoid allowing multiple ways of doing the same thing.