### PR TITLE
Rephrase incompatibility with common v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.19.0 / 2023-02-27
 
-The module `prometheus/common v0.48.0` introduced a bug when used together with client_golang. If your project uses client_golang and you want to use `prometheus/common v0.48.0` or higher, please update client_golang to v1.19.0.
+The module `prometheus/common v0.48.0` introduced an incompatibility when used together with client_golang (See https://github.com/prometheus/client_golang/pull/1448 for more details). If your project uses client_golang and you want to use `prometheus/common v0.48.0` or higher, please update client_golang to v1.19.0.
 
 * [CHANGE] Minimum required go version is now 1.20 (we also test client_golang against new 1.22 version). #1445 #1449
 * [FEATURE] collectors: Add version collector. #1422 #1427


### PR DESCRIPTION
Stating that it was a bug sounds like the change made upstream was accidental and due to a mistake.

The change was intentional, so let's rephrase our changelog :)