### PR TITLE
Update linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,4 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           args: --verbose
-          version: v1.59.1
+          version: v1.60.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,8 @@ linters-settings:
     local-prefixes: github.com/prometheus/client_golang
   gofumpt:
     extra-rules: true
+  predeclared:
+    ignore: "min,max"
   revive:
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v1.60.2
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/prometheus/graphite/bridge_test.go
+++ b/prometheus/graphite/bridge_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -238,7 +239,7 @@ prefix.name_bucket;constname=constvalue;labelname=val2;le=+Inf 3 1477043
 	got := buf.String()
 
 	if err := checkLinesAreEqual(want, got, useTags); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -290,7 +291,7 @@ prefix.name;constname=constvalue;labelname=val2 1 1477043
 	got := buf.String()
 
 	if err := checkLinesAreEqual(want, got, useTags); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -322,7 +323,7 @@ func checkLinesAreEqual(w, g string, useTags bool) error {
 			log += fmt.Sprintf("want: %v\ngot: %v\n\n", wantSplit, gotSplit)
 
 			if !reflect.DeepEqual(wantSplit, gotSplit) {
-				return fmt.Errorf(log)
+				return errors.New(log)
 			}
 		}
 		return nil

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -39,6 +39,7 @@ package testutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -310,7 +311,7 @@ func compare(got, want []*dto.MetricFamily) error {
 		}
 	}
 	if diffErr := diff.Diff(gotBuf.String(), wantBuf.String()); diffErr != "" {
-		return fmt.Errorf(diffErr)
+		return errors.New(diffErr)
 	}
 	return nil
 }


### PR DESCRIPTION
* Update golangci-lint from upstream prometheus repo.
* Ignore min/max in predeclared.
* Fix `Errorf()` use.