### PR TITLE
exp/api: Add accepted msg type validation to handler

### DIFF
--- a/exp/api/remote/remote_api.go
+++ b/exp/api/remote/remote_api.go
@@ -379,7 +379,6 @@ type writeStorage interface {
 type handler struct {
 	store                writeStorage
 	acceptedMessageTypes MessageTypes
-	acceptedMap          map[WriteMessageType]struct{}
 	opts                 handlerOpts
 }
 
@@ -470,7 +469,6 @@ func NewHandler(store writeStorage, acceptedMessageTypes MessageTypes, opts ...H
 		opts:                 o,
 		store:                store,
 		acceptedMessageTypes: acceptedMessageTypes,
-		acceptedMap:          acceptedMessageTypes.Map(),
 	}
 
 	// Apply all middlewares in order
@@ -532,7 +530,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := h.acceptedMap[msgType]; !ok {
+	if !h.acceptedMessageTypes.Contains(msgType) {
 		err := fmt.Errorf("%v protobuf message is not accepted by this server; only accepts %v", msgType, h.acceptedMessageTypes.String())
 		h.opts.logger.Error("Unaccepted message type", "msgType", msgType, "err", err)
 		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)

--- a/exp/api/remote/remote_api_test.go
+++ b/exp/api/remote/remote_api_test.go
@@ -147,7 +147,7 @@ func TestRemoteAPI_Write_WithHandler(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tLogger := slog.Default()
 		mStore := &mockStorage{}
-		srv := httptest.NewServer(NewHandler(mStore, WithHandlerLogger(tLogger)))
+		srv := httptest.NewServer(NewHandler(mStore, MessageTypes{WriteV2MessageType}, WithHandlerLogger(tLogger)))
 		t.Cleanup(srv.Close)
 
 		client, err := NewAPI(srv.URL,
@@ -182,7 +182,7 @@ func TestRemoteAPI_Write_WithHandler(t *testing.T) {
 			mockErr:  errors.New("storage error"),
 			mockCode: &mockCode,
 		}
-		srv := httptest.NewServer(NewHandler(mStore, WithHandlerLogger(tLogger)))
+		srv := httptest.NewServer(NewHandler(mStore, MessageTypes{WriteV2MessageType}, WithHandlerLogger(tLogger)))
 		t.Cleanup(srv.Close)
 
 		client, err := NewAPI(srv.URL,

--- a/exp/api/remote/remote_headers.go
+++ b/exp/api/remote/remote_headers.go
@@ -59,13 +59,13 @@ func (n WriteMessageType) Validate() error {
 	case WriteV1MessageType, WriteV2MessageType:
 		return nil
 	default:
-		return fmt.Errorf("unknown type for remote write protobuf message %v, supported: %v", n, messageTypes{WriteV1MessageType, WriteV2MessageType}.String())
+		return fmt.Errorf("unknown type for remote write protobuf message %v, supported: %v", n, MessageTypes{WriteV1MessageType, WriteV2MessageType}.String())
 	}
 }
 
-type messageTypes []WriteMessageType
+type MessageTypes []WriteMessageType
 
-func (m messageTypes) Strings() []string {
+func (m MessageTypes) Strings() []string {
 	ret := make([]string, 0, len(m))
 	for _, typ := range m {
 		ret = append(ret, string(typ))
@@ -73,8 +73,16 @@ func (m messageTypes) Strings() []string {
 	return ret
 }
 
-func (m messageTypes) String() string {
+func (m MessageTypes) String() string {
 	return strings.Join(m.Strings(), ", ")
+}
+
+func (m MessageTypes) Map() map[WriteMessageType]struct{} {
+	ret := make(map[WriteMessageType]struct{}, len(m))
+	for _, typ := range m {
+		ret[typ] = struct{}{}
+	}
+	return ret
 }
 
 var contentTypeHeaders = map[WriteMessageType]string{

--- a/exp/api/remote/remote_headers.go
+++ b/exp/api/remote/remote_headers.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -77,12 +78,8 @@ func (m MessageTypes) String() string {
 	return strings.Join(m.Strings(), ", ")
 }
 
-func (m MessageTypes) Map() map[WriteMessageType]struct{} {
-	ret := make(map[WriteMessageType]struct{}, len(m))
-	for _, typ := range m {
-		ret[typ] = struct{}{}
-	}
-	return ret
+func (m MessageTypes) Contains(mType WriteMessageType) bool {
+	return slices.Contains(m, mType)
 }
 
 var contentTypeHeaders = map[WriteMessageType]string{


### PR DESCRIPTION
This PR adds an accepted message arg to NewHandler, to allow callers to limit what remote write messages their servers can handle.