### PR TITLE
ci: bump dagger to the latest version

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,9 @@
 {
   "name": "client_golang",
   "sdk": "go",
+  "includes": [
+    "dagger"
+  ],
   "dependencies": [
     {
       "name": "golang",
@@ -8,5 +11,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "v0.12.0"
+  "engineVersion": "v0.12.5"
 }


### PR DESCRIPTION
this commit also adds an `includes` field to the dagger.json so the initial SDK code generation runs faster as only the Dagger module source is included