### PR TITLE
Remove synchronize trigger from changelog workflow

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -3,7 +3,7 @@ name: Changelog automation
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize]
+    types: [opened, edited]
 
 permissions:
     contents: read # the config file


### PR DESCRIPTION
<!-- Refer to CONTRIBUTING.md for more details and examples.
https://github.com/prometheus/client_golang/blob/main/CONTRIBUTING.md#how-to-write-a-pr-description
-->
### Describe your PR
Remove synchronize trigger from changelog automation workflow. 
Related https://github.com/prometheus/client_golang/pull/1496#issuecomment-2145363857

### What type of PR is this?
/kind release-note-none
<!-- Format: /kind followed by ONE of the type {fix, bugfix, enhancement, feature, feat, change, release-note-none} -->


### Changelog Entry
```release-note
NONE
```
<!-- Briefly describe any USER-FACING changes introduced in your PR. If your change should not appear in the changelog, write NONE. -->
