### PR TITLE
native histogram: Fix race between Write and addExemplar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [BUGFIX] histograms: Fix possible data race when appending exemplars vs metrics gather. #1623
+
 ## 1.20.3 / 2024-09-05
 
 * [BUGFIX] histograms: Fix possible data race when appending exemplars. #1608

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -844,9 +844,7 @@ func (h *histogram) Write(out *dto.Metric) error {
 			}}
 		}
 
-		// If exemplars are not configured, the cap will be 0.
-		// So append is not needed in this case.
-		if cap(h.nativeExemplars.exemplars) > 0 {
+		if h.nativeExemplars.isEnabled() {
 			h.nativeExemplars.Lock()
 			his.Exemplars = append(his.Exemplars, h.nativeExemplars.exemplars...)
 			h.nativeExemplars.Unlock()
@@ -1665,6 +1663,10 @@ type nativeExemplars struct {
 	exemplars []*dto.Exemplar
 }
 
+func (n *nativeExemplars) isEnabled() bool {
+	return n.ttl != -1
+}
+
 func makeNativeExemplars(ttl time.Duration, maxCount int) nativeExemplars {
 	if ttl == 0 {
 		ttl = 5 * time.Minute
@@ -1686,7 +1688,7 @@ func makeNativeExemplars(ttl time.Duration, maxCount int) nativeExemplars {
 }
 
 func (n *nativeExemplars) addExemplar(e *dto.Exemplar) {
-	if n.ttl == -1 {
+	if !n.isEnabled() {
 		return
 	}
 


### PR DESCRIPTION
Follow-up to #1608

Fixes
```
2024-09-06T08:32:44.9910707Z 08:29:59 ingester-3: WARNING: DATA RACE
2024-09-06T08:32:44.9911367Z 08:29:59 ingester-3: Read at 0x00c001b9f4d8 by goroutine 480:
2024-09-06T08:32:44.9912309Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*histogram).Write()
2024-09-06T08:32:44.9913404Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/histogram.go:849 +0x16ef
2024-09-06T08:32:44.9914502Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*wrappingMetric).Write()
2024-09-06T08:32:44.9915647Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/wrap.go:172 +0x65
2024-09-06T08:32:44.9916698Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*wrappingMetric).Write()
2024-09-06T08:32:44.9917746Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/wrap.go:172 +0x65
2024-09-06T08:32:44.9919099Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*wrappingMetric).Write()
2024-09-06T08:32:44.9920110Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/wrap.go:172 +0x65
2024-09-06T08:32:44.9921088Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.processMetric()
2024-09-06T08:32:44.9922271Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/registry.go:633 +0x112
2024-09-06T08:32:44.9923296Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*Registry).Gather()
2024-09-06T08:32:44.9924408Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/registry.go:502 +0xe8a
2024-09-06T08:32:44.9925524Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*noTransactionGatherer).Gather()
2024-09-06T08:32:44.9926636Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/registry.go:1074 +0x3a
2024-09-06T08:32:44.9927818Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus/promhttp.HandlerForTransactional.func1()
2024-09-06T08:32:44.9929026Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/promhttp/http.go:165 +0x3fa
```

vs

```
2024-09-06T08:32:44.9959927Z 08:29:59 ingester-3: Previous write at 0x00c001b9f4d8 by goroutine 370:
2024-09-06T08:32:44.9960836Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*nativeExemplars).addExemplar()
2024-09-06T08:32:44.9962035Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/histogram.go:1706 +0x188b
2024-09-06T08:32:44.9963229Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*histogram).updateExemplar()
2024-09-06T08:32:44.9964331Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/histogram.go:1140 +0x116
2024-09-06T08:32:44.9965403Z 08:29:59 ingester-3: github.com/prometheus/client_golang/prometheus.(*histogram).ObserveWithExemplar()
2024-09-06T08:32:44.9966601Z 08:29:59 ingester-3: /__w/mimir/mimir/vendor/github.com/prometheus/client_golang/prometheus/histogram.go:770 +0x69
2024-09-06T08:32:44.9967591Z 08:29:59 ingester-3: github.com/grafana/dskit/instrument.ObserveWithExemplar()
```
