### PR TITLE
Cleanup NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,11 +17,6 @@ http://github.com/golang/protobuf/
 Copyright 2010 The Go Authors
 See source code for license details.
 
-Support for streaming Protocol Buffer messages for the Go language (golang).
-https://github.com/matttproud/golang_protobuf_extensions
-Copyright 2013 Matt T. Proud
-Licensed under the Apache License, Version 2.0
-
 diff - a pretty-printed complete of a Go data structure
 https://github.com/kylelemons/godebug
 Copyright 2013 Google Inc.  All rights reserved.


### PR DESCRIPTION
### Describe your PR

The `github.com/matttproud/golang_protobuf_extensions` dependency was removed in favor of upstream protobuf functions.

### What type of PR is this?

/kind release-note-none

### Changelog Entry
```release-note
NONE
```