### PR TITLE
ci: Remove hardcoded supported Go versions from go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Read supported_go_versions.txt
         id: matrix
         run: |
-            versions=$(head -n 3 supported_go_versions.txt)
+            versions=$(cat supported_go_versions.txt)
             matrix="[$(echo "$versions" | sed 's/\(.*\)/"\1"/' | paste -s -d,)]"
             echo "supported_versions=$matrix" >> $GITHUB_OUTPUT
   

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,13 +12,29 @@ permissions:
   contents: read
 
 jobs:
+  supportedVersions:
+    name: Fetch supported Go versions
+    runs-on: ubuntu-latest
+    outputs:
+        supported_versions: ${{ steps.matrix.outputs.supported_versions }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Read supported_go_versions.txt
+        id: matrix
+        run: |
+            versions=$(head -n 3 supported_go_versions.txt)
+            matrix="[$(echo "$versions" | sed 's/\(.*\)/"\1"/' | paste -s -d,)]"
+            echo "supported_versions=$matrix" >> $GITHUB_OUTPUT
+  
   test:
     name: Tests
     runs-on: ubuntu-latest
+    needs: supportedVersions
 
     strategy:
       matrix:
-        go_version: ["1.20", "1.21", "1.22"]
+        go_version: ${{ fromJSON(needs.supportedVersions.outputs.supported_versions) }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Currently, go.yml file contains hardcoded list of [supported Go versions](https://github.com/prometheus/client_golang/blob/e38b67e77a6969b0c660691e1a7d29404c24dcfb/.github/workflows/go.yml#L21). This needs to be manually updated when a new Go version is available.

With this PR, this list will be fetched from [supprted_go_versions.txt](https://github.com/prometheus/client_golang/blob/e38b67e77a6969b0c660691e1a7d29404c24dcfb/supported_go_versions.txt) (only the latest 3 Go versions). 

Related PR: https://github.com/prometheus/client_golang/pull/1481