### PR TITLE
Optimize BuildFQName function

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -108,15 +108,23 @@ func BuildFQName(namespace, subsystem, name string) string {
 	if name == "" {
 		return ""
 	}
-	switch {
-	case namespace != "" && subsystem != "":
-		return strings.Join([]string{namespace, subsystem, name}, "_")
-	case namespace != "":
-		return strings.Join([]string{namespace, name}, "_")
-	case subsystem != "":
-		return strings.Join([]string{subsystem, name}, "_")
+
+	sb := strings.Builder{}
+	sb.Grow(len(namespace) + len(subsystem) + len(name) + 2)
+
+	if namespace != "" {
+		sb.WriteString(namespace)
+		sb.WriteString("_")
 	}
-	return name
+
+	if subsystem != "" {
+		sb.WriteString(subsystem)
+		sb.WriteString("_")
+	}
+
+	sb.WriteString(name)
+
+	return sb.String()
 }
 
 type invalidMetric struct {


### PR DESCRIPTION
The BuildFQName function is used on many exporters multiple times.

The overall benefit might be quite low, but the I'm happy to contribute an optimization.

`strings.Builder` is available since go 1.10 and should me the current requirements.

```
% benchstat BenchmarkBuildFQName1.txt BenchmarkBuildFQName2.txt                                             
goos: darwin
goarch: amd64
pkg: github.com/prometheus/client_golang/prometheus
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
               │ BenchmarkBuildFQName1.txt │      BenchmarkBuildFQName2.txt      │
               │          sec/op           │   sec/op     vs base                │
BuildFQName1-8                 60.43n ± 0%   45.05n ± 0%  -25.44% (p=0.000 n=20)
BuildFQName2-8                 2.310n ± 1%   2.333n ± 1%   +1.00% (p=0.038 n=20)
BuildFQName3-8                 71.14n ± 1%   50.13n ± 0%  -29.53% (p=0.000 n=20)
geomean                        21.49n        17.40n       -19.04%
```

Go test commands:

```
go test -bench="BenchmarkBuildFQName" -run=^BenchmarkBuildFQName -count=20 | tee BenchmarkBuildFQName1.txt
```

Benchmark File:

```
func BenchmarkBuildFQName1(b *testing.B) {
	for i := 0; i < b.N; i++ {
		prometheus.BuildFQName("node", "", "usage_seconds_total")
	}
}

func BenchmarkBuildFQName2(b *testing.B) {
	for i := 0; i < b.N; i++ {
		prometheus.BuildFQName("node", "cpu", "")
	}
}

func BenchmarkBuildFQName3(b *testing.B) {
	for i := 0; i < b.N; i++ {
		prometheus.BuildFQName("node", "cpu", "usage_seconds_total")
	}
}
```