### PR TITLE
retract v1.23.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ require (
 )
 
 exclude github.com/prometheus/client_golang v1.12.1
+
+retract v1.23.0-rc.0


### PR DESCRIPTION
A mistake was made in making v1.23.0-rc.0, retracting as agreed with @kakkoyun 