### PR TITLE
Update runtime metrics for Go v1.23 and v1.24

### DIFF
--- a/prometheus/collectors/go_collector_go123_test.go
+++ b/prometheus/collectors/go_collector_go123_test.go
@@ -52,6 +52,7 @@ func withAllMetrics() []string {
 		"go_gc_scan_stack_bytes",
 		"go_gc_scan_total_bytes",
 		"go_gc_stack_starting_size_bytes",
+		"go_godebug_non_default_behavior_allowmultiplevcs_events_total",
 		"go_godebug_non_default_behavior_asynctimerchan_events_total",
 		"go_godebug_non_default_behavior_execerrdot_events_total",
 		"go_godebug_non_default_behavior_gocachehash_events_total",
@@ -169,6 +170,7 @@ func withSchedulerMetrics() []string {
 
 func withDebugMetrics() []string {
 	return withBaseMetrics([]string{
+		"go_godebug_non_default_behavior_allowmultiplevcs_events_total",
 		"go_godebug_non_default_behavior_asynctimerchan_events_total",
 		"go_godebug_non_default_behavior_execerrdot_events_total",
 		"go_godebug_non_default_behavior_gocachehash_events_total",

--- a/prometheus/collectors/go_collector_go124_test.go
+++ b/prometheus/collectors/go_collector_go124_test.go
@@ -52,6 +52,7 @@ func withAllMetrics() []string {
 		"go_gc_scan_stack_bytes",
 		"go_gc_scan_total_bytes",
 		"go_gc_stack_starting_size_bytes",
+		"go_godebug_non_default_behavior_allowmultiplevcs_events_total",
 		"go_godebug_non_default_behavior_asynctimerchan_events_total",
 		"go_godebug_non_default_behavior_execerrdot_events_total",
 		"go_godebug_non_default_behavior_gocachehash_events_total",
@@ -172,6 +173,7 @@ func withSchedulerMetrics() []string {
 
 func withDebugMetrics() []string {
 	return withBaseMetrics([]string{
+		"go_godebug_non_default_behavior_allowmultiplevcs_events_total",
 		"go_godebug_non_default_behavior_asynctimerchan_events_total",
 		"go_godebug_non_default_behavior_execerrdot_events_total",
 		"go_godebug_non_default_behavior_gocachehash_events_total",

--- a/prometheus/go_collector_metrics_go123_test.go
+++ b/prometheus/go_collector_metrics_go123_test.go
@@ -42,6 +42,7 @@ var (
 		"/gc/scan/stack:bytes":                                             "go_gc_scan_stack_bytes",
 		"/gc/scan/total:bytes":                                             "go_gc_scan_total_bytes",
 		"/gc/stack/starting-size:bytes":                                    "go_gc_stack_starting_size_bytes",
+		"/godebug/non-default-behavior/allowmultiplevcs:events":            "go_godebug_non_default_behavior_allowmultiplevcs_events_total",
 		"/godebug/non-default-behavior/asynctimerchan:events":              "go_godebug_non_default_behavior_asynctimerchan_events_total",
 		"/godebug/non-default-behavior/execerrdot:events":                  "go_godebug_non_default_behavior_execerrdot_events_total",
 		"/godebug/non-default-behavior/gocachehash:events":                 "go_godebug_non_default_behavior_gocachehash_events_total",
@@ -105,4 +106,4 @@ var (
 	}
 )
 
-const expectedRuntimeMetricsCardinality = 168
+const expectedRuntimeMetricsCardinality = 169

--- a/prometheus/go_collector_metrics_go124_test.go
+++ b/prometheus/go_collector_metrics_go124_test.go
@@ -42,6 +42,7 @@ var (
 		"/gc/scan/stack:bytes":                                             "go_gc_scan_stack_bytes",
 		"/gc/scan/total:bytes":                                             "go_gc_scan_total_bytes",
 		"/gc/stack/starting-size:bytes":                                    "go_gc_stack_starting_size_bytes",
+		"/godebug/non-default-behavior/allowmultiplevcs:events":            "go_godebug_non_default_behavior_allowmultiplevcs_events_total",
 		"/godebug/non-default-behavior/asynctimerchan:events":              "go_godebug_non_default_behavior_asynctimerchan_events_total",
 		"/godebug/non-default-behavior/execerrdot:events":                  "go_godebug_non_default_behavior_execerrdot_events_total",
 		"/godebug/non-default-behavior/gocachehash:events":                 "go_godebug_non_default_behavior_gocachehash_events_total",
@@ -108,4 +109,4 @@ var (
 	}
 )
 
-const expectedRuntimeMetricsCardinality = 171
+const expectedRuntimeMetricsCardinality = 172


### PR DESCRIPTION
Update runtime metrics for Go v1.23 and v1.24, to include `go_godebug_non_default_behavior_allowmultiplevcs_events_total`.