### PR TITLE
feat(api/prometheus): add format_query endpoint for query formatting

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1391,7 +1391,6 @@ func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error)
 		return "", err
 	}
 
-	// var qres queryResult
 	return string(body), nil
 }
 

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -381,6 +381,7 @@ const (
 	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
 	epTSDB            = apiPrefix + "/status/tsdb"
 	epWalReplay       = apiPrefix + "/status/walreplay"
+	epFormatQuery     = apiPrefix + "/format_query"
 )
 
 // AlertState models the state of an alert.
@@ -1378,6 +1379,20 @@ func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, e
 	var res []ExemplarQueryResult
 	err = json.Unmarshal(body, &res)
 	return res, err
+}
+
+func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error) {
+	u := h.client.URL(epFormatQuery, nil)
+	q := u.Query()
+	q.Set("query", query)
+
+	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return "", err
+	}
+
+	// var qres queryResult
+	return string(body), nil
 }
 
 // Warnings is an array of non critical errors

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -240,6 +240,13 @@ func TestAPIs(t *testing.T) {
 		}
 	}
 
+	doFormatQuery := func(query string) func() (interface{}, Warnings, error) {
+		return func() (interface{}, Warnings, error) {
+			v, err := promAPI.FormatQuery(context.Background(), query)
+			return v, nil, err
+		}
+	}
+
 	queryTests := []apiTest{
 		{
 			do: doQuery("2", testTime, WithTimeout(5*time.Second)),
@@ -1205,6 +1212,13 @@ func TestAPIs(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			do:        doFormatQuery("foo/bar"),
+			reqMethod: "POST",
+			reqPath:   "/api/v1/format_query",
+			inRes:     "foo / bar",
+			res:       "\"foo / bar\"",
 		},
 	}
 


### PR DESCRIPTION
The changes introduce a new `/format_query` API endpoint to handle query formatting in the Prometheus API.

This includes implementing the `FormatQuery` function in `api.go` and adding corresponding test cases in `api_test.go` to ensure proper functionality.

Fix #1845 