### PR TITLE
chore: Refactor how base metrics are added to Sched metrics

### DIFF
--- a/prometheus/collectors/go_collector_go120_test.go
+++ b/prometheus/collectors/go_collector_go120_test.go
@@ -19,9 +19,6 @@ package collectors
 func withAllMetrics() []string {
 	return withBaseMetrics([]string{
 		"go_cgo_go_to_c_calls_calls_total",
-		"go_gc_cycles_automatic_gc_cycles_total",
-		"go_gc_cycles_forced_gc_cycles_total",
-		"go_gc_cycles_total_gc_cycles_total",
 		"go_cpu_classes_gc_mark_assist_cpu_seconds_total",
 		"go_cpu_classes_gc_mark_dedicated_cpu_seconds_total",
 		"go_cpu_classes_gc_mark_idle_cpu_seconds_total",
@@ -33,6 +30,9 @@ func withAllMetrics() []string {
 		"go_cpu_classes_scavenge_total_cpu_seconds_total",
 		"go_cpu_classes_total_cpu_seconds_total",
 		"go_cpu_classes_user_cpu_seconds_total",
+		"go_gc_cycles_automatic_gc_cycles_total",
+		"go_gc_cycles_forced_gc_cycles_total",
+		"go_gc_cycles_total_gc_cycles_total",
 		"go_gc_heap_allocs_by_size_bytes",
 		"go_gc_heap_allocs_bytes_total",
 		"go_gc_heap_allocs_objects_total",
@@ -106,14 +106,9 @@ func withMemoryMetrics() []string {
 }
 
 func withSchedulerMetrics() []string {
-	return []string{
-		"go_gc_duration_seconds",
-		"go_goroutines",
-		"go_info",
-		"go_memstats_last_gc_time_seconds",
+	return withBaseMetrics([]string{
 		"go_sched_gomaxprocs_threads",
 		"go_sched_goroutines_goroutines",
 		"go_sched_latencies_seconds",
-		"go_threads",
-	}
+	})
 }

--- a/prometheus/collectors/go_collector_go121_test.go
+++ b/prometheus/collectors/go_collector_go121_test.go
@@ -138,20 +138,15 @@ func withMemoryMetrics() []string {
 }
 
 func withSchedulerMetrics() []string {
-	return []string{
-		"go_gc_duration_seconds",
-		"go_goroutines",
-		"go_info",
-		"go_memstats_last_gc_time_seconds",
+	return withBaseMetrics([]string{
 		"go_sched_gomaxprocs_threads",
 		"go_sched_goroutines_goroutines",
 		"go_sched_latencies_seconds",
-		"go_threads",
-	}
+	})
 }
 
 func withDebugMetrics() []string {
-	return []string{
+	return withBaseMetrics([]string{
 		"go_godebug_non_default_behavior_execerrdot_events_total",
 		"go_godebug_non_default_behavior_gocachehash_events_total",
 		"go_godebug_non_default_behavior_gocachetest_events_total",
@@ -170,5 +165,5 @@ func withDebugMetrics() []string {
 		"go_godebug_non_default_behavior_x509sha1_events_total",
 		"go_godebug_non_default_behavior_x509usefallbackroots_events_total",
 		"go_godebug_non_default_behavior_zipinsecurepath_events_total",
-	}
+	})
 }

--- a/prometheus/collectors/go_collector_go122_test.go
+++ b/prometheus/collectors/go_collector_go122_test.go
@@ -149,11 +149,7 @@ func withMemoryMetrics() []string {
 }
 
 func withSchedulerMetrics() []string {
-	return []string{
-		"go_gc_duration_seconds",
-		"go_goroutines",
-		"go_info",
-		"go_memstats_last_gc_time_seconds",
+	return withBaseMetrics([]string{
 		"go_sched_gomaxprocs_threads",
 		"go_sched_goroutines_goroutines",
 		"go_sched_latencies_seconds",
@@ -161,12 +157,11 @@ func withSchedulerMetrics() []string {
 		"go_sched_pauses_stopping_other_seconds",
 		"go_sched_pauses_total_gc_seconds",
 		"go_sched_pauses_total_other_seconds",
-		"go_threads",
-	}
+	})
 }
 
 func withDebugMetrics() []string {
-	return []string{
+	return withBaseMetrics([]string{
 		"go_godebug_non_default_behavior_execerrdot_events_total",
 		"go_godebug_non_default_behavior_gocachehash_events_total",
 		"go_godebug_non_default_behavior_gocachetest_events_total",
@@ -192,5 +187,5 @@ func withDebugMetrics() []string {
 		"go_godebug_non_default_behavior_x509usefallbackroots_events_total",
 		"go_godebug_non_default_behavior_x509usepolicies_events_total",
 		"go_godebug_non_default_behavior_zipinsecurepath_events_total",
-	}
+	})
 }


### PR DESCRIPTION
A small refactoring to how base metrics are added to scheduler metrics.

I've noticed that this could be simplified while working on https://github.com/prometheus/client_golang/pull/1389. Some changes will conflict with the mentioned PR, but I'll solve them once one of them is merged :)

cc @SachinSahu431 @kakkoyun 