### PR TITLE
fix: replace fmt.Errorf with errors.New

### DIFF
--- a/prometheus/process_collector_darwin.go
+++ b/prometheus/process_collector_darwin.go
@@ -25,7 +25,7 @@ import (
 
 // notImplementedErr is returned by stub functions that replace cgo functions, when cgo
 // isn't available.
-var notImplementedErr = fmt.Errorf("not implemented")
+var notImplementedErr = errors.New("not implemented")
 
 type memoryInfo struct {
 	vsize uint64 // Virtual memory size in bytes


### PR DESCRIPTION
```shell
prometheus/process_collector_darwin.go:28:25: fmt.Errorf can be replaced with errors.New (perfsprint)
var notImplementedErr = fmt.Errorf("not implemented")
```

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
