### PR TITLE
feat: Support zstd compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.20
 require (
 	github.com/beorn7/perks v1.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/google/go-cmp v0.6.0
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.17.8
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.53.0
 	github.com/prometheus/procfs v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -12,11 +12,14 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
+github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/github.com/golang/gddo/LICENSE
+++ b/internal/github.com/golang/gddo/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/github.com/golang/gddo/README.md
+++ b/internal/github.com/golang/gddo/README.md
@@ -1,0 +1,1 @@
+This source code is a stripped down version from the archived repository https://github.com/golang/gddo and licensed under BSD.

--- a/internal/github.com/golang/gddo/httputil/header/header.go
+++ b/internal/github.com/golang/gddo/httputil/header/header.go
@@ -1,0 +1,145 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+// Package header provides functions for parsing HTTP headers.
+package header
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Octet types from RFC 2616.
+var octetTypes [256]octetType
+
+type octetType byte
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.ContainsRune(" \t\"(),/:;<=>?@[]\\{}", rune(c))
+		if strings.ContainsRune(" \t\r\n", rune(c)) {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+// AcceptSpec describes an Accept* header.
+type AcceptSpec struct {
+	Value string
+	Q     float64
+}
+
+// ParseAccept parses Accept* headers.
+func ParseAccept(header http.Header, key string) (specs []AcceptSpec) {
+loop:
+	for _, s := range header[key] {
+		for {
+			var spec AcceptSpec
+			spec.Value, s = expectTokenSlash(s)
+			if spec.Value == "" {
+				continue loop
+			}
+			spec.Q = 1.0
+			s = skipSpace(s)
+			if strings.HasPrefix(s, ";") {
+				s = skipSpace(s[1:])
+				if !strings.HasPrefix(s, "q=") {
+					continue loop
+				}
+				spec.Q, s = expectQuality(s[2:])
+				if spec.Q < 0.0 {
+					continue loop
+				}
+			}
+			specs = append(specs, spec)
+			s = skipSpace(s)
+			if !strings.HasPrefix(s, ",") {
+				continue loop
+			}
+			s = skipSpace(s[1:])
+		}
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectTokenSlash(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		b := s[i]
+		if (octetTypes[b]&isToken == 0) && b != '/' {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectQuality(s string) (q float64, rest string) {
+	switch {
+	case len(s) == 0:
+		return -1, ""
+	case s[0] == '0':
+		q = 0
+	case s[0] == '1':
+		q = 1
+	default:
+		return -1, ""
+	}
+	s = s[1:]
+	if !strings.HasPrefix(s, ".") {
+		return q, s
+	}
+	s = s[1:]
+	i := 0
+	n := 0
+	d := 1
+	for ; i < len(s); i++ {
+		b := s[i]
+		if b < '0' || b > '9' {
+			break
+		}
+		n = n*10 + int(b) - '0'
+		d *= 10
+	}
+	return q + float64(n)/float64(d), s[i:]
+}

--- a/internal/github.com/golang/gddo/httputil/header/header_test.go
+++ b/internal/github.com/golang/gddo/httputil/header/header_test.go
@@ -1,0 +1,49 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+package header
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var parseAcceptTests = []struct {
+	s        string
+	expected []AcceptSpec
+}{
+	{"text/html", []AcceptSpec{{"text/html", 1}}},
+	{"text/html; q=0", []AcceptSpec{{"text/html", 0}}},
+	{"text/html; q=0.0", []AcceptSpec{{"text/html", 0}}},
+	{"text/html; q=1", []AcceptSpec{{"text/html", 1}}},
+	{"text/html; q=1.0", []AcceptSpec{{"text/html", 1}}},
+	{"text/html; q=0.1", []AcceptSpec{{"text/html", 0.1}}},
+	{"text/html;q=0.1", []AcceptSpec{{"text/html", 0.1}}},
+	{"text/html, text/plain", []AcceptSpec{{"text/html", 1}, {"text/plain", 1}}},
+	{"text/html; q=0.1, text/plain", []AcceptSpec{{"text/html", 0.1}, {"text/plain", 1}}},
+	{"iso-8859-5, unicode-1-1;q=0.8,iso-8859-1", []AcceptSpec{{"iso-8859-5", 1}, {"unicode-1-1", 0.8}, {"iso-8859-1", 1}}},
+	{"iso-8859-1", []AcceptSpec{{"iso-8859-1", 1}}},
+	{"*", []AcceptSpec{{"*", 1}}},
+	{"da, en-gb;q=0.8, en;q=0.7", []AcceptSpec{{"da", 1}, {"en-gb", 0.8}, {"en", 0.7}}},
+	{"da, q, en-gb;q=0.8", []AcceptSpec{{"da", 1}, {"q", 1}, {"en-gb", 0.8}}},
+	{"image/png, image/*;q=0.5", []AcceptSpec{{"image/png", 1}, {"image/*", 0.5}}},
+
+	// bad cases
+	{"value1; q=0.1.2", []AcceptSpec{{"value1", 0.1}}},
+	{"da, en-gb;q=foo", []AcceptSpec{{"da", 1}}},
+}
+
+func TestParseAccept(t *testing.T) {
+	for _, tt := range parseAcceptTests {
+		header := http.Header{"Accept": {tt.s}}
+		actual := ParseAccept(header, "Accept")
+		if !cmp.Equal(actual, tt.expected) {
+			t.Errorf("ParseAccept(h, %q)=%v, want %v", tt.s, actual, tt.expected)
+		}
+	}
+}

--- a/internal/github.com/golang/gddo/httputil/negotiate.go
+++ b/internal/github.com/golang/gddo/httputil/negotiate.go
@@ -1,0 +1,36 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+package httputil
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil/header"
+)
+
+// NegotiateContentEncoding returns the best offered content encoding for the
+// request's Accept-Encoding header. If two offers match with equal weight and
+// then the offer earlier in the list is preferred. If no offers are
+// acceptable, then "" is returned.
+func NegotiateContentEncoding(r *http.Request, offers []string) string {
+	bestOffer := "identity"
+	bestQ := -1.0
+	specs := header.ParseAccept(r.Header, "Accept-Encoding")
+	for _, offer := range offers {
+		for _, spec := range specs {
+			if spec.Q > bestQ &&
+				(spec.Value == "*" || spec.Value == offer) {
+				bestQ = spec.Q
+				bestOffer = offer
+			}
+		}
+	}
+	if bestQ == 0 {
+		bestOffer = ""
+	}
+	return bestOffer
+}

--- a/internal/github.com/golang/gddo/httputil/negotiate_test.go
+++ b/internal/github.com/golang/gddo/httputil/negotiate_test.go
@@ -1,0 +1,40 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+package httputil
+
+import (
+	"net/http"
+	"testing"
+)
+
+var negotiateContentEncodingTests = []struct {
+	s      string
+	offers []string
+	expect string
+}{
+	{"", []string{"identity", "gzip"}, "identity"},
+	{"*;q=0", []string{"identity", "gzip"}, ""},
+	{"gzip", []string{"identity", "gzip"}, "gzip"},
+	{"gzip,zstd", []string{"identity", "zstd"}, "zstd"},
+	{"zstd,gzip", []string{"gzip", "zstd"}, "gzip"},
+	{"gzip,zstd", []string{"gzip", "zstd"}, "gzip"},
+	{"gzip,zstd", []string{"zstd", "gzip"}, "zstd"},
+	{"gzip;q=0.1,zstd;q=0.5", []string{"gzip", "zstd"}, "zstd"},
+	{"gzip;q=1.0, identity; q=0.5, *;q=0", []string{"identity", "gzip"}, "gzip"},
+	{"gzip;q=1.0, identity; q=0.5, *;q=0", []string{"identity", "zstd"}, "identity"},
+	{"zstd", []string{"identity", "gzip"}, "identity"},
+}
+
+func TestNegotiateContentEncoding(t *testing.T) {
+	for _, tt := range negotiateContentEncodingTests {
+		r := &http.Request{Header: http.Header{"Accept-Encoding": {tt.s}}}
+		actual := NegotiateContentEncoding(r, tt.offers)
+		if actual != tt.expect {
+			t.Errorf("NegotiateContentEncoding(%q, %#v)=%q, want %q", tt.s, tt.offers, actual, tt.expect)
+		}
+	}
+}

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -55,6 +55,8 @@ const (
 	processStartTimeHeader = "Process-Start-Time-Unix"
 )
 
+// Compression represents the content encodings handlers support for the HTTP
+// responses.
 type Compression string
 
 const (
@@ -427,7 +429,7 @@ func httpError(rsp http.ResponseWriter, err error) {
 	)
 }
 
-// NegotiateEncodingWriter reads the Accept-Encoding header from a request and
+// negotiateEncodingWriter reads the Accept-Encoding header from a request and
 // selects the right compression based on an allow-list of supported
 // compressions. It returns a writer implementing the compression and an the
 // correct value that the caller can set in the response header.
@@ -451,8 +453,6 @@ func negotiateEncodingWriter(r *http.Request, rw io.Writer, compressions []strin
 		return z, selected, func() { _ = z.Close() }, nil
 	case "gzip":
 		gz := gzipPool.Get().(*gzip.Writer)
-		defer gzipPool.Put(gz)
-
 		gz.Reset(rw)
 		return gz, selected, func() { _ = gz.Close(); gzipPool.Put(gz) }, nil
 	case "identity":

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -361,7 +361,7 @@ type HandlerOpts struct {
 	// DisableCompression disables the response encoding (compression) and
 	// encoding negotiation. If true, the handler will
 	// never compress the response, even if requested
-	// by the client and the OfferedCompressions field is ignored.
+	// by the client and the OfferedCompressions field is set.
 	DisableCompression bool
 	// OfferedCompressions is a set of encodings (compressions) handler will
 	// try to offer when negotiating with the client. This defaults to identity, gzip

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -133,7 +133,7 @@ func HandlerForTransactional(reg prometheus.TransactionalGatherer, opts HandlerO
 		}
 	}
 
-	// Select all supported compression formats
+	// Select compression formats to offer based on default or user choice.
 	var compressions []string
 	if !opts.DisableCompression {
 		offers := defaultCompressionFormats

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -364,10 +364,10 @@ type HandlerOpts struct {
 	// by the client and the OfferedCompressions field is ignored.
 	DisableCompression bool
 	// OfferedCompressions is a set of encodings (compressions) handler will
-	// try to offer when negotiating with the client. This defaults to zstd,
-	// gzip and identity.
-	// NOTE: If handler can't agree on the encodings with the client or
-	// caller using unsupported or empty encodings in OfferedCompressions,
+	// try to offer when negotiating with the client. This defaults to identity, gzip
+	// and zstd.
+	// NOTE: If handler can't agree with the client on the encodings or
+	// unsupported or empty encodings are set in OfferedCompressions,
 	// handler always fallbacks to no compression (identity), for
 	// compatibility reasons. In such cases ErrorLog will be used if set.
 	OfferedCompressions []Compression

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -490,7 +490,6 @@ func TestNegotiateEncodingWriter(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		disableCompression  bool
 		offeredCompressions []string
 		acceptEncoding      string
 		expectedCompression string
@@ -498,15 +497,13 @@ func TestNegotiateEncodingWriter(t *testing.T) {
 	}{
 		{
 			name:                "test without compression enabled",
-			disableCompression:  true,
-			offeredCompressions: defaultCompressions,
+			offeredCompressions: []string{},
 			acceptEncoding:      "",
 			expectedCompression: "identity",
 			err:                 nil,
 		},
 		{
 			name:                "test with compression enabled with empty accept-encoding header",
-			disableCompression:  false,
 			offeredCompressions: defaultCompressions,
 			acceptEncoding:      "",
 			expectedCompression: "identity",
@@ -514,7 +511,6 @@ func TestNegotiateEncodingWriter(t *testing.T) {
 		},
 		{
 			name:                "test with gzip compression requested",
-			disableCompression:  false,
 			offeredCompressions: defaultCompressions,
 			acceptEncoding:      "gzip",
 			expectedCompression: "gzip",
@@ -522,7 +518,6 @@ func TestNegotiateEncodingWriter(t *testing.T) {
 		},
 		{
 			name:                "test with gzip, zstd compression requested",
-			disableCompression:  false,
 			offeredCompressions: defaultCompressions,
 			acceptEncoding:      "gzip,zstd",
 			expectedCompression: "gzip",
@@ -530,7 +525,6 @@ func TestNegotiateEncodingWriter(t *testing.T) {
 		},
 		{
 			name:                "test with zstd, gzip compression requested",
-			disableCompression:  false,
 			offeredCompressions: defaultCompressions,
 			acceptEncoding:      "zstd,gzip",
 			expectedCompression: "gzip",
@@ -542,7 +536,7 @@ func TestNegotiateEncodingWriter(t *testing.T) {
 		request, _ := http.NewRequest("GET", "/", nil)
 		request.Header.Add(acceptEncodingHeader, test.acceptEncoding)
 		rr := httptest.NewRecorder()
-		_, encodingHeader, _, err := NegotiateEncodingWriter(request, rr, test.disableCompression, test.offeredCompressions)
+		_, encodingHeader, _, err := negotiateEncodingWriter(request, rr, test.offeredCompressions)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("got error: %v, expected: %v", err, test.err)


### PR DESCRIPTION
This allows endpoints to respond with zstd compressed metric data, if the requester supports it. For backwards compatibility, gzip compression will take precedence.


I added a benchmark to the http_test.go, that will test with a differently sized synthetic metric series.



```
Running tool: go test -benchmem -run=^$ -bench ^BenchmarkEncoding$ github.com/prometheus/client_golang/prometheus/promhttp

goos: linux
goarch: amd64
pkg: github.com/prometheus/client_golang/prometheus/promhttp
cpu: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz
BenchmarkEncoding/test_with_gzip_encoding_small-8         	   20670	     53641 ns/op	  111770 B/op	      49 allocs/op
BenchmarkEncoding/test_with_zstd_encoding_small-8         	    7838	    178033 ns/op	 1121493 B/op	      75 allocs/op
BenchmarkEncoding/test_with_no_encoding_small-8           	   56409	     20998 ns/op	   38030 B/op	      43 allocs/op
BenchmarkEncoding/test_with_gzip_encoding_medium-8        	    8493	    143460 ns/op	   78918 B/op	      49 allocs/op
BenchmarkEncoding/test_with_zstd_encoding_medium-8        	    3650	    345559 ns/op	 1155737 B/op	      76 allocs/op
BenchmarkEncoding/test_with_no_encoding_medium-8          	    8816	    122759 ns/op	   72252 B/op	      44 allocs/op
BenchmarkEncoding/test_with_gzip_encoding_large-8         	     944	   1206069 ns/op	  479829 B/op	      52 allocs/op
BenchmarkEncoding/test_with_zstd_encoding_large-8         	     817	   1482854 ns/op	 1429911 B/op	      75 allocs/op
BenchmarkEncoding/test_with_no_encoding_large-8           	     994	   1213586 ns/op	  346837 B/op	      45 allocs/op
BenchmarkEncoding/test_with_gzip_encoding_extra-large-8   	      85	  14008798 ns/op	 2972152 B/op	      56 allocs/op
BenchmarkEncoding/test_with_zstd_encoding_extra-large-8   	      90	  14638520 ns/op	 3731521 B/op	      74 allocs/op
BenchmarkEncoding/test_with_no_encoding_extra-large-8     	      93	  13897780 ns/op	 2648745 B/op	      45 allocs/op
PASS
ok  	github.com/prometheus/client_golang/prometheus/promhttp	17.534s

```

See also: https://github.com/prometheus/prometheus/issues/13866


/kind feature



Release note:
```release-note
promhttp: Support zstd compression	
```