### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -418,7 +418,7 @@ type HandlerOpts struct {
 	// Created Timestamps for counters, histograms and summaries, which for the current
 	// version of OpenMetrics are defined as extra series with the same name and "_created"
 	// suffix. See also the OpenMetrics specification for more details
-	// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#counter-1
+	// https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#counter-1
 	//
 	// Created timestamps are used to improve the accuracy of reset detection,
 	// but the way it's designed in OpenMetrics 1.0 it also dramatically increases cardinality


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.