### PR TITLE
Upgrade to prometheus/common 0.62.0 with breaking change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/kylelemons/godebug v1.1.0
 	github.com/prometheus/client_model v0.6.1
-	github.com/prometheus/common v0.61.0
+	github.com/prometheus/common v0.62.0
 	github.com/prometheus/procfs v0.15.1
 	golang.org/x/sys v0.28.0
 	google.golang.org/protobuf v1.36.1
@@ -23,7 +23,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	golang.org/x/net v0.32.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
-github.com/prometheus/common v0.61.0 h1:3gv/GThfX0cV2lpO7gkTUwZru38mxevy90Bj8YFSRQQ=
-github.com/prometheus/common v0.61.0/go.mod h1:zr29OCN/2BsJRaFwG8QOBr41D6kkchKbpeNH7pAjb/s=
+github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
+github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
@@ -46,8 +46,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -291,7 +291,7 @@ func TestCounterExemplar(t *testing.T) {
 			}
 		}()
 		// Should panic because of invalid label name.
-		counter.AddWithExemplar(42, Labels{":o)": "smile"})
+		counter.AddWithExemplar(42, Labels{"in\x80valid": "smile"})
 		return nil
 	}
 	if addExemplarWithInvalidLabel() == nil {

--- a/prometheus/internal/go_runtime_metrics.go
+++ b/prometheus/internal/go_runtime_metrics.go
@@ -66,7 +66,8 @@ func RuntimeMetricsToProm(d *metrics.Description) (string, string, string, bool)
 		name += "_total"
 	}
 
-	valid := model.IsValidMetricName(model.LabelValue(namespace + "_" + subsystem + "_" + name))
+	// Our current conversion moves to legacy naming, so use legacy validation.
+	valid := model.IsValidLegacyMetricName(namespace + "_" + subsystem + "_" + name)
 	switch d.Kind {
 	case metrics.KindUint64:
 	case metrics.KindFloat64:

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -66,7 +66,7 @@ func TestLabelCheck(t *testing.T) {
 		},
 		"all labels used with an invalid const label name": {
 			varLabels:     []string{"code", "method"},
-			constLabels:   []string{"in-valid", "bar"},
+			constLabels:   []string{"in\x80valid", "bar"},
 			curriedLabels: []string{"dings", "bums"},
 			dynamicLabels: []string{"dyn", "amics"},
 			ok:            false,
@@ -120,14 +120,14 @@ func TestLabelCheck(t *testing.T) {
 			ok:            false,
 		},
 		"invalid name and otherwise empty": {
-			metricName:    "in-valid",
+			metricName:    "in\x80valid",
 			varLabels:     []string{},
 			constLabels:   []string{},
 			curriedLabels: []string{},
 			ok:            false,
 		},
 		"invalid name with all the otherwise valid labels": {
-			metricName:    "in-valid",
+			metricName:    "in\x80valid",
 			varLabels:     []string{"code", "method"},
 			constLabels:   []string{"foo", "bar"},
 			curriedLabels: []string{"dings", "bums"},

--- a/prometheus/push/push_test.go
+++ b/prometheus/push/push_test.go
@@ -229,7 +229,7 @@ func TestPush(t *testing.T) {
 		t.Error("push with grouping contained in metrics succeeded")
 	}
 	if err := New(pgwOK.URL, "testjob").
-		Grouping("foo-bar", "bums").
+		Grouping("foo\x80bar", "bums").
 		Collector(metric1).
 		Collector(metric2).
 		Push(); err == nil {

--- a/prometheus/wrap_test.go
+++ b/prometheus/wrap_test.go
@@ -153,7 +153,7 @@ func TestWrap(t *testing.T) {
 			output: []Collector{simpleGge, labeledPreCnt},
 		},
 		"wrap counter with invalid prefix": {
-			prefix:      "1+1",
+			prefix:      "1\x801",
 			preRegister: []Collector{simpleGge},
 			toRegister: []struct {
 				collector         Collector
@@ -163,7 +163,7 @@ func TestWrap(t *testing.T) {
 		},
 		"wrap counter with invalid label": {
 			preRegister: []Collector{simpleGge},
-			labels:      Labels{"42": "bar"},
+			labels:      Labels{"\x80": "bar"},
 			toRegister: []struct {
 				collector         Collector
 				registrationFails bool


### PR DESCRIPTION
common 0.62.0 switches NameValidationScheme global variable to UTF8Validation. While relaxing validation this will likely yield test failures downstream.

It's unfortunate, but the alternatives were worse: https://github.com/prometheus/common/pull/724

Good news is that client_golang should work with older common deps and callers can easily change model.NameValidationScheme value to old value to solve any compatibility issues.

