### PR TITLE
client: Add Option to provide limit query param for APIs that support it

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1026,7 +1026,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 
 func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error) {
 	u := h.client.URL(epLabels, nil)
-	q := formatOptions(u.Query(), opts)
+	q := addOptionalURLParams(u.Query(), opts)
 
 	if !startTime.IsZero() {
 		q.Set("start", formatTime(startTime))
@@ -1049,7 +1049,7 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 
 func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error) {
 	u := h.client.URL(epLabelValues, map[string]string{"name": label})
-	q := formatOptions(u.Query(), opts)
+	q := addOptionalURLParams(u.Query(), opts)
 
 	if !startTime.IsZero() {
 		q.Set("start", formatTime(startTime))
@@ -1091,15 +1091,15 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithLimit can be used to provide an optional maximum number of returned entries for APIs that support that.
-// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+// WithLimit provides an optional maximum number of returned entries for APIs that support limit parameter
+// e.g. https://prometheus.io/docs/prometheus/latest/querying/api/#instant-querie:~:text=%3A%20End%20timestamp.-,limit%3D%3Cnumber%3E,-%3A%20Maximum%20number%20of
 func WithLimit(limit uint64) Option {
 	return func(o *apiOptions) {
 		o.limit = limit
 	}
 }
 
-func formatOptions(q url.Values, opts []Option) url.Values {
+func addOptionalURLParams(q url.Values, opts []Option) url.Values {
 	opt := &apiOptions{}
 	for _, o := range opts {
 		o(opt)
@@ -1118,7 +1118,7 @@ func formatOptions(q url.Values, opts []Option) url.Values {
 
 func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
 	u := h.client.URL(epQuery, nil)
-	q := formatOptions(u.Query(), opts)
+	q := addOptionalURLParams(u.Query(), opts)
 
 	q.Set("query", query)
 	if !ts.IsZero() {
@@ -1136,7 +1136,7 @@ func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ..
 
 func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error) {
 	u := h.client.URL(epQueryRange, nil)
-	q := formatOptions(u.Query(), opts)
+	q := addOptionalURLParams(u.Query(), opts)
 
 	q.Set("query", query)
 	q.Set("start", formatTime(r.Start))
@@ -1154,7 +1154,7 @@ func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ..
 
 func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error) {
 	u := h.client.URL(epSeries, nil)
-	q := formatOptions(u.Query(), opts)
+	q := addOptionalURLParams(u.Query(), opts)
 
 	for _, m := range matches {
 		q.Add("match[]", m)
@@ -1286,7 +1286,7 @@ func (h *httpAPI) Metadata(ctx context.Context, metric, limit string) (map[strin
 
 func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) {
 	u := h.client.URL(epTSDB, nil)
-	q := formatOptions(u.Query(), opts)
+	q := addOptionalURLParams(u.Query(), opts)
 	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -475,9 +475,9 @@ type API interface {
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
 	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
-	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time) ([]string, Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error)
 	// LabelValues performs a query for the values of the given label, time range and matchers.
-	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time) (model.LabelValues, Warnings, error)
+	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
 	// Query performs a query for the given time.
 	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error)
 	// QueryRange performs a query for the given range.
@@ -489,7 +489,7 @@ type API interface {
 	// Runtimeinfo returns the various runtime information properties about the Prometheus server.
 	Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error)
 	// Series finds series by label matchers.
-	Series(ctx context.Context, matches []string, startTime, endTime time.Time) ([]model.LabelSet, Warnings, error)
+	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error)
 	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
 	// under the TSDB's data directory and returns the directory as response.
 	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
@@ -502,7 +502,7 @@ type API interface {
 	// Metadata returns metadata about metrics currently scraped by the metric name.
 	Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error)
 	// TSDB returns the cardinality statistics.
-	TSDB(ctx context.Context) (TSDBResult, error)
+	TSDB(ctx context.Context, opts ...Option) (TSDBResult, error)
 	// WalReplay returns the current replay status of the wal.
 	WalReplay(ctx context.Context) (WalReplayStatus, error)
 }
@@ -1024,9 +1024,10 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 	return res, err
 }
 
-func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time) ([]string, Warnings, error) {
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error) {
 	u := h.client.URL(epLabels, nil)
-	q := u.Query()
+	q := formatOptions(u.Query(), opts)
+
 	if !startTime.IsZero() {
 		q.Set("start", formatTime(startTime))
 	}
@@ -1046,9 +1047,10 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 	return labelNames, w, err
 }
 
-func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time) (model.LabelValues, Warnings, error) {
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error) {
 	u := h.client.URL(epLabelValues, map[string]string{"name": label})
-	q := u.Query()
+	q := formatOptions(u.Query(), opts)
+
 	if !startTime.IsZero() {
 		q.Set("start", formatTime(startTime))
 	}
@@ -1076,6 +1078,7 @@ func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []strin
 
 type apiOptions struct {
 	timeout time.Duration
+	limit   uint64
 }
 
 type Option func(c *apiOptions)
@@ -1088,19 +1091,34 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
-	u := h.client.URL(epQuery, nil)
-	q := u.Query()
+// WithLimit can be used to provide an optional maximum number of returned entries for APIs that support that.
+// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+func WithLimit(limit uint64) Option {
+	return func(o *apiOptions) {
+		o.limit = limit
+	}
+}
 
+func formatOptions(q url.Values, opts []Option) url.Values {
 	opt := &apiOptions{}
 	for _, o := range opts {
 		o(opt)
 	}
 
-	d := opt.timeout
-	if d > 0 {
-		q.Set("timeout", d.String())
+	if opt.timeout > 0 {
+		q.Set("timeout", opt.timeout.String())
 	}
+
+	if opt.limit > 0 {
+		q.Set("limit", strconv.FormatUint(opt.limit, 10))
+	}
+
+	return q
+}
+
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
+	u := h.client.URL(epQuery, nil)
+	q := formatOptions(u.Query(), opts)
 
 	q.Set("query", query)
 	if !ts.IsZero() {
@@ -1118,22 +1136,12 @@ func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ..
 
 func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error) {
 	u := h.client.URL(epQueryRange, nil)
-	q := u.Query()
+	q := formatOptions(u.Query(), opts)
 
 	q.Set("query", query)
 	q.Set("start", formatTime(r.Start))
 	q.Set("end", formatTime(r.End))
 	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
-
-	opt := &apiOptions{}
-	for _, o := range opts {
-		o(opt)
-	}
-
-	d := opt.timeout
-	if d > 0 {
-		q.Set("timeout", d.String())
-	}
 
 	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
@@ -1141,13 +1149,12 @@ func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ..
 	}
 
 	var qres queryResult
-
 	return qres.v, warnings, json.Unmarshal(body, &qres)
 }
 
-func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time) ([]model.LabelSet, Warnings, error) {
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error) {
 	u := h.client.URL(epSeries, nil)
-	q := u.Query()
+	q := formatOptions(u.Query(), opts)
 
 	for _, m := range matches {
 		q.Add("match[]", m)
@@ -1166,8 +1173,7 @@ func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTi
 	}
 
 	var mset []model.LabelSet
-	err = json.Unmarshal(body, &mset)
-	return mset, warnings, err
+	return mset, warnings, json.Unmarshal(body, &mset)
 }
 
 func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
@@ -1278,8 +1284,10 @@ func (h *httpAPI) Metadata(ctx context.Context, metric, limit string) (map[strin
 	return res, err
 }
 
-func (h *httpAPI) TSDB(ctx context.Context) (TSDBResult, error) {
+func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) {
 	u := h.client.URL(epTSDB, nil)
+	q := formatOptions(u.Query(), opts)
+	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -154,15 +154,15 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
-	doLabelNames := func(matches []string, startTime, endTime time.Time) func() (interface{}, Warnings, error) {
+	doLabelNames := func(matches []string, startTime, endTime time.Time, opts ...Option) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			return promAPI.LabelNames(context.Background(), matches, startTime, endTime)
+			return promAPI.LabelNames(context.Background(), matches, startTime, endTime, opts...)
 		}
 	}
 
-	doLabelValues := func(matches []string, label string, startTime, endTime time.Time) func() (interface{}, Warnings, error) {
+	doLabelValues := func(matches []string, label string, startTime, endTime time.Time, opts ...Option) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			return promAPI.LabelValues(context.Background(), label, matches, startTime, endTime)
+			return promAPI.LabelValues(context.Background(), label, matches, startTime, endTime, opts...)
 		}
 	}
 
@@ -178,9 +178,9 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
-	doSeries := func(matcher string, startTime, endTime time.Time) func() (interface{}, Warnings, error) {
+	doSeries := func(matcher string, startTime, endTime time.Time, opts ...Option) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			return promAPI.Series(context.Background(), []string{matcher}, startTime, endTime)
+			return promAPI.Series(context.Background(), []string{matcher}, startTime, endTime, opts...)
 		}
 	}
 
@@ -219,9 +219,9 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
-	doTSDB := func() func() (interface{}, Warnings, error) {
+	doTSDB := func(opts ...Option) func() (interface{}, Warnings, error) {
 		return func() (interface{}, Warnings, error) {
-			v, err := promAPI.TSDB(context.Background())
+			v, err := promAPI.TSDB(context.Background(), opts...)
 			return v, nil, err
 		}
 	}


### PR DESCRIPTION
<!-- Refer to CONTRIBUTING.md for more details and examples.
https://github.com/prometheus/client_golang/blob/main/CONTRIBUTING.md#how-to-write-a-pr-description
-->
### Describe your PR
This PR adds an option to client APIs to specify limit query parameters for APIs that support it.

For example, APIs, such as [Finding series by label matchers](https://prometheus.io/docs/prometheus/latest/querying/api/#finding-series-by-label-matchers), support optional query param:
  - limit=<number>: Maximum number of returned series. 
 
However, the current  [client interface](https://github.com/prometheus/client_golang/blob/main/api/prometheus/v1/api.go#L492) provides no way to pass that parameter.

To minimize the impact on existing users of that client interface, this parameter is implemented as an existing optional argument. 

### What type of PR is this?

<!-- Format: /kind followed by ONE of the type {fix, bugfix, enhancement, feature, feat, change, release-note-none} -->
/kind enhancement

### Changelog Entry
```release-note
Client APIs support extra arguments to specify limit query parameters for APIs that support it.

```
<!-- Briefly describe any USER-FACING changes introduced in your PR. If your change should not appear in the changelog, write NONE. -->
