### PR TITLE
promhttp: add support for custom `gzip.Writer` pool

### DIFF
--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -428,7 +428,7 @@ type HandlerOpts struct {
 	// NOTE: This feature is experimental and not covered by OpenMetrics or Prometheus
 	// exposition format.
 	ProcessStartTime time.Time
-	// GzipPool provides pool of gzip writers. Default is sync.Pool instance.
+	// GzipPool provides pool of gzip writers. Default is using sync.Pool.
 	GzipPool Pool
 }
 

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -652,27 +652,18 @@ func BenchmarkCompression(b *testing.B) {
 	benchmarks := []struct {
 		name            string
 		compressionType string
-		opts            HandlerOpts
 	}{
 		{
 			name:            "test with gzip compression",
 			compressionType: "gzip",
-			opts:            HandlerOpts{},
-		},
-		{
-			name:            "test with gzip compression with custom pool",
-			compressionType: "gzip",
-			opts:            HandlerOpts{GzipPool: newChannelGzipPool(2)},
 		},
 		{
 			name:            "test with zstd compression",
 			compressionType: "zstd",
-			opts:            HandlerOpts{},
 		},
 		{
 			name:            "test with no compression",
 			compressionType: "identity",
-			opts:            HandlerOpts{},
 		},
 	}
 	sizes := []struct {
@@ -714,6 +705,7 @@ func BenchmarkCompression(b *testing.B) {
 
 	for _, size := range sizes {
 		reg := prometheus.NewRegistry()
+		handler := HandlerFor(reg, HandlerOpts{})
 
 		// Generate Metrics
 		// Original source: https://github.com/prometheus-community/avalanche/blob/main/metrics/serve.go
@@ -736,7 +728,6 @@ func BenchmarkCompression(b *testing.B) {
 		}
 
 		for _, benchmark := range benchmarks {
-			handler := HandlerFor(reg, benchmark.opts)
 			b.Run(benchmark.name+"_"+size.name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					writer := httptest.NewRecorder()

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -714,7 +714,6 @@ func BenchmarkCompression(b *testing.B) {
 
 	for _, size := range sizes {
 		reg := prometheus.NewRegistry()
-		handler := HandlerFor(reg, HandlerOpts{})
 
 		// Generate Metrics
 		// Original source: https://github.com/prometheus-community/avalanche/blob/main/metrics/serve.go
@@ -737,6 +736,7 @@ func BenchmarkCompression(b *testing.B) {
 		}
 
 		for _, benchmark := range benchmarks {
+			handler := HandlerFor(reg, benchmark.opts)
 			b.Run(benchmark.name+"_"+size.name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					writer := httptest.NewRecorder()


### PR DESCRIPTION
`sync.Pool` used for `gzip.Writer`s is not suitable for long(er)-live objects, objects can be evicted by GC (which may not manifest in tight-loop benchmarks). This may occur quite often in memory-constrained environment (eg. with low `GOMEMLIMIT` and/or `GOGC` value), therefore new instances are also allocated again quite often, which further increases pressure on GC.

This PR adds support for providing alternative pool implementation for `gzip.Writers` via new `promhttp.HandlerOpts` field `GzipPool` of `Pool` type:

```go
type Pool interface {
	Get() any
	Put(x any)
}
```

`sync.Pool` implements this interface, and is used as the default implementation as it has been so far.