### PR TITLE
exp/api: Bubble up status code from writeResponse

### DIFF
--- a/exp/api/remote/remote_api.go
+++ b/exp/api/remote/remote_api.go
@@ -553,5 +553,5 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, storeErr.Error(), writeResponse.StatusCode())
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(writeResponse.StatusCode())
 }


### PR DESCRIPTION
Bubble up the write response code instead of hard-coding it to 204. The write response struct by default uses 204, but many rw 1.0 implementations in the wild will be using 2xx. This allows it to be flexible.

cc: @bwplotka 
