### PR TITLE
Remove support for go 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        go_version: ["1.19", "1.20", "1.21", "1.22"]
+        go_version: ["1.20", "1.21", "1.22"]
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: deps common-test
 test-short: deps common-test-short
 
 .PHONY: generate-go-collector-test-files
-VERSIONS := 1.19 1.20 1.21 1.22
+VERSIONS := 1.20 1.21 1.22
 generate-go-collector-test-files:
 	for GO_VERSION in $(VERSIONS); do \
 		docker run \

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is the [Go](http://golang.org) client library for
 instrumenting application code, and one for creating clients that talk to the
 Prometheus HTTP API.
 
-**This library requires Go1.19 or later.**
-> The library mandates the use of Go1.19 or subsequent versions. While it has demonstrated functionality with versions as old as Go 1.17, our commitment remains to offer support and rectifications for only the most recent three major releases.
+**This library requires Go1.20 or later.**
+> The library mandates the use of Go1.20 or subsequent versions. While it has demonstrated functionality with versions as old as Go 1.17, our commitment remains to offer support and rectifications for only the most recent three major releases.
 
 ## Important note about releases and stability
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/client_golang
 
-go 1.19
+go 1.20
 
 require (
 	github.com/beorn7/perks v1.0.1

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -157,7 +157,7 @@ func TestHistogramConcurrency(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 
 	it := func(n uint32) bool {
 		mutations := int(n%1e4 + 1e4)
@@ -243,7 +243,7 @@ func TestHistogramVecConcurrency(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 
 	it := func(n uint32) bool {
 		mutations := int(n%1e4 + 1e4)
@@ -1010,7 +1010,7 @@ func TestNativeHistogramConcurrency(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 
 	it := func(n uint32) bool {
 		ts := time.Now().Add(30 * time.Second).Unix()

--- a/prometheus/summary_test.go
+++ b/prometheus/summary_test.go
@@ -203,7 +203,7 @@ func TestSummaryConcurrency(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 	objMap := map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
 
 	it := func(n uint32) bool {
@@ -284,7 +284,7 @@ func TestSummaryVecConcurrency(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 	objMap := map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
 
 	objSlice := make([]float64, 0, len(objMap))


### PR DESCRIPTION
We promise support for the latest 3 major versions of go. With #1445 merged, support for 1.19 is no longer promised.

In addition, the latest release of prometheus/common uses a function only present in go 1.20 (See [workflow logs](https://github.com/prometheus/client_golang/actions/runs/8017443782/job/21901319988?pr=1447) from PR #1447), meaning that we can't upgrade common without bumping our go version.