### PR TITLE
Fix `errNotImplemented` reference

### DIFF
--- a/prometheus/process_collector_mem_nocgo_darwin.go
+++ b/prometheus/process_collector_mem_nocgo_darwin.go
@@ -16,7 +16,7 @@
 package prometheus
 
 func getMemory() (*memoryInfo, error) {
-	return nil, notImplementedErr
+	return nil, errNotImplemented
 }
 
 // describe returns all descriptions of the collector for Darwin.


### PR DESCRIPTION
Replace `notImplementedErr` reference with `errNotImplemented` in prometheus/process_collector_mem_nocgo_darwin.go, since the former doesn't exist any longer.