### PR TITLE
Remove go_memstat_lookups_total; added runtime/metrics calculation to memstat metric's help.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [CHANGE] go-collector: Remove `go_memstat_lookups_total` metric which was always 0; Go runtime stopped sharing pointer lookup statistics.
+
 ## 1.19.0 / 2023-02-27
 
 The module `prometheus/common v0.48.0` introduced an incompatibility when used together with client_golang (See https://github.com/prometheus/client_golang/pull/1448 for more details). If your project uses client_golang and you want to use `prometheus/common v0.48.0` or higher, please update client_golang to v1.19.0.

--- a/prometheus/collectors/go_collector_latest.go
+++ b/prometheus/collectors/go_collector_latest.go
@@ -47,7 +47,6 @@ var (
 // go_memstats_alloc_bytes
 // go_memstats_alloc_bytes_total
 // go_memstats_sys_bytes
-// go_memstats_lookups_total
 // go_memstats_mallocs_total
 // go_memstats_frees_total
 // go_memstats_heap_alloc_bytes

--- a/prometheus/collectors/go_collector_latest_test.go
+++ b/prometheus/collectors/go_collector_latest_test.go
@@ -50,7 +50,6 @@ var memstatMetrics = []string{
 	"go_memstats_heap_objects",
 	"go_memstats_heap_released_bytes",
 	"go_memstats_heap_sys_bytes",
-	"go_memstats_lookups_total",
 	"go_memstats_mallocs_total",
 	"go_memstats_mcache_inuse_bytes",
 	"go_memstats_mcache_sys_bytes",

--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -52,7 +52,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("mallocs_total"),
-				// TODO(bwplotka): We could add go_memstats_heap_objects, probably useful for discovery. Let's gather more feedback, kind of waste of bytes for everybody for compatibility reason to keep both, and we can't reall rename/remove useful metric.
+				// TODO(bwplotka): We could add go_memstats_heap_objects, probably useful for discovery. Let's gather more feedback, kind of a waste of bytes for everybody for compatibility reasons to keep both, and we can't really rename/remove useful metric.
 				"Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.",
 				nil, nil,
 			),

--- a/prometheus/go_collector.go
+++ b/prometheus/go_collector.go
@@ -28,7 +28,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		{
 			desc: NewDesc(
 				memstatNamespace("alloc_bytes"),
-				"Number of bytes allocated and currently in use.",
+				"Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.Alloc) },
@@ -36,7 +36,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("alloc_bytes_total"),
-				"Total number of bytes allocated until now, even if released already.",
+				"Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.TotalAlloc) },
@@ -44,24 +44,16 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("sys_bytes"),
-				"Number of bytes obtained from system.",
+				"Number of bytes obtained from system. Equals to /memory/classes/total:byte.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.Sys) },
 			valType: GaugeValue,
 		}, {
 			desc: NewDesc(
-				memstatNamespace("lookups_total"),
-				"Total number of pointer lookups.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.Lookups) },
-			valType: CounterValue,
-		}, {
-			desc: NewDesc(
 				memstatNamespace("mallocs_total"),
-				// TODO(bwplotka): We could add go_memstats_heap_objects, probably useful for discovery. Let's gather more feedback, kind of waste of bytes for everybody for compatibility reason.
-				"Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge.",
+				// TODO(bwplotka): We could add go_memstats_heap_objects, probably useful for discovery. Let's gather more feedback, kind of waste of bytes for everybody for compatibility reason to keep both, and we can't reall rename/remove useful metric.
+				"Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.Mallocs) },
@@ -69,7 +61,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("frees_total"),
-				"Total number of heap objects frees.",
+				"Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.Frees) },
@@ -77,7 +69,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("heap_alloc_bytes"),
-				"Number of heap bytes allocated and currently in use.",
+				"Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapAlloc) },
@@ -85,7 +77,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("heap_sys_bytes"),
-				"Number of heap bytes obtained from system.",
+				"Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapSys) },
@@ -93,7 +85,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("heap_idle_bytes"),
-				"Number of heap bytes waiting to be used.",
+				"Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapIdle) },
@@ -101,7 +93,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("heap_inuse_bytes"),
-				"Number of heap bytes that are in use.",
+				"Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapInuse) },
@@ -109,7 +101,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("heap_released_bytes"),
-				"Number of heap bytes released to OS.",
+				"Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapReleased) },
@@ -117,7 +109,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("heap_objects"),
-				"Number of currently allocated objects.",
+				"Number of currently allocated objects. Equals to /gc/heap/objects:objects.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapObjects) },
@@ -125,7 +117,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("stack_inuse_bytes"),
-				"Number of bytes in use by the stack allocator.",
+				"Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.StackInuse) },
@@ -133,7 +125,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("stack_sys_bytes"),
-				"Number of bytes obtained from system for stack allocator.",
+				"Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.StackSys) },
@@ -141,7 +133,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("mspan_inuse_bytes"),
-				"Number of bytes in use by mspan structures.",
+				"Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.MSpanInuse) },
@@ -149,7 +141,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("mspan_sys_bytes"),
-				"Number of bytes used for mspan structures obtained from system.",
+				"Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.MSpanSys) },
@@ -157,7 +149,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("mcache_inuse_bytes"),
-				"Number of bytes in use by mcache structures.",
+				"Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.MCacheInuse) },
@@ -165,7 +157,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("mcache_sys_bytes"),
-				"Number of bytes used for mcache structures obtained from system.",
+				"Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.MCacheSys) },
@@ -173,7 +165,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("buck_hash_sys_bytes"),
-				"Number of bytes used by the profiling bucket hash table.",
+				"Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.BuckHashSys) },
@@ -181,7 +173,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("gc_sys_bytes"),
-				"Number of bytes used for garbage collection system metadata.",
+				"Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.GCSys) },
@@ -189,7 +181,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("other_sys_bytes"),
-				"Number of bytes used for other system allocations.",
+				"Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.OtherSys) },
@@ -197,7 +189,7 @@ func goRuntimeMemStats() memStatsMetrics {
 		}, {
 			desc: NewDesc(
 				memstatNamespace("next_gc_bytes"),
-				"Number of heap bytes when next garbage collection will take place.",
+				"Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.",
 				nil, nil,
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.NextGC) },


### PR DESCRIPTION

I know we ideally should not remove any metric from default list, but this one is always zero, so let's save everyone's money.