### PR TITLE
Add: exponential backoff for CAS operations on floats

### DIFF
--- a/prometheus/atomic_update.go
+++ b/prometheus/atomic_update.go
@@ -1,0 +1,48 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+)
+
+// atomicUpdateFloat atomically updates the float64 value pointed to by bits
+// using the provided updateFunc, with an exponential backoff on contention.
+func atomicUpdateFloat(bits *uint64, updateFunc func(float64) float64) {
+	const (
+		maxBackoff     = 320 * time.Millisecond
+		initialBackoff = 10 * time.Millisecond
+	)
+	var backoff = initialBackoff
+
+	for {
+		loadedBits := atomic.LoadUint64(bits)
+		oldFloat := math.Float64frombits(loadedBits)
+		newFloat := updateFunc(oldFloat)
+		newBits := math.Float64bits(newFloat)
+
+		if atomic.CompareAndSwapUint64(bits, loadedBits, newBits) {
+			break
+		} else {
+			// Exponential backoff with sleep and cap to avoid infinite wait
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}

--- a/prometheus/atomic_update.go
+++ b/prometheus/atomic_update.go
@@ -26,7 +26,7 @@ func atomicUpdateFloat(bits *uint64, updateFunc func(float64) float64) {
 		maxBackoff     = 320 * time.Millisecond
 		initialBackoff = 10 * time.Millisecond
 	)
-	var backoff = initialBackoff
+	backoff := initialBackoff
 
 	for {
 		loadedBits := atomic.LoadUint64(bits)

--- a/prometheus/atomic_update.go
+++ b/prometheus/atomic_update.go
@@ -23,6 +23,8 @@ import (
 // using the provided updateFunc, with an exponential backoff on contention.
 func atomicUpdateFloat(bits *uint64, updateFunc func(float64) float64) {
 	const (
+		// both numbers are derived from empirical observations
+		// documented in this PR: https://github.com/prometheus/client_golang/pull/1661
 		maxBackoff     = 320 * time.Millisecond
 		initialBackoff = 10 * time.Millisecond
 	)

--- a/prometheus/atomic_update_test.go
+++ b/prometheus/atomic_update_test.go
@@ -1,0 +1,133 @@
+package prometheus
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"unsafe"
+)
+
+var output float64
+
+func TestAtomicUpdateFloat(t *testing.T) {
+	var val float64 = 0.0
+	bits := (*uint64)(unsafe.Pointer(&val))
+	var wg sync.WaitGroup
+	numGoroutines := 100000
+	increment := 1.0
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			atomicUpdateFloat(bits, func(f float64) float64 {
+				return f + increment
+			})
+		}()
+	}
+
+	wg.Wait()
+	expected := float64(numGoroutines) * increment
+	if val != expected {
+		t.Errorf("Expected %f, got %f", expected, val)
+	}
+}
+
+// Benchmark for atomicUpdateFloat with single goroutine (no contention).
+func BenchmarkAtomicUpdateFloat_SingleGoroutine(b *testing.B) {
+	var val float64 = 0.0
+	bits := (*uint64)(unsafe.Pointer(&val))
+
+	for i := 0; i < b.N; i++ {
+		atomicUpdateFloat(bits, func(f float64) float64 {
+			return f + 1.0
+		})
+	}
+
+	output = val
+}
+
+// Benchmark for old implementation with single goroutine (no contention) -> to check overhead of backoff
+func BenchmarkAtomicNoBackoff_SingleGoroutine(b *testing.B) {
+	var val float64 = 0.0
+	bits := (*uint64)(unsafe.Pointer(&val))
+
+	for i := 0; i < b.N; i++ {
+		for {
+			loadedBits := atomic.LoadUint64(bits)
+			newBits := math.Float64bits(math.Float64frombits(loadedBits) + 1.0)
+			if atomic.CompareAndSwapUint64(bits, loadedBits, newBits) {
+				break
+			}
+		}
+	}
+
+	output = val
+}
+
+// Benchmark varying the number of goroutines.
+func benchmarkAtomicUpdateFloatConcurrency(b *testing.B, numGoroutines int) {
+	var val float64 = 0.0
+	bits := (*uint64)(unsafe.Pointer(&val))
+	b.SetParallelism(numGoroutines)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			atomicUpdateFloat(bits, func(f float64) float64 {
+				return f + 1.0
+			})
+		}
+	})
+
+	output = val
+}
+
+func benchmarkAtomicNoBackoffFloatConcurrency(b *testing.B, numGoroutines int) {
+	var val float64 = 0.0
+	bits := (*uint64)(unsafe.Pointer(&val))
+	b.SetParallelism(numGoroutines)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for {
+				loadedBits := atomic.LoadUint64(bits)
+				newBits := math.Float64bits(math.Float64frombits(loadedBits) + 1.0)
+				if atomic.CompareAndSwapUint64(bits, loadedBits, newBits) {
+					break
+				}
+			}
+		}
+	})
+
+	output = val
+}
+
+func BenchmarkAtomicUpdateFloat_1Goroutine(b *testing.B) {
+	benchmarkAtomicUpdateFloatConcurrency(b, 1)
+}
+func BenchmarkAtomicNoBackoff_1Goroutine(b *testing.B) {
+	benchmarkAtomicNoBackoffFloatConcurrency(b, 1)
+}
+func BenchmarkAtomicUpdateFloat_2Goroutines(b *testing.B) {
+	benchmarkAtomicUpdateFloatConcurrency(b, 2)
+}
+func BenchmarkAtomicNoBackoff_2Goroutines(b *testing.B) {
+	benchmarkAtomicNoBackoffFloatConcurrency(b, 2)
+}
+func BenchmarkAtomicUpdateFloat_4Goroutines(b *testing.B) {
+	benchmarkAtomicUpdateFloatConcurrency(b, 4)
+}
+
+func BenchmarkAtomicNoBackoff_4Goroutines(b *testing.B) {
+	benchmarkAtomicNoBackoffFloatConcurrency(b, 4)
+}
+func BenchmarkAtomicUpdateFloat_8Goroutines(b *testing.B) {
+	benchmarkAtomicUpdateFloatConcurrency(b, 8)
+}
+
+func BenchmarkAtomicNoBackoff_8Goroutines(b *testing.B) {
+	benchmarkAtomicNoBackoffFloatConcurrency(b, 8)
+}

--- a/prometheus/atomic_update_test.go
+++ b/prometheus/atomic_update_test.go
@@ -1,3 +1,16 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package prometheus
 
 import (

--- a/prometheus/atomic_update_test.go
+++ b/prometheus/atomic_update_test.go
@@ -131,3 +131,19 @@ func BenchmarkAtomicUpdateFloat_8Goroutines(b *testing.B) {
 func BenchmarkAtomicNoBackoff_8Goroutines(b *testing.B) {
 	benchmarkAtomicNoBackoffFloatConcurrency(b, 8)
 }
+
+func BenchmarkAtomicUpdateFloat_16Goroutines(b *testing.B) {
+	benchmarkAtomicUpdateFloatConcurrency(b, 16)
+}
+
+func BenchmarkAtomicNoBackoff_16Goroutines(b *testing.B) {
+	benchmarkAtomicNoBackoffFloatConcurrency(b, 16)
+}
+
+func BenchmarkAtomicUpdateFloat_32Goroutines(b *testing.B) {
+	benchmarkAtomicUpdateFloatConcurrency(b, 32)
+}
+
+func BenchmarkAtomicNoBackoff_32Goroutines(b *testing.B) {
+	benchmarkAtomicNoBackoffFloatConcurrency(b, 32)
+}

--- a/prometheus/atomic_update_test.go
+++ b/prometheus/atomic_update_test.go
@@ -108,15 +108,19 @@ func benchmarkAtomicNoBackoffFloatConcurrency(b *testing.B, numGoroutines int) {
 func BenchmarkAtomicUpdateFloat_1Goroutine(b *testing.B) {
 	benchmarkAtomicUpdateFloatConcurrency(b, 1)
 }
+
 func BenchmarkAtomicNoBackoff_1Goroutine(b *testing.B) {
 	benchmarkAtomicNoBackoffFloatConcurrency(b, 1)
 }
+
 func BenchmarkAtomicUpdateFloat_2Goroutines(b *testing.B) {
 	benchmarkAtomicUpdateFloatConcurrency(b, 2)
 }
+
 func BenchmarkAtomicNoBackoff_2Goroutines(b *testing.B) {
 	benchmarkAtomicNoBackoffFloatConcurrency(b, 2)
 }
+
 func BenchmarkAtomicUpdateFloat_4Goroutines(b *testing.B) {
 	benchmarkAtomicUpdateFloatConcurrency(b, 4)
 }
@@ -124,6 +128,7 @@ func BenchmarkAtomicUpdateFloat_4Goroutines(b *testing.B) {
 func BenchmarkAtomicNoBackoff_4Goroutines(b *testing.B) {
 	benchmarkAtomicNoBackoffFloatConcurrency(b, 4)
 }
+
 func BenchmarkAtomicUpdateFloat_8Goroutines(b *testing.B) {
 	benchmarkAtomicUpdateFloatConcurrency(b, 8)
 }

--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -134,13 +134,9 @@ func (c *counter) Add(v float64) {
 		return
 	}
 
-	for {
-		oldBits := atomic.LoadUint64(&c.valBits)
-		newBits := math.Float64bits(math.Float64frombits(oldBits) + v)
-		if atomic.CompareAndSwapUint64(&c.valBits, oldBits, newBits) {
-			return
-		}
-	}
+	atomicUpdateFloat(&c.valBits, func(oldVal float64) float64 {
+		return oldVal + v
+	})
 }
 
 func (c *counter) AddWithExemplar(v float64, e Labels) {

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -120,13 +120,9 @@ func (g *gauge) Dec() {
 }
 
 func (g *gauge) Add(val float64) {
-	for {
-		oldBits := atomic.LoadUint64(&g.valBits)
-		newBits := math.Float64bits(math.Float64frombits(oldBits) + val)
-		if atomic.CompareAndSwapUint64(&g.valBits, oldBits, newBits) {
-			return
-		}
-	}
+	atomicUpdateFloat(&g.valBits, func(oldVal float64) float64 {
+		return oldVal + val
+	})
 }
 
 func (g *gauge) Sub(val float64) {

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -1621,13 +1621,9 @@ func waitForCooldown(count uint64, counts *histogramCounts) {
 // atomicAddFloat adds the provided float atomically to another float
 // represented by the bit pattern the bits pointer is pointing to.
 func atomicAddFloat(bits *uint64, v float64) {
-	for {
-		loadedBits := atomic.LoadUint64(bits)
-		newBits := math.Float64bits(math.Float64frombits(loadedBits) + v)
-		if atomic.CompareAndSwapUint64(bits, loadedBits, newBits) {
-			break
-		}
-	}
+	atomicUpdateFloat(bits, func(oldVal float64) float64 {
+		return oldVal + v
+	})
 }
 
 // atomicDecUint32 atomically decrements the uint32 p points to.  See

--- a/prometheus/process_collector_cgo_darwin.go
+++ b/prometheus/process_collector_cgo_darwin.go
@@ -22,9 +22,7 @@ import "C"
 import "fmt"
 
 func getMemory() (*memoryInfo, error) {
-	var (
-		rss, vsize C.ulonglong
-	)
+	var rss, vsize C.ulonglong
 
 	if err := C.get_memory_info(&rss, &vsize); err != 0 {
 		return nil, fmt.Errorf("task_info() failed with 0x%x", int(err))

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -468,13 +468,9 @@ func (s *noObjectivesSummary) Observe(v float64) {
 	n := atomic.AddUint64(&s.countAndHotIdx, 1)
 	hotCounts := s.counts[n>>63]
 
-	for {
-		oldBits := atomic.LoadUint64(&hotCounts.sumBits)
-		newBits := math.Float64bits(math.Float64frombits(oldBits) + v)
-		if atomic.CompareAndSwapUint64(&hotCounts.sumBits, oldBits, newBits) {
-			break
-		}
-	}
+	atomicUpdateFloat(&hotCounts.sumBits, func(oldVal float64) float64 {
+		return oldVal + v
+	})
 	// Increment count last as we take it as a signal that the observation
 	// is complete.
 	atomic.AddUint64(&hotCounts.count, 1)
@@ -516,14 +512,13 @@ func (s *noObjectivesSummary) Write(out *dto.Metric) error {
 	// Finally add all the cold counts to the new hot counts and reset the cold counts.
 	atomic.AddUint64(&hotCounts.count, count)
 	atomic.StoreUint64(&coldCounts.count, 0)
-	for {
-		oldBits := atomic.LoadUint64(&hotCounts.sumBits)
-		newBits := math.Float64bits(math.Float64frombits(oldBits) + sum.GetSampleSum())
-		if atomic.CompareAndSwapUint64(&hotCounts.sumBits, oldBits, newBits) {
-			atomic.StoreUint64(&coldCounts.sumBits, 0)
-			break
-		}
-	}
+
+	// Use atomicUpdateFloat to update hotCounts.sumBits atomically.
+	atomicUpdateFloat(&hotCounts.sumBits, func(oldVal float64) float64 {
+		return oldVal + sum.GetSampleSum()
+	})
+	atomic.StoreUint64(&coldCounts.sumBits, 0)
+
 	return nil
 }
 


### PR DESCRIPTION
## What problem this PR is solving

Hi! 
This kind of issues: https://github.com/cockroachdb/cockroach/issues/133306 pushed me to investigate if it is possible to optimize client metrics library in terms of CPU and performance especially under contention. So mostly this PR is about that.

## Proposed changes

Add sort of exponential backoff for tight loops on CAS operations, which potentially will decrease contention and as a result will lead to better latencies and lower CPU consumption. This is well known trick that is used in many projects that deal with concurrency.

In addition this logic was refactored into single place in code because case of atomic update of float64 can be meet in different parts of the codebase.

## Results

All test results are from AWS c7i.2xlarge type of instance.

main vs proposed for histograms:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/client_golang/prometheus
cpu: Intel(R) Xeon(R) Platinum 8488C
                           │ ../../bhOLD.txt │           ../../bhNEW.txt           │
                           │     sec/op      │    sec/op     vs base               │
HistogramWithLabelValues-8      87.81n ±  1%   90.36n ±  1%   +2.90% (p=0.002 n=6)
HistogramNoLabels-8             36.15n ±  1%   39.55n ±  0%   +9.42% (p=0.002 n=6)
HistogramObserve1-8             31.23n ±  1%   32.52n ±  1%   +4.15% (p=0.002 n=6)
HistogramObserve2-8            242.45n ± 16%   86.89n ±  0%  -64.16% (p=0.002 n=6)
HistogramObserve4-8             372.8n ± 14%   175.0n ± 19%  -53.05% (p=0.002 n=6)
HistogramObserve8-8             953.0n ±  1%   415.4n ± 32%  -56.41% (p=0.002 n=6)
HistogramWrite1-8               1.456µ ± 11%   1.454µ ± 12%        ~ (p=0.699 n=6)
HistogramWrite2-8               3.103µ ±  3%   3.125µ ±  7%        ~ (p=0.485 n=6)
HistogramWrite4-8               6.087µ ±  3%   6.041µ ±  4%        ~ (p=0.937 n=6)
HistogramWrite8-8               11.71µ ±  2%   11.90µ ±  3%   +1.61% (p=0.004 n=6)
geomean                         554.5n         434.5n        -21.64%

                           │ ../../bhOLD.txt │          ../../bhNEW.txt           │
                           │      B/op       │    B/op     vs base                │
HistogramWithLabelValues-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
HistogramNoLabels-8             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                    ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                           │ ../../bhOLD.txt │          ../../bhNEW.txt           │
                           │    allocs/op    │ allocs/op   vs base                │
HistogramWithLabelValues-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
HistogramNoLabels-8             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                    ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
changes leading to slight increase of latency in single-threaded use case but significantly decrease it in contended case.

main vs proposed for summaries:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/client_golang/prometheus
cpu: Intel(R) Xeon(R) Platinum 8488C
                         │ ../../bsOLD.txt │           ../../bsNEW.txt           │
                         │     sec/op      │    sec/op     vs base               │
SummaryWithLabelValues-8      264.0n ±  1%   267.6n ±  3%   +1.34% (p=0.017 n=6)
SummaryNoLabels-8             186.6n ±  1%   186.6n ±  0%        ~ (p=0.920 n=6)
SummaryObserve1-8             22.57n ±  1%   23.66n ±  0%   +4.83% (p=0.002 n=6)
SummaryObserve2-8            192.75n ± 31%   52.13n ±  1%  -72.95% (p=0.002 n=6)
SummaryObserve4-8             297.9n ± 27%   126.7n ± 16%  -57.47% (p=0.002 n=6)
SummaryObserve8-8             937.5n ±  5%   319.1n ± 48%  -65.96% (p=0.002 n=6)
SummaryWrite1-8               135.1n ± 32%   134.1n ±  9%        ~ (p=0.485 n=6)
SummaryWrite2-8               319.9n ±  3%   327.4n ±  4%        ~ (p=0.240 n=6)
SummaryWrite4-8               665.7n ±  5%   664.0n ±  9%        ~ (p=0.699 n=6)
SummaryWrite8-8               1.402µ ±  9%   1.318µ ± 11%        ~ (p=0.180 n=6)
geomean                       274.3n         198.6n        -27.59%

                         │ ../../bsOLD.txt │          ../../bsNEW.txt           │
                         │      B/op       │    B/op     vs base                │
SummaryWithLabelValues-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
SummaryNoLabels-8             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                  ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │ ../../bsOLD.txt │          ../../bsNEW.txt           │
                         │    allocs/op    │ allocs/op   vs base                │
SummaryWithLabelValues-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
SummaryNoLabels-8             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                  ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
same is true for summaries as well

Some additional illustrations:
Gap between implementations is wider for higher number of parallel/contending goroutines.
![image](https://github.com/user-attachments/assets/917c828a-b9c6-46ac-9ae0-e75061a330d5)
![image](https://github.com/user-attachments/assets/32048246-c39a-4e10-8719-d673c91bb4f4)

Side by side comparison of backoff/no-backoff implementations are in `atomic_update_test.go` file:
```
BenchmarkAtomicUpdateFloat_SingleGoroutine-8   	94284844	       12.59 ns/op
BenchmarkAtomicNoBackoff_SingleGoroutine-8     	97815223	       12.24 ns/op
BenchmarkAtomicUpdateFloat_1Goroutine-8        	91764830	       15.45 ns/op
BenchmarkAtomicNoBackoff_1Goroutine-8          	13282502	       90.47 ns/op
BenchmarkAtomicUpdateFloat_2Goroutines-8       	67590978	       19.70 ns/op
BenchmarkAtomicNoBackoff_2Goroutines-8         	13490074	       89.20 ns/op
BenchmarkAtomicUpdateFloat_4Goroutines-8       	88974640	       14.74 ns/op
BenchmarkAtomicNoBackoff_4Goroutines-8         	13480230	       89.29 ns/op
BenchmarkAtomicUpdateFloat_8Goroutines-8       	85171494	       13.94 ns/op
BenchmarkAtomicNoBackoff_8Goroutines-8         	13474435	       89.39 ns/op
BenchmarkAtomicUpdateFloat_16Goroutines-8      	80687557	       14.96 ns/op
BenchmarkAtomicNoBackoff_16Goroutines-8        	13556298	       90.21 ns/op
BenchmarkAtomicUpdateFloat_32Goroutines-8      	71862175	       14.98 ns/op
BenchmarkAtomicNoBackoff_32Goroutines-8        	13522851	       88.90 ns/op
```

### CPU profiles
for `go test -bench='BenchmarkHistogramObserve*' -run=^# -count=6`
old top:
```
      flat  flat%   sum%        cum   cum%
     0.56s  0.34%  0.34%    166.28s 99.93%  github.com/prometheus/client_golang/prometheus.benchmarkHistogramObserve.func1
     0.57s  0.34%  0.68%    165.71s 99.59%  github.com/prometheus/client_golang/prometheus.(*histogram).Observe
    32.65s 19.62% 20.30%    128.03s 76.94%  github.com/prometheus/client_golang/prometheus.(*histogram).observe
    56.26s 33.81% 54.11%     95.38s 57.32%  github.com/prometheus/client_golang/prometheus.(*histogramCounts).observe
    29.38s 17.66% 71.77%     39.12s 23.51%  github.com/prometheus/client_golang/prometheus.atomicAddFloat (inline)
     0.25s  0.15% 71.92%     37.11s 22.30%  github.com/prometheus/client_golang/prometheus.(*histogram).findBucket
    33.38s 20.06% 91.98%     36.86s 22.15%  sort.SearchFloat64s (inline)
     9.10s  5.47% 97.45%      9.10s  5.47%  math.Float64frombits (inline)
     2.05s  1.23% 98.68%      3.46s  2.08%  sort.Search
     1.41s  0.85% 99.53%      1.41s  0.85%  github.com/prometheus/client_golang/prometheus.(*histogram).findBucket.SearchFloat64s.func1
```
new top:
```
      flat  flat%   sum%        cum   cum%
     0.48s  1.94%  1.94%     24.61s 99.31%  github.com/prometheus/client_golang/prometheus.benchmarkHistogramObserve.func1
     0.41s  1.65%  3.59%     24.13s 97.38%  github.com/prometheus/client_golang/prometheus.(*histogram).Observe
     7.89s 31.84% 35.43%     19.77s 79.78%  github.com/prometheus/client_golang/prometheus.(*histogram).observe
        5s 20.18% 55.61%     11.88s 47.94%  github.com/prometheus/client_golang/prometheus.(*histogramCounts).observe
         0     0% 55.61%      6.88s 27.76%  github.com/prometheus/client_golang/prometheus.atomicAddFloat (inline)
     5.99s 24.17% 79.78%      6.88s 27.76%  github.com/prometheus/client_golang/prometheus.atomicUpdateFloat
     0.18s  0.73% 80.51%      3.95s 15.94%  github.com/prometheus/client_golang/prometheus.(*histogram).findBucket
     0.51s  2.06% 82.57%      3.77s 15.21%  sort.SearchFloat64s (inline)
     2.01s  8.11% 90.68%      3.26s 13.16%  sort.Search
     1.25s  5.04% 95.72%      1.25s  5.04%  github.com/prometheus/client_golang/prometheus.(*histogram).findBucket.SearchFloat64s.func1
```

## Downsides

Everything comes with the price, so in this case 
* code is slightly more complex
* some magic constants introduced (10ms and 320ms -- mostly result of empirical testing)
* single-threaded performance weaker by 4%-5%
* `time.sleep` introducing additional syscall (? not sure about that)

## Further improvements

* Some random jitter can be added to avoid thundering herd problem
* I briefly explored hybrid approach when there is staged backoff with first stage using `runtime.Gosched()` and only then `time.sleep` but it was not looking impressive from results point of view
* better code layout?

@vesari
@ArthurSens
@bwplotka
@kakkoyun


