### PR TITLE
Generate with.*Metrics even if empty

### DIFF
--- a/prometheus/collectors/gen_go_collector_set.go
+++ b/prometheus/collectors/gen_go_collector_set.go
@@ -128,7 +128,7 @@ func rm2prom(d metrics.Description) string {
 func groupMetrics(metricsList []string) []metricGroup {
 	var groupedMetrics []metricGroup
 	for _, group := range metricGroups {
-		var matchedMetrics []string
+		matchedMetrics := make([]string, 0)
 		for _, metric := range metricsList {
 			if group.Regex == nil || group.Regex.MatchString(metric) {
 				matchedMetrics = append(matchedMetrics, metric)
@@ -148,13 +148,11 @@ func groupMetrics(metricsList []string) []metricGroup {
 			matchedMetrics = append(matchedMetrics, baseMatrices...)
 		}
 		sort.Strings(matchedMetrics)
-		if len(matchedMetrics) > 0 {
-			groupedMetrics = append(groupedMetrics, metricGroup{
-				Name:    group.Name,
-				Regex:   group.Regex,
-				Metrics: matchedMetrics,
-			})
-		}
+		groupedMetrics = append(groupedMetrics, metricGroup{
+			Name:    group.Name,
+			Regex:   group.Regex,
+			Metrics: matchedMetrics,
+		})
 	}
 	return groupedMetrics
 }

--- a/prometheus/collectors/go_collector_go120_test.go
+++ b/prometheus/collectors/go_collector_go120_test.go
@@ -19,9 +19,6 @@ package collectors
 func withAllMetrics() []string {
 	return withBaseMetrics([]string{
 		"go_cgo_go_to_c_calls_calls_total",
-		"go_gc_cycles_automatic_gc_cycles_total",
-		"go_gc_cycles_forced_gc_cycles_total",
-		"go_gc_cycles_total_gc_cycles_total",
 		"go_cpu_classes_gc_mark_assist_cpu_seconds_total",
 		"go_cpu_classes_gc_mark_dedicated_cpu_seconds_total",
 		"go_cpu_classes_gc_mark_idle_cpu_seconds_total",
@@ -33,6 +30,9 @@ func withAllMetrics() []string {
 		"go_cpu_classes_scavenge_total_cpu_seconds_total",
 		"go_cpu_classes_total_cpu_seconds_total",
 		"go_cpu_classes_user_cpu_seconds_total",
+		"go_gc_cycles_automatic_gc_cycles_total",
+		"go_gc_cycles_forced_gc_cycles_total",
+		"go_gc_cycles_total_gc_cycles_total",
 		"go_gc_heap_allocs_by_size_bytes",
 		"go_gc_heap_allocs_bytes_total",
 		"go_gc_heap_allocs_objects_total",
@@ -116,4 +116,8 @@ func withSchedulerMetrics() []string {
 		"go_sched_latencies_seconds",
 		"go_threads",
 	}
+}
+
+func withDebugMetrics() []string {
+	return []string{}
 }


### PR DESCRIPTION
I was taking a look at https://github.com/prometheus/client_golang/pull/1389 again and noticed that we'll need to generate the withDebugMetrics even if it returns an empty array.

I've updated the script accordingly :)