### PR TITLE
Add CollectAndFormat to testutil, allowing caller to assert as they want to on the exported metric 

### DIFF
--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/common/expfmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -429,5 +431,34 @@ func TestCollectAndCount(t *testing.T) {
 	}
 	if got, want := CollectAndCount(c, "some_other_total"), 0; got != want {
 		t.Errorf("unexpected metric count, got %d, want %d", got, want)
+	}
+}
+
+func TestCollectAndFormat(t *testing.T) {
+	const expected = `# HELP foo_bar A value that represents the number of bars in foo.
+# TYPE foo_bar counter
+foo_bar{fizz="bang"} 1
+`
+	c := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "foo_bar",
+			Help: "A value that represents the number of bars in foo.",
+		},
+		[]string{"fizz"},
+	)
+	c.WithLabelValues("bang").Inc()
+
+	got, err := CollectAndFormat(c, expfmt.TypeTextPlain, "foo_bar")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	gotS := string(got)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	if gotS != expected {
+		t.Errorf("unexpected metric output, got %q, expected %q", gotS, expected)
 	}
 }


### PR DESCRIPTION
CollectAndFormat is a helper function that returns the formatted metrics to the caller, allowing them to use it how they want. This is different to CollectAndCompare where the comparison is done strictly on behalf of the caller. Often it is more convenient to perform a simple substring match on the formatted metric rather than the full export. This is especially true testing a duration-like gauge metric, where the exact value of the metric might not be easily determined up front.