### PR TITLE
fix: fix the possible overflow case in the current implementation

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -35,12 +35,10 @@ func TestCounterAddExcess(t *testing.T) {
 	}).(*counter)
 
 	counter.Add(1<<64 - 1)
-	if expected, got := uint64(1<<64-1), counter.valInt; expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
+	if expected, got := float64(1<<64-1), math.Float64frombits(counter.valBits); expected != got {
+		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 
-	// add 1 to value 1<<64-1 will cause an overflow, and then fail the test
-	// the Inc is ditto
 	counter.Add(1)
 	if expected, got := uint64(0), counter.valInt; expected == got {
 		t.Errorf("oops! overflow")


### PR DESCRIPTION
# Possible Overflow

Currently, the `Add` API of Counter and the similar implementation has the overflow problem. I write a test case to demonstrate it by the test case [TestCounterAddExcess](https://github.com/prometheus/client_golang/compare/main...xieyuschen:client_golang:main#diff-6732d569ae11a1997480439357d141b25e6d021d0efbdcffc6b058b1e41266d6R28) in the commit 3227fc0bf8bfe059e1eaaaa0557b41b72524b9c4. And the output verifies the overflow does happen as expected.

```
➜  client_golang git:(3227fc0) go version
go version go1.21.3 darwin/arm64
➜  client_golang git:(3227fc0) go test ./prometheus
--- FAIL: TestCounterAddExcess (0.00s)
    counter_test.go:46: oops! overflow
    counter_test.go:63: failed because the internal overflow
    counter_test.go:69: verify the overflow case
```

# Proposal

I think it's nice to fix it as it's a possible case. I haven't checked much about the history discussions about this topic. As a result, I would like to discuss with the maintainers to see whether you would like to accept such changes or not.

We need to check two additional cases for the possible overflows:
- the input float `v` is large enough so it will lose precise during casting by `uint`.
- the addition overflows

One step further, we can add the `valInt` value into the float set `valBits` and then reset the `valInt` to zero. 

Regards.