### PR TITLE
Update Dagger and build.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "monthly"
   - package-ecosystem: "gomod"
+    directory: "/dagger"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gomod"
     directory: "/examples/middleware"
     schedule:
       interval: "monthly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set docker hub repo name
         run: echo "DOCKER_REPO_NAME=$(make docker-repo-name)" >> $GITHUB_ENV
       - name: Push README to Dockerhub
@@ -40,7 +40,7 @@ jobs:
     if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set quay.io org name
         run: echo "DOCKER_REPO=$(echo quay.io/${GITHUB_REPOSITORY_OWNER} | tr -d '-')" >> $GITHUB_ENV
       - name: Set quay.io repo name

--- a/.github/workflows/dagger-golangci-lint.yml
+++ b/.github/workflows/dagger-golangci-lint.yml
@@ -17,15 +17,15 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   golangci:
     permissions:
-      contents: read  # for actions/checkout to fetch code
+      contents: read  # for actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Lint
-        uses: dagger/dagger-for-github@v5
+        uses: dagger/dagger-for-github@8ab204f3cf74a4940a1648469c426ef0d28af7cc # v6.6.0
         with:
           version: "latest"
           verb: call

--- a/.github/workflows/dagger-golangci-lint.yml
+++ b/.github/workflows/dagger-golangci-lint.yml
@@ -17,7 +17,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   golangci:
     permissions:
-      contents: read  # for actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      contents: read  # for actions/checkout to fetch code
       pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
         supported_versions: ${{ steps.matrix.outputs.supported_versions }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Read supported_go_versions.txt
         id: matrix
         run: |
@@ -43,17 +43,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Run tests and check license
-        uses: dagger/dagger-for-github@v5
+        uses: dagger/dagger-for-github@8ab204f3cf74a4940a1648469c426ef0d28af7cc # v6.6.0
         with:
           version: "latest"
           verb: call
           args: -vvv --src . make --go-version ${{matrix.go_version}} --args 'check_license test'
 
       - name: Run style and unused
-        uses: dagger/dagger-for-github@v6
+        uses: dagger/dagger-for-github@8ab204f3cf74a4940a1648469c426ef0d28af7cc # v6.6.0
         if: ${{ matrix.go_version == '1.21' }}
         with:
           version: "latest"

--- a/.github/workflows/update-go-versions.yml
+++ b/.github/workflows/update-go-versions.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Execute bash script
         run: bash update-go-version.bash
@@ -22,7 +22,7 @@ jobs:
       # no pull request will be created and the action exits silently.
       - name: Create a Pull Request
         if: github.event_name != 'pull_request'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update Go Collector metrics for new Go version"

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -35,7 +35,7 @@ func New(src *dagger.Directory) *ClientGolang {
 func (m *ClientGolang) Make(
 	// +optional
 	args string,
-	// +default="1.20"
+	// +default="1.23"
 	goVersion string,
 	// +optional
 	env []string,

--- a/tutorials/whatsup/go.mod
+++ b/tutorials/whatsup/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/client_golang/tutorials/whatsup
 
-go 1.20
+go 1.21
 
 require (
 	github.com/bwplotka/tracing-go v0.0.0-20230421061608-abdf862ceccd


### PR DESCRIPTION
* Update dagger actions to use pinnning.
* Add /dagger to dependabot to keep the Dagger modules up-to-date.
* Update dagger default Go version.
* Update tutorials/whatsup Go version.
* Update actions to use pinning.
