### PR TITLE
fix: prevent overflow on counter adding

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -25,6 +25,50 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+func TestCounterAddExcess(t *testing.T) {
+	now := time.Now()
+	counter := NewCounter(CounterOpts{
+		Name:        "test",
+		Help:        "test help",
+		ConstLabels: Labels{"a": "1", "b": "2"},
+		now:         func() time.Time { return now },
+	}).(*counter)
+
+	counter.Add(1 << 63)
+	if expected, got := uint64(1<<63), counter.valInt; expected != got {
+		t.Errorf("Expected %d, got %d.", expected, got)
+	}
+
+	counter.Add(1 << 63)
+	if expected, got := uint64(0), counter.valInt; expected == got {
+		t.Errorf("oops! overflow")
+	}
+
+	m := &dto.Metric{}
+	counter.Write(m)
+
+	expected := &dto.Metric{
+		Label: []*dto.LabelPair{
+			{Name: proto.String("a"), Value: proto.String("1")},
+			{Name: proto.String("b"), Value: proto.String("2")},
+		},
+		Counter: &dto.Counter{
+			Value:            proto.Float64(1 << 64),
+			CreatedTimestamp: timestamppb.New(now),
+		},
+	}
+
+	if !proto.Equal(expected, m) {
+		t.Errorf("failed because the internal overflow")
+	}
+
+	// verify the overflow case
+	expected.Counter.Value = proto.Float64(0)
+	if proto.Equal(expected, m) {
+		t.Errorf("verify the overflow case")
+	}
+}
+
 func TestCounterAdd(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
# Possible Overflow

Currently, the `Add` API of Counter and the similar implementation has the overflow problem. I write a test case to demonstrate it by the test case [TestCounterAddExcess](https://github.com/prometheus/client_golang/compare/main...xieyuschen:client_golang:main#diff-6732d569ae11a1997480439357d141b25e6d021d0efbdcffc6b058b1e41266d6R28) in the commit d222f971e2f5f9518bb69772bfeb34c17e92abdc. And the output verifies the overflow does happen as expected.

```
--- FAIL: TestCounterAddExcess (0.00s)
    /home/xieyuschen/client_golang/prometheus/counter_test.go:44: oops! overflow
    /home/xieyuschen/client_golang/prometheus/counter_test.go:62: failed because the internal overflow
    /home/xieyuschen/client_golang/prometheus/counter_test.go:68: verify the overflow case
FAIL
FAIL	github.com/prometheus/client_golang/prometheus	0.007s
```

# Proposal

I think it's nice to fix it as it's a possible case. I haven't checked much about the history discussions about this topic. As a result, I would like to discuss with the maintainers to see whether you would like to accept such changes or not.

We need to check one more additional cases for the possible overflows, as the `uint()` cast already prevents the precise lost during conversion(for example, 2<<64-1).
- the addition overflows

One step further, we can add the `valInt` value into the float set `valBits` and then reset the `valInt` to zero. 

Regards.