### PR TITLE
process collector: Fixed pedantic registry failures on darwin with cgo.

### DIFF
--- a/prometheus/process_collector_cgo_darwin.go
+++ b/prometheus/process_collector_cgo_darwin.go
@@ -30,3 +30,22 @@ func getMemory() (*memoryInfo, error) {
 
 	return &memoryInfo{vsize: uint64(vsize), rss: uint64(rss)}, nil
 }
+
+// describe returns all descriptions of the collector for Darwin.
+// Ensure that this list of descriptors is kept in sync with the metrics collected
+// in the processCollect method. Any changes to the metrics in processCollect
+// (such as adding or removing metrics) should be reflected in this list of descriptors.
+func (c *processCollector) describe(ch chan<- *Desc) {
+	ch <- c.cpuTotal
+	ch <- c.openFDs
+	ch <- c.maxFDs
+	ch <- c.maxVsize
+	ch <- c.startTime
+	ch <- c.rss
+	ch <- c.vsize
+
+	/* the process could be collected but not implemented yet
+	ch <- c.inBytes
+	ch <- c.outBytes
+	*/
+}

--- a/prometheus/process_collector_darwin.go
+++ b/prometheus/process_collector_darwin.go
@@ -69,25 +69,6 @@ func getOpenFileCount() (float64, error) {
 	}
 }
 
-// describe returns all descriptions of the collector for Darwin.
-// Ensure that this list of descriptors is kept in sync with the metrics collected
-// in the processCollect method. Any changes to the metrics in processCollect
-// (such as adding or removing metrics) should be reflected in this list of descriptors.
-func (c *processCollector) describe(ch chan<- *Desc) {
-	ch <- c.cpuTotal
-	ch <- c.openFDs
-	ch <- c.maxFDs
-	ch <- c.maxVsize
-	ch <- c.startTime
-
-	/* the process could be collected but not implemented yet
-	ch <- c.rss
-	ch <- c.vsize
-	ch <- c.inBytes
-	ch <- c.outBytes
-	*/
-}
-
 func (c *processCollector) processCollect(ch chan<- Metric) {
 	if procs, err := unix.SysctlKinfoProcSlice("kern.proc.pid", os.Getpid()); err == nil {
 		if len(procs) == 1 {

--- a/prometheus/process_collector_nocgo_darwin.go
+++ b/prometheus/process_collector_nocgo_darwin.go
@@ -18,3 +18,22 @@ package prometheus
 func getMemory() (*memoryInfo, error) {
 	return nil, notImplementedErr
 }
+
+// describe returns all descriptions of the collector for Darwin.
+// Ensure that this list of descriptors is kept in sync with the metrics collected
+// in the processCollect method. Any changes to the metrics in processCollect
+// (such as adding or removing metrics) should be reflected in this list of descriptors.
+func (c *processCollector) describe(ch chan<- *Desc) {
+	ch <- c.cpuTotal
+	ch <- c.openFDs
+	ch <- c.maxFDs
+	ch <- c.maxVsize
+	ch <- c.startTime
+
+	/* the process could be collected but not implemented yet
+	ch <- c.rss
+	ch <- c.vsize
+	ch <- c.inBytes
+	ch <- c.outBytes
+	*/
+}


### PR DESCRIPTION
Errors:

```
 * collected metric process_resident_memory_bytes gauge:{value:8.798208e+06} with unregistered descriptor Desc{fqName: "process_resident_memory_bytes", help: "Resident memory size in bytes.", constLabels: {}, variableLabels: {}}
 * collected metric process_virtual_memory_bytes gauge:{value:4.2175053824e+11} with unregistered descriptor Desc{fqName: "process_virtual_memory_bytes", help: "Virtual memory size in bytes.", constLabels: {}, variableLabels: {}}

```