### PR TITLE
feat(prometheus/testutil/promlint/validations): refine lintMetricType…

### DIFF
--- a/prometheus/testutil/promlint/promlint_test.go
+++ b/prometheus/testutil/promlint/promlint_test.go
@@ -668,7 +668,6 @@ func TestLintMetricTypeInName(t *testing.T) {
 		twoProbTest,
 		genTest("instance_memory_limit_bytes_gauge", "gauge", "gauge"),
 		genTest("request_duration_seconds_summary", "summary", "summary"),
-		genTest("request_duration_seconds_summary", "histogram", "summary"),
 		genTest("request_duration_seconds_histogram", "histogram", "histogram"),
 		genTest("request_duration_seconds_HISTOGRAM", "histogram", "histogram"),
 

--- a/prometheus/testutil/promlint/validations/generic_name_validations.go
+++ b/prometheus/testutil/promlint/validations/generic_name_validations.go
@@ -44,21 +44,21 @@ func LintMetricUnits(mf *dto.MetricFamily) []error {
 	return problems
 }
 
-// LintMetricTypeInName detects when metric types are included in the metric name.
+// LintMetricTypeInName detects when the metric type is included in the metric name.
 func LintMetricTypeInName(mf *dto.MetricFamily) []error {
-	var problems []error
-	n := strings.ToLower(mf.GetName())
-
-	for i, t := range dto.MetricType_name {
-		if i == int32(dto.MetricType_UNTYPED) {
-			continue
-		}
-
-		typename := strings.ToLower(t)
-		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
-			problems = append(problems, fmt.Errorf(`metric name should not include type '%s'`, typename))
-		}
+	if mf.GetType() == dto.MetricType_UNTYPED {
+		return nil
 	}
+
+	var problems []error
+
+	n := strings.ToLower(mf.GetName())
+	typename := strings.ToLower(mf.GetType().String())
+
+	if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+		problems = append(problems, fmt.Errorf(`metric name should not include type '%s'`, typename))
+	}
+
 	return problems
 }
 


### PR DESCRIPTION
Change the lintMetricTypeInName linter inside promlint to only trigger an error when the metric name matches the type of the metric.

Resolves:  #1453