### PR TITLE
improved code more clean use time.IsZero() replace t = time.Time{}  

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -234,7 +234,7 @@ func NewMetricWithExemplars(m Metric, exemplars ...Exemplar) (Metric, error) {
 	)
 	for i, e := range exemplars {
 		ts := e.Timestamp
-		if ts == (time.Time{}) {
+		if ts.IsZero() {
 			ts = now
 		}
 		exs[i], err = newExemplar(e.Value, ts, e.Labels)


### PR DESCRIPTION
use  time.IsZero() for test time instance not set, replace code ' t = time.Time{}' make code more readable;  @ArthurSens @bwplotka @kakkoyun
golang doc for IsZero()
![image](https://github.com/prometheus/client_golang/assets/1732373/837f225d-a631-40db-bc0e-88cd0b9d48f0)
