### PR TITLE
Return an http error during scraping if metrics collide when escaped to underscores

### DIFF
--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -135,8 +135,8 @@ func HandlerForTransactional(reg prometheus.TransactionalGatherer, opts HandlerO
 				panic(err)
 			}
 		}
-		hasEscapedCollisions = opts.Registry.HasEscapedCollision()
 	}
+	hasEscapedCollisions = reg.HasEscapedCollision()
 
 	// Select compression formats to offer based on default or user choice.
 	var compressions []string

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -81,6 +81,10 @@ func (g *mockTransactionGatherer) Gather() (_ []*dto.MetricFamily, done func(), 
 	return mfs, func() { g.doneInvoked++ }, err
 }
 
+func (g *mockTransactionGatherer) HasEscapedCollision() bool {
+	return g.g.HasEscapedCollision()
+}
+
 func readCompressedBody(r io.Reader, comp Compression) (string, error) {
 	switch comp {
 	case Gzip:
@@ -567,9 +571,7 @@ func TestEscapedCollisions(t *testing.T) {
 		Help: "A test metric with dots",
 	}))
 
-	handler := HandlerFor(reg, HandlerOpts{
-		Registry: reg,
-	})
+	handler := HandlerFor(reg, HandlerOpts{})
 
 	t.Run("fail case", func(t *testing.T) {
 		writer := httptest.NewRecorder()

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -1364,6 +1364,10 @@ func (g *tGatherer) Gather() (_ []*dto.MetricFamily, done func(), err error) {
 	}, func() { g.done = true }, g.err
 }
 
+func (g *tGatherer) HasEscapedCollision() bool {
+	return false
+}
+
 func TestNewMultiTRegistry(t *testing.T) {
 	treg := &tGatherer{}
 

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -117,10 +117,6 @@ func (r *wrappingRegisterer) Unregister(c Collector) bool {
 	})
 }
 
-func (r *wrappingRegisterer) HasEscapedCollision() bool {
-	return r.wrappedRegisterer.HasEscapedCollision()
-}
-
 type wrappingCollector struct {
 	wrappedCollector Collector
 	prefix           string

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -117,6 +117,10 @@ func (r *wrappingRegisterer) Unregister(c Collector) bool {
 	})
 }
 
+func (r *wrappingRegisterer) HasEscapedCollision() bool {
+	return r.wrappedRegisterer.HasEscapedCollision()
+}
+
 type wrappingCollector struct {
 	wrappedCollector Collector
 	prefix           string


### PR DESCRIPTION
fixes https://github.com/prometheus/client_golang/issues/1638

This change prevents a possible issue when UTF-8 metrics are scraped by a system that does not support UTF-8. The metric names will be escaped, and if two metrics escape to the same legacy name, they will appear in the exposition "twice", causing collision problems. Therefore, during scraping we return an http error if two metrics escape to the same legacy string. 

This change creates a new uint64 per metric and two new maps in the Registry. The new maps are only populated if the hash of the original metric data contains UTF-8 data. This means memory usage will be lower in the near term and will go up in the long term or for OTLP-heavy users. Eventually (i.e. Prom 4.0 or later) we could deprecate the compatibility modes with legacy systems to save this memory, but it's also not clear to me that the memory usage will be that high.

To avoid performance issues checking for collisions on every scrape, the actual collision detection is done at registration time but only reported at scrape time.