### PR TITLE
fix: add very small delay between observations in `TestHistogramAtomicObserve`

### DIFF
--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -382,6 +382,7 @@ func TestHistogramAtomicObserve(t *testing.T) {
 				return
 			default:
 				his.Observe(1)
+				time.Sleep(time.Nanosecond)
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

Test `TestHistogramAtomicObserve` taking too long to complete after introducing [this](https://github.com/prometheus/client_golang/pull/1661) change:

```
=== RUN   TestHistogramAtomicObserve
--- PASS: TestHistogramAtomicObserve (487.82s)
```
## Analysis

@ywwg pointed out that increase for this test runtime were introduced after adding exponential back-off to histograms.
If we will take a look at this test closely we will see that observations here
```go
for {
	select {
	case <-quit:
		return
	default:
		his.Observe(1)
	}
}
```

introduced in a very high pace inside tight loop without any delay or limit.
*  With multiple goroutines failing CAS operations and backing off, they sleep for significant amounts of time. 
* This leads to longer wait times for the `waitForCooldown` function in the `Write` method, as observations are delayed.
* Previous implementation used a CAS loop without sleeping even though CAS failures occurred, goroutines would retry immediately, eventually succeeding. 
* This kept the observations progressing quickly, and the test ran faster. The addition of sleep delays introduces significant latency during high contention. 

## Solution

Under typical workloads, contention is usually not as extreme as in this test. Observations has at least some delays between them. So proposal is to alter test by adding nanosecond sleep to it, which significantly reduce runtime and makes it a little bit closer to what happens typically in production.

```
=== RUN   TestHistogramAtomicObserve
--- PASS: TestHistogramAtomicObserve (0.76s)
```

