### PR TITLE
[Experiment] fastdto for MakePairLabels (on top of #1734) 

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -94,7 +94,7 @@ func NewCounter(opts CounterOpts) Counter {
 	if opts.now == nil {
 		opts.now = time.Now
 	}
-	result := &counter{desc: desc, labelPairs: desc.constLabelPairs, now: opts.now}
+	result := &counter{desc: desc, labelPairs: desc.labelPairs, now: opts.now}
 	result.init(result) // Init self-collection.
 	result.createdTs = timestamppb.New(opts.now())
 	return result

--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -19,6 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/internal/fastdto"
+
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -94,7 +96,7 @@ func NewCounter(opts CounterOpts) Counter {
 	if opts.now == nil {
 		opts.now = time.Now
 	}
-	result := &counter{desc: desc, labelPairs: desc.labelPairs, now: opts.now}
+	result := &counter{desc: desc, labelPairs: fastdto.ToDTOLabelPair(desc.labelPairs), now: opts.now}
 	result.init(result) // Init self-collection.
 	result.createdTs = timestamppb.New(opts.now())
 	return result

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -47,12 +47,17 @@ type Desc struct {
 	fqName string
 	// help provides some helpful information about this metric.
 	help string
-	// constLabelPairs contains precalculated DTO label pairs based on
-	// the constant labels.
-	constLabelPairs []*dto.LabelPair
 	// variableLabels contains names of labels and normalization function for
 	// which the metric maintains variable values.
 	variableLabels *compiledLabels
+	// labelPairs contains the sorted DTO label pairs based on the constant labels
+	// and variable labels
+	labelPairs []*dto.LabelPair
+	// variableLabelIndexesInLabelPairs holds all indexes variable labels in the
+	// labelPairs with the expected index of the variableLabel. This makes it easy
+	// to identify all variable labels in the labelPairs and where to get their value
+	// from when given the variable label values
+	variableLabelIndexesInLabelPairs map[int]int
 	// id is a hash of the values of the ConstLabels and fqName. This
 	// must be unique among all registered descriptors and can therefore be
 	// used as an identifier of the descriptor.
@@ -160,14 +165,36 @@ func (v2) NewDesc(fqName, help string, variableLabels ConstrainableLabels, const
 	}
 	d.dimHash = xxh.Sum64()
 
-	d.constLabelPairs = make([]*dto.LabelPair, 0, len(constLabels))
+	d.labelPairs = make([]*dto.LabelPair, 0, len(constLabels)+len(d.variableLabels.names))
 	for n, v := range constLabels {
-		d.constLabelPairs = append(d.constLabelPairs, &dto.LabelPair{
+		d.labelPairs = append(d.labelPairs, &dto.LabelPair{
 			Name:  proto.String(n),
 			Value: proto.String(v),
 		})
 	}
-	sort.Sort(internal.LabelPairSorter(d.constLabelPairs))
+	for _, labelName := range d.variableLabels.names {
+		d.labelPairs = append(d.labelPairs, &dto.LabelPair{
+			Name: proto.String(labelName),
+		})
+	}
+	sort.Sort(internal.LabelPairSorter(d.labelPairs))
+
+	// In order to facilitate mapping from the unsorted variable labels to
+	// the sorted variable labels we generate a mapping from output labelPair
+	// index -> variableLabel index for constructing the final label pairs later
+	d.variableLabelIndexesInLabelPairs = make(map[int]int, len(d.variableLabels.names))
+	for outputIndex, pair := range d.labelPairs {
+		// Constant labels have values variable labels do not
+		if pair.Value != nil {
+			continue
+		}
+		for sourceIndex, variableLabel := range d.variableLabels.names {
+			if variableLabel == pair.GetName() {
+				d.variableLabelIndexesInLabelPairs[outputIndex] = sourceIndex
+			}
+		}
+	}
+
 	return d
 }
 
@@ -182,8 +209,11 @@ func NewInvalidDesc(err error) *Desc {
 }
 
 func (d *Desc) String() string {
-	lpStrings := make([]string, 0, len(d.constLabelPairs))
-	for _, lp := range d.constLabelPairs {
+	lpStrings := make([]string, 0, len(d.labelPairs))
+	for _, lp := range d.labelPairs {
+		if lp.Value == nil {
+			continue
+		}
 		lpStrings = append(
 			lpStrings,
 			fmt.Sprintf("%s=%q", lp.GetName(), lp.GetValue()),

--- a/prometheus/desc_test.go
+++ b/prometheus/desc_test.go
@@ -14,6 +14,7 @@
 package prometheus
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -59,5 +60,31 @@ func TestNewInvalidDesc_String(t *testing.T) {
 	)
 	if desc.String() != `Desc{fqName: "", help: "", constLabels: {}, variableLabels: {}}` {
 		t.Errorf("String: unexpected output: %s", desc.String())
+	}
+}
+
+func BenchmarkNewDesc(b *testing.B) {
+	for _, bm := range []struct {
+		labelCount int
+		descFunc   func() *Desc
+	}{
+		{
+			labelCount: 1,
+			descFunc:   new1LabelDescFunc,
+		},
+		{
+			labelCount: 3,
+			descFunc:   new3LabelsDescFunc,
+		},
+		{
+			labelCount: 10,
+			descFunc:   new10LabelsDescFunc,
+		},
+	} {
+		b.Run(fmt.Sprintf("labels=%v", bm.labelCount), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bm.descFunc()
+			}
+		})
 	}
 }

--- a/prometheus/desc_test.go
+++ b/prometheus/desc_test.go
@@ -63,6 +63,18 @@ func TestNewInvalidDesc_String(t *testing.T) {
 	}
 }
 
+/*
+	 export bench=newDesc && go test ./prometheus \
+		-run '^$' -bench '^BenchmarkNewDesc/labels=10' \
+		-benchtime 5s -benchmem -cpu 2 -timeout 999m \
+		-memprofile=${bench}.mem.pprof \
+		| tee ${bench}.txt
+
+	 export bench=newDesc-v2 && go test ./prometheus \
+		-run '^$' -bench '^BenchmarkNewDesc' \
+		-benchtime 5s -benchmem -count=6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
 func BenchmarkNewDesc(b *testing.B) {
 	for _, bm := range []struct {
 		labelCount int
@@ -82,6 +94,8 @@ func BenchmarkNewDesc(b *testing.B) {
 		},
 	} {
 		b.Run(fmt.Sprintf("labels=%v", bm.labelCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				bm.descFunc()
 			}

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -82,7 +82,7 @@ func NewGauge(opts GaugeOpts) Gauge {
 		nil,
 		opts.ConstLabels,
 	)
-	result := &gauge{desc: desc, labelPairs: desc.constLabelPairs}
+	result := &gauge{desc: desc, labelPairs: desc.labelPairs}
 	result.init(result) // Init self-collection.
 	return result
 }

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/internal/fastdto"
+
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -82,7 +84,7 @@ func NewGauge(opts GaugeOpts) Gauge {
 		nil,
 		opts.ConstLabels,
 	)
-	result := &gauge{desc: desc, labelPairs: desc.labelPairs}
+	result := &gauge{desc: desc, labelPairs: fastdto.ToDTOLabelPair(desc.labelPairs)}
 	result.init(result) // Init self-collection.
 	return result
 }

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -537,12 +537,7 @@ func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogr
 		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, labelValues))
 	}
 
-	for _, n := range desc.variableLabels.names {
-		if n == bucketLabel {
-			panic(errBucketLabelNotAllowed)
-		}
-	}
-	for _, lp := range desc.constLabelPairs {
+	for _, lp := range desc.labelPairs {
 		if lp.GetName() == bucketLabel {
 			panic(errBucketLabelNotAllowed)
 		}

--- a/prometheus/internal/fastdto/labels.go
+++ b/prometheus/internal/fastdto/labels.go
@@ -1,0 +1,58 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastdto
+
+import (
+	dto "github.com/prometheus/client_model/go"
+)
+
+type LabelPair struct {
+	Name  string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Value string `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+}
+
+func (p LabelPair) GetName() string {
+	return p.Name
+}
+
+func (p LabelPair) GetValue() string {
+	return p.Value
+}
+
+// LabelPairSorter implements sort.Interface. It is used to sort a slice of
+// LabelPairs
+type LabelPairSorter []LabelPair
+
+func (s LabelPairSorter) Len() int {
+	return len(s)
+}
+
+func (s LabelPairSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s LabelPairSorter) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+func ToDTOLabelPair(in []LabelPair) []*dto.LabelPair {
+	ret := make([]*dto.LabelPair, len(in))
+	for i := range in {
+		ret[i] = &dto.LabelPair{
+			Name:  &(in[i].Name),
+			Value: &(in[i].Value),
+		}
+	}
+	return ret
+}

--- a/prometheus/internal/fastdto/labels_test.go
+++ b/prometheus/internal/fastdto/labels_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastdto
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+)
+
+func BenchmarkToDTOLabelPairs(b *testing.B) {
+	test := []LabelPair{
+		{"foo", "bar"},
+		{"foo2", "bar2"},
+		{"foo3", "bar3"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ToDTOLabelPair(test)
+	}
+}
+
+func TestLabelPairSorter(t *testing.T) {
+	test := []LabelPair{
+		{"foo3", "bar3"},
+		{"foo", "bar"},
+		{"foo2", "bar2"},
+	}
+	sort.Sort(LabelPairSorter(test))
+
+	expected := []LabelPair{
+		{"foo", "bar"},
+		{"foo2", "bar2"},
+		{"foo3", "bar3"},
+	}
+	if diff := cmp.Diff(test, expected); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestToDTOLabelPair(t *testing.T) {
+	test := []LabelPair{
+		{"foo", "bar"},
+		{"foo2", "bar2"},
+		{"foo3", "bar3"},
+	}
+	expected := []*dto.LabelPair{
+		{Name: proto.String("foo"), Value: proto.String("bar")},
+		{Name: proto.String("foo2"), Value: proto.String("bar2")},
+		{Name: proto.String("foo3"), Value: proto.String("bar3")},
+	}
+	if diff := cmp.Diff(ToDTOLabelPair(test), expected, cmpopts.IgnoreUnexported(dto.LabelPair{})); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -971,7 +971,7 @@ func checkDescConsistency(
 	for i, lpFromDesc := range desc.labelPairs {
 		lpFromMetric := dtoMetric.Label[i]
 		if lpFromDesc.GetName() != lpFromMetric.GetName() ||
-			lpFromDesc.Value != nil && lpFromDesc.GetValue() != lpFromMetric.GetValue() {
+			lpFromDesc.Value != "" && lpFromDesc.GetValue() != lpFromMetric.GetValue() {
 			return fmt.Errorf(
 				"labels in collected metric %s %s are inconsistent with descriptor %s",
 				metricFamily.GetName(), dtoMetric, desc,

--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -962,21 +962,13 @@ func checkDescConsistency(
 	}
 
 	// Is the desc consistent with the content of the metric?
-	lpsFromDesc := make([]*dto.LabelPair, len(desc.constLabelPairs), len(dtoMetric.Label))
-	copy(lpsFromDesc, desc.constLabelPairs)
-	for _, l := range desc.variableLabels.names {
-		lpsFromDesc = append(lpsFromDesc, &dto.LabelPair{
-			Name: proto.String(l),
-		})
-	}
-	if len(lpsFromDesc) != len(dtoMetric.Label) {
+	if len(desc.labelPairs) != len(dtoMetric.Label) {
 		return fmt.Errorf(
 			"labels in collected metric %s %s are inconsistent with descriptor %s",
 			metricFamily.GetName(), dtoMetric, desc,
 		)
 	}
-	sort.Sort(internal.LabelPairSorter(lpsFromDesc))
-	for i, lpFromDesc := range lpsFromDesc {
+	for i, lpFromDesc := range desc.labelPairs {
 		lpFromMetric := dtoMetric.Label[i]
 		if lpFromDesc.GetName() != lpFromMetric.GetName() ||
 			lpFromDesc.Value != nil && lpFromDesc.GetValue() != lpFromMetric.GetValue() {

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -196,12 +196,7 @@ func newSummary(desc *Desc, opts SummaryOpts, labelValues ...string) Summary {
 		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, labelValues))
 	}
 
-	for _, n := range desc.variableLabels.names {
-		if n == quantileLabel {
-			panic(errQuantileLabelNotAllowed)
-		}
-	}
-	for _, lp := range desc.constLabelPairs {
+	for _, lp := range desc.labelPairs {
 		if lp.GetName() == quantileLabel {
 			panic(errQuantileLabelNotAllowed)
 		}

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -221,20 +221,22 @@ func MakeLabelPairs(desc *Desc, labelValues []string) []*dto.LabelPair {
 		return desc.labelPairs
 	}
 	labelPairs := make([]*dto.LabelPair, 0, len(desc.labelPairs))
-	for i, lp := range desc.labelPairs {
+	for _, lp := range desc.labelPairs {
 		var labelToAdd *dto.LabelPair
-		// Variable labels have no value and need to be inserted with a new dto.LabelPair containing the labelValue
+		// Variable labels have no value and need to be inserted with a new dto.LabelPair containing the labelValue.
 		if lp.Value == nil {
-			variableLabelIndex := desc.variableLabelIndexesInLabelPairs[i]
 			labelToAdd = &dto.LabelPair{
-				Name:  lp.Name,
-				Value: proto.String(labelValues[variableLabelIndex]),
+				Name: lp.Name,
 			}
 		} else {
 			labelToAdd = lp
 		}
 		labelPairs = append(labelPairs, labelToAdd)
 	}
+	for i, outputIndex := range desc.variableLabelOrder {
+		labelPairs[outputIndex].Value = proto.String(labelValues[i])
+	}
+
 	return labelPairs
 }
 

--- a/prometheus/value_test.go
+++ b/prometheus/value_test.go
@@ -217,6 +217,18 @@ var new10LabelsDescFunc = func() *Desc {
 		Labels{"const-label-4": "value", "const-label-1": "value", "const-label-7": "value", "const-label-2": "value", "const-label-9": "value", "const-label-8": "value", "const-label-10": "value", "const-label-3": "value", "const-label-6": "value", "const-label-5": "value"})
 }
 
+/*
+	 export bench=makeLabelPairs-v2 && go test ./prometheus \
+		-run '^$' -bench '^BenchmarkMakeLabelPairs' \
+		-benchtime 5s -benchmem -count=6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+
+	export bench=makeLabelPairs-v2pp && go test ./prometheus \
+		-run '^$' -bench '^BenchmarkMakeLabelPairs' \
+		-benchtime 5s -benchmem -cpu 2 -timeout 999m \
+		-memprofile=${bench}.mem.pprof \
+		| tee ${bench}.txt
+*/
 func BenchmarkMakeLabelPairs(b *testing.B) {
 	for _, bm := range []struct {
 		desc                *Desc
@@ -236,6 +248,8 @@ func BenchmarkMakeLabelPairs(b *testing.B) {
 		},
 	} {
 		b.Run(fmt.Sprintf("labels=%v", len(bm.makeLabelPairValues)), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				MakeLabelPairs(bm.desc, bm.makeLabelPairValues)
 			}

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -188,17 +188,20 @@ func (m *wrappingMetric) Write(out *dto.Metric) error {
 
 func wrapDesc(desc *Desc, prefix string, labels Labels) *Desc {
 	constLabels := Labels{}
-	for _, lp := range desc.constLabelPairs {
-		constLabels[*lp.Name] = *lp.Value
+	for _, lp := range desc.labelPairs {
+		// Variable labels have no values
+		if lp.Value != nil {
+			constLabels[*lp.Name] = *lp.Value
+		}
 	}
 	for ln, lv := range labels {
 		if _, alreadyUsed := constLabels[ln]; alreadyUsed {
 			return &Desc{
-				fqName:          desc.fqName,
-				help:            desc.help,
-				variableLabels:  desc.variableLabels,
-				constLabelPairs: desc.constLabelPairs,
-				err:             fmt.Errorf("attempted wrapping with already existing label name %q", ln),
+				fqName:         desc.fqName,
+				help:           desc.help,
+				variableLabels: desc.variableLabels,
+				labelPairs:     desc.labelPairs,
+				err:            fmt.Errorf("attempted wrapping with already existing label name %q", ln),
 			}
 		}
 		constLabels[ln] = lv

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -190,8 +190,8 @@ func wrapDesc(desc *Desc, prefix string, labels Labels) *Desc {
 	constLabels := Labels{}
 	for _, lp := range desc.labelPairs {
 		// Variable labels have no values
-		if lp.Value != nil {
-			constLabels[*lp.Name] = *lp.Value
+		if lp.Value == "" {
+			constLabels[lp.Name] = lp.Value
 		}
 	}
 	for ln, lv := range labels {


### PR DESCRIPTION
Experimenting with tailored dto for https://github.com/prometheus/client_golang/pull/1734

*dto.LabelPairs are pretty bad. We got stuck with *dto.Metric in our API since the beginning. This is problematic with the notorious use of small objects and pointers everywhere and all structs are bigger to support unknown fields and parsing. We don't need any of this in client_golang - it's just overhead for us. We only need interim struct and fast encoding.

This is also the reason why we can't optimize https://github.com/prometheus/client_golang/pull/1734 further.

We always wanted to do move out, but we can't change dto.Metric use due to compatibility....

...unless we can (: 

We could start introducing it slowly and then do `Write2(m fastdto.Metric)` or so API if we want (or release v2 client golang which I would love to avoid).


Benchmarks are not ideal. I think it keeps the CPU adventage of https://github.com/prometheus/client_golang/pull/1734, but "reverts" the allocs to where they were.

```
benchstat newDesc-v1.txt newDesc-v2.txt 
goos: darwin
goarch: arm64
pkg: github.com/prometheus/client_golang/prometheus
                    │ newDesc-v1.txt │           newDesc-v2.txt            │
                    │     sec/op     │    sec/op     vs base               │
NewDesc/labels=1-2      547.5n ± 15%   420.8n ±  6%  -23.14% (p=0.002 n=6)
NewDesc/labels=3-2     1152.5n ±  3%   879.6n ± 17%  -23.68% (p=0.002 n=6)
NewDesc/labels=10-2     4.955µ ±  3%   3.929µ ±  6%  -20.71% (p=0.002 n=6)
geomean                 1.462µ         1.133µ        -22.52%

                    │ newDesc-v1.txt │           newDesc-v2.txt            │
                    │      B/op      │     B/op      vs base               │
NewDesc/labels=1-2        504.0 ± 0%     376.0 ± 0%  -25.40% (p=0.002 n=6)
NewDesc/labels=3-2       1064.0 ± 0%     680.0 ± 0%  -36.09% (p=0.002 n=6)
NewDesc/labels=10-2     4.488Ki ± 0%   3.301Ki ± 0%  -26.46% (p=0.002 n=6)
geomean                 1.319Ki          952.5       -29.48%

                    │ newDesc-v1.txt │          newDesc-v2.txt           │
                    │   allocs/op    │ allocs/op   vs base               │
NewDesc/labels=1-2        15.00 ± 0%   10.00 ± 0%  -33.33% (p=0.002 n=6)
NewDesc/labels=3-2        27.00 ± 0%   12.00 ± 0%  -55.56% (p=0.002 n=6)
NewDesc/labels=10-2       72.00 ± 0%   22.00 ± 0%  -69.44% (p=0.002 n=6)
geomean                   30.78        13.82       -55.10%
```

```
benchstat makeLabelPairs-v1.txt makeLabelPairs-v2.txt
goos: darwin
goarch: arm64
pkg: github.com/prometheus/client_golang/prometheus
                           │ makeLabelPairs-v1.txt │       makeLabelPairs-v2.txt        │
                           │        sec/op         │    sec/op     vs base              │
MakeLabelPairs/labels=1-2             65.21n ±  6%   66.42n ± 19%       ~ (p=0.132 n=6)
MakeLabelPairs/labels=3-2             156.8n ±  1%   171.2n ±  3%  +9.18% (p=0.002 n=6)
MakeLabelPairs/labels=10-2            501.5n ± 12%   516.2n ±  4%       ~ (p=0.310 n=6)
geomean                               172.4n         180.4n        +4.61%

                           │ makeLabelPairs-v1.txt │       makeLabelPairs-v2.txt        │
                           │         B/op          │    B/op      vs base               │
MakeLabelPairs/labels=1-2               96.00 ± 0%   144.00 ± 0%  +50.00% (p=0.002 n=6)
MakeLabelPairs/labels=3-2               288.0 ± 0%    432.0 ± 0%  +50.00% (p=0.002 n=6)
MakeLabelPairs/labels=10-2              960.0 ± 0%   1440.0 ± 0%  +50.00% (p=0.002 n=6)
geomean                                 298.3         447.4       +50.00%

                           │ makeLabelPairs-v1.txt │       makeLabelPairs-v2.txt        │
                           │       allocs/op       │ allocs/op   vs base                │
MakeLabelPairs/labels=1-2               3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=6) ¹
MakeLabelPairs/labels=3-2               7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=6) ¹
MakeLabelPairs/labels=10-2              21.00 ± 0%   21.00 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                 7.612        7.612       +0.00%
¹ all samples are equal
```

I think for the next iteration we could try moving this cost to `Write` (so when collect is used). When collecting one could pool/reuse dto.Metrics OR use `Write2` with fastdto Metric 🤔 