### PR TITLE
[CI]: Add Concurrency Grouping to GitHub Workflows

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,6 +1,10 @@
 name: Dependabot auto-merge
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '31 21 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 # Minimal permissions to be inherited by any job that don't declare it's own permissions
 permissions:
   contents: read

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,10 @@ on:
       - main
       - "release-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 # Minimal permissions to be inherited by any job that don't declare it's own permissions
 permissions:
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,6 +12,10 @@ on:
       - ".golangci.yml"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
 


### PR DESCRIPTION
### What problem is this PR solving?
fixes https://github.com/prometheus/client_golang/issues/1437

### Description of the changes
- Whenever we push commits to a PR, workflows are triggered for that commit. After that, if we push additional commits to this PR, workflows in Github Actions run on both commits.
- We need to cancel the previous run and run only on the most recent pushed commit. This would help save some GitHub Action Minutes (probably not a problem for this project but its always better to same some resources) and unexpected workflow failures on previous commits.

