### PR TITLE
testutil compareMetricFamilies: make less error-prone

### DIFF
--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -277,6 +277,9 @@ func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...str
 	if metricNames != nil {
 		got = filterMetrics(got, metricNames)
 		expected = filterMetrics(expected, metricNames)
+		if len(metricNames) > len(got) {
+			return fmt.Errorf("expected metrics name not found")
+		}
 	}
 
 	return compare(got, expected)

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -278,7 +278,20 @@ func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...str
 		got = filterMetrics(got, metricNames)
 		expected = filterMetrics(expected, metricNames)
 		if len(metricNames) > len(got) {
-			return fmt.Errorf("expected metrics name not found")
+			h := make(map[string]struct{})
+			for _, mf := range got {
+				if mf == nil {
+					continue
+				}
+				h[mf.GetName()] = struct{}{}
+			}
+			var missingMetricNames []string
+			for _, name := range metricNames {
+				if _, ok := h[name]; !ok {
+					missingMetricNames = append(missingMetricNames, name)
+				}
+			}
+			return fmt.Errorf("expected metric name(s) not found: %v", missingMetricNames)
 		}
 	}
 

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -278,16 +278,9 @@ func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...str
 		got = filterMetrics(got, metricNames)
 		expected = filterMetrics(expected, metricNames)
 		if len(metricNames) > len(got) {
-			h := make(map[string]struct{})
-			for _, mf := range got {
-				if mf == nil {
-					continue
-				}
-				h[mf.GetName()] = struct{}{}
-			}
 			var missingMetricNames []string
 			for _, name := range metricNames {
-				if _, ok := h[name]; !ok {
+				if ok := hasMetricByName(got, name); !ok {
 					missingMetricNames = append(missingMetricNames, name)
 				}
 			}
@@ -333,4 +326,13 @@ func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFam
 		}
 	}
 	return filtered
+}
+
+func hasMetricByName(metrics []*dto.MetricFamily, name string) bool {
+	for _, mf := range metrics {
+		if mf.GetName() == name {
+			return true
+		}
+	}
+	return false
 }

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -328,27 +328,32 @@ func TestMetricNotFound(t *testing.T) {
 }
 
 func TestScrapeAndCompare(t *testing.T) {
-	const expected = `
+	scenarios := map[string]struct {
+		want        string
+		metricNames []string
+		errPrefix   string
+		fail        bool
+	}{
+		"empty metric Names": {
+			want: `
 		# HELP some_total A value that represents a counter.
 		# TYPE some_total counter
 
 		some_total{ label1 = "value1" } 1
-	`
+	`,
+			metricNames: []string{},
+		},
+		"one metric": {
+			want: `
+		# HELP some_total A value that represents a counter.
+		# TYPE some_total counter
 
-	expectedReader := strings.NewReader(expected)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, expected)
-	}))
-	defer ts.Close()
-
-	if err := ScrapeAndCompare(ts.URL, expectedReader, "some_total"); err != nil {
-		t.Errorf("unexpected scraping result:\n%s", err)
-	}
-}
-
-func TestScrapeAndCompareWithMultipleExpected(t *testing.T) {
-	const expected = `
+		some_total{ label1 = "value1" } 1
+	`,
+			metricNames: []string{"some_total"},
+		},
+		"multiple expected": {
+			want: `
 		# HELP some_total A value that represents a counter.
 		# TYPE some_total counter
 
@@ -358,53 +363,94 @@ func TestScrapeAndCompareWithMultipleExpected(t *testing.T) {
 		# TYPE some_total2 counter
 
 		some_total2{ label2 = "value2" } 1
-	`
+	`,
+			metricNames: []string{"some_total2"},
+		},
+		"expected metric name is not scraped": {
+			want: `
+		# HELP some_total A value that represents a counter.
+		# TYPE some_total counter
 
-	expectedReader := strings.NewReader(expected)
+		some_total{ label1 = "value1" } 1
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, expected)
-	}))
-	defer ts.Close()
+		# HELP some_total2 A value that represents a counter.
+		# TYPE some_total2 counter
 
-	if err := ScrapeAndCompare(ts.URL, expectedReader, "some_total2"); err != nil {
-		t.Errorf("unexpected scraping result:\n%s", err)
+		some_total2{ label2 = "value2" } 1
+	`,
+			metricNames: []string{"some_total3"},
+			errPrefix:   "expected metrics name not found",
+			fail:        true,
+		},
+		"one of multiple expected metric names is not scraped": {
+			want: `
+		# HELP some_total A value that represents a counter.
+		# TYPE some_total counter
+
+		some_total{ label1 = "value1" } 1
+
+		# HELP some_total2 A value that represents a counter.
+		# TYPE some_total2 counter
+
+		some_total2{ label2 = "value2" } 1
+	`,
+			metricNames: []string{"some_total1", "some_total3"},
+			errPrefix:   "expected metrics name not found",
+			fail:        true,
+		},
 	}
-}
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			expectedReader := strings.NewReader(scenario.want)
 
-func TestScrapeAndCompareFetchingFail(t *testing.T) {
-	err := ScrapeAndCompare("some_url", strings.NewReader("some expectation"), "some_total")
-	if err == nil {
-		t.Errorf("expected an error but got nil")
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, scenario.want)
+			}))
+			defer ts.Close()
+			if err := ScrapeAndCompare(ts.URL, expectedReader, scenario.metricNames...); err != nil {
+				if !scenario.fail || !strings.HasPrefix(err.Error(), scenario.errPrefix) {
+					t.Errorf("unexpected error happened: %s", err)
+				}
+			} else if scenario.fail {
+				t.Errorf("expected an error but got nil")
+			}
+		})
 	}
-	if !strings.HasPrefix(err.Error(), "scraping metrics failed") {
-		t.Errorf("unexpected error happened: %s", err)
-	}
-}
 
-func TestScrapeAndCompareBadStatusCode(t *testing.T) {
-	const expected = `
+	t.Run("fetching fail", func(t *testing.T) {
+		err := ScrapeAndCompare("some_url", strings.NewReader("some expectation"), "some_total")
+		if err == nil {
+			t.Errorf("expected an error but got nil")
+		}
+		if !strings.HasPrefix(err.Error(), "scraping metrics failed") {
+			t.Errorf("unexpected error happened: %s", err)
+		}
+	})
+
+	t.Run("bad status code", func(t *testing.T) {
+		const expected = `
 		# HELP some_total A value that represents a counter.
 		# TYPE some_total counter
 
 		some_total{ label1 = "value1" } 1
 	`
 
-	expectedReader := strings.NewReader(expected)
+		expectedReader := strings.NewReader(expected)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-		fmt.Fprintln(w, expected)
-	}))
-	defer ts.Close()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprintln(w, expected)
+		}))
+		defer ts.Close()
 
-	err := ScrapeAndCompare(ts.URL, expectedReader, "some_total")
-	if err == nil {
-		t.Errorf("expected an error but got nil")
-	}
-	if !strings.HasPrefix(err.Error(), "the scraping target returned a status code other than 200") {
-		t.Errorf("unexpected error happened: %s", err)
-	}
+		err := ScrapeAndCompare(ts.URL, expectedReader, "some_total")
+		if err == nil {
+			t.Errorf("expected an error but got nil")
+		}
+		if !strings.HasPrefix(err.Error(), "the scraping target returned a status code other than 200") {
+			t.Errorf("unexpected error happened: %s", err)
+		}
+	})
 }
 
 func TestCollectAndCount(t *testing.T) {

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -379,7 +379,7 @@ func TestScrapeAndCompare(t *testing.T) {
 		some_total2{ label2 = "value2" } 1
 	`,
 			metricNames: []string{"some_total3"},
-			errPrefix:   "expected metrics name not found",
+			errPrefix:   "expected metric name(s) not found",
 			fail:        true,
 		},
 		"one of multiple expected metric names is not scraped": {
@@ -395,7 +395,7 @@ func TestScrapeAndCompare(t *testing.T) {
 		some_total2{ label2 = "value2" } 1
 	`,
 			metricNames: []string{"some_total1", "some_total3"},
-			errPrefix:   "expected metrics name not found",
+			errPrefix:   "expected metric name(s) not found",
 			fail:        true,
 		},
 	}

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -331,8 +331,8 @@ func TestScrapeAndCompare(t *testing.T) {
 	scenarios := map[string]struct {
 		want        string
 		metricNames []string
-		// expectedErrPrefix if empty, means no fail is expected for the comparison.
-		expectedErrPrefix string
+		// expectedErr if empty, means no fail is expected for the comparison.
+		expectedErr string
 	}{
 		"empty metric Names": {
 			want: `
@@ -378,8 +378,8 @@ func TestScrapeAndCompare(t *testing.T) {
 
 		some_total2{ label2 = "value2" } 1
 	`,
-			metricNames:       []string{"some_total3"},
-			expectedErrPrefix: "expected metric name(s) not found",
+			metricNames: []string{"some_total3"},
+			expectedErr: "expected metric name(s) not found: [some_total3]",
 		},
 		"one of multiple expected metric names is not scraped": {
 			want: `
@@ -393,8 +393,8 @@ func TestScrapeAndCompare(t *testing.T) {
 
 		some_total2{ label2 = "value2" } 1
 	`,
-			metricNames:       []string{"some_total1", "some_total3"},
-			expectedErrPrefix: "expected metric name(s) not found",
+			metricNames: []string{"some_total1", "some_total3"},
+			expectedErr: "expected metric name(s) not found: [some_total1 some_total3]",
 		},
 	}
 	for name, scenario := range scenarios {
@@ -406,10 +406,10 @@ func TestScrapeAndCompare(t *testing.T) {
 			}))
 			defer ts.Close()
 			if err := ScrapeAndCompare(ts.URL, expectedReader, scenario.metricNames...); err != nil {
-				if scenario.expectedErrPrefix == "" || !strings.HasPrefix(err.Error(), scenario.expectedErrPrefix) {
+				if scenario.expectedErr == "" || err.Error() != scenario.expectedErr {
 					t.Errorf("unexpected error happened: %s", err)
 				}
-			} else if scenario.expectedErrPrefix != "" {
+			} else if scenario.expectedErr != "" {
 				t.Errorf("expected an error but got nil")
 			}
 		})


### PR DESCRIPTION
The functions `GatherAndCompare`, `ScrapeAndCompare` and others that use
`compareMetricFamilies` under the hood can return no error if
`metricNames` includes none of the names found in the scraped/gathered
results. To avoid false Positves (an error being the negative case), we
can return an error if there is is at least one name in `metricNames`
that is not in the filtered results.

Fixes: https://github.com/prometheus/client_golang/issues/1351

Signed-off-by: leonnicolas <leonloechner@gmx.de>
