### PR TITLE
promhttp: Isolate zstd support and klauspost/compress library use to promhttp/zstd package

### DIFF
--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -30,6 +30,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/client_golang/prometheus"
+	_ "github.com/prometheus/client_golang/prometheus/promhttp/zstd"
 )
 
 type errorCollector struct{}
@@ -484,7 +485,7 @@ func TestInstrumentMetricHandlerWithCompression(t *testing.T) {
 func TestNegotiateEncodingWriter(t *testing.T) {
 	var defaultCompressions []string
 
-	for _, comp := range defaultCompressionFormats {
+	for _, comp := range defaultCompressionFormats() {
 		defaultCompressions = append(defaultCompressions, string(comp))
 	}
 

--- a/prometheus/promhttp/internal/compression.go
+++ b/prometheus/promhttp/internal/compression.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"io"
+)
+
+// NewZstdWriter enables zstd write support if non-nil.
+var NewZstdWriter func(rw io.Writer) (_ io.Writer, closeWriter func(), _ error)

--- a/prometheus/promhttp/zstd/zstd.go
+++ b/prometheus/promhttp/zstd/zstd.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package zstd activates support for zstd compression.
+// To enable zstd compression support, import like this:
+//
+//	import (
+//	        _ "github.com/prometheus/client_golang/prometheus/promhttp/zstd"
+//	)
+//
+// This support is currently implemented via the github.com/klauspost/compress library,
+// so importing this package requires linking and building that library.
+// Once stdlib support is added to the Go standard library (https://github.com/golang/go/issues/62513),
+// this package is expected to become a no-op, and zstd support will be enabled by default.
+package zstd
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp/internal"
+)
+
+func init() {
+	// Enable zstd support
+	internal.NewZstdWriter = func(rw io.Writer) (_ io.Writer, closeWriter func(), _ error) {
+		// TODO(mrueg): Replace klauspost/compress with stdlib implementation once https://github.com/golang/go/issues/62513 is implemented, and move this package to be a no-op / backfill for older go versions.
+		z, err := zstd.NewWriter(rw, zstd.WithEncoderLevel(zstd.SpeedFastest))
+		if err != nil {
+			return nil, func() {}, err
+		}
+
+		z.Reset(rw)
+		return z, func() { _ = z.Close() }, nil
+	}
+}


### PR DESCRIPTION
This PR is a proof of concept for package isolation discussed in https://github.com/kubernetes/kubernetes/pull/130569#discussion_r1981503174

Eventually, zstd support is expected in the Go stdlib, but until then, making zstd support optional lets downstream consumers decide if they want to vendor / link the ~28kloc go+assembly klauspost/compress library into their build or not.

This _does_ change default behavior for library consumers who would now have to opt into zstd support, so I'll let the client_golang maintainers decide if that's acceptable, and if so, how best to manage that change.

xref discussion at https://github.com/prometheus/client_golang/pull/1496/files#r1717633170 as well when this was introduced