### PR TITLE
Timer helpers

### DIFF
--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -17,6 +17,7 @@ package prometheus
 // Histogram and Summary to add observations.
 type Observer interface {
 	Observe(float64)
+	Collector
 }
 
 // The ObserverFunc type is an adapter to allow the use of ordinary

--- a/prometheus/timer.go
+++ b/prometheus/timer.go
@@ -13,9 +13,7 @@
 
 package prometheus
 
-import (
-	"time"
-)
+import "time"
 
 // Timer is a helper type to time functions. Use NewTimer to create new
 // instances.
@@ -154,7 +152,7 @@ func (t *TimerHistogramVec) Wrap(labels map[string]string, fn func()) {
 	fn()
 }
 
-func (t *TimerHistogramVec) WrapLV(values []string, fn func()) {
+func (t *TimerHistogramVec) WrapLabelValues(values []string, fn func()) {
 	defer t.ObserveLabelValues(values...)()
 	fn()
 }
@@ -201,7 +199,7 @@ func (t *TimerCounter) Observe() func() {
 
 	return func() {
 		d := time.Since(start)
-		t.Counter.Add(d.Seconds())
+		t.Add(d.Seconds())
 	}
 }
 
@@ -227,7 +225,7 @@ func (t *TimerCounterVec) Observe(labels map[string]string) func() {
 
 	return func() {
 		d := time.Since(start)
-		t.CounterVec.With(labels).Add(d.Seconds())
+		t.With(labels).Add(d.Seconds())
 	}
 }
 
@@ -235,7 +233,7 @@ func (t *TimerCounterVec) ObserveLabelValues(values ...string) func() {
 	start := time.Now()
 	return func() {
 		d := time.Since(start)
-		t.CounterVec.WithLabelValues(values...).Add(d.Seconds())
+		t.WithLabelValues(values...).Add(d.Seconds())
 	}
 }
 
@@ -292,13 +290,13 @@ func (t *TimerContinuous) Observe() func() {
 			case <-ch:
 				d := time.Since(start)
 				if diff := d.Seconds() - added; diff > 0 {
-					t.Counter.Add(diff)
+					t.Add(diff)
 				}
 				return
 			case <-ticker.C:
 				d := time.Since(start)
 				if diff := d.Seconds() - added; diff > 0 {
-					t.Counter.Add(diff)
+					t.Add(diff)
 					added += diff
 				}
 			}
@@ -340,13 +338,13 @@ func (t *TimerContinuousVec) Observe(labels map[string]string) func() {
 			case <-ch:
 				d := time.Since(start)
 				if diff := d.Seconds() - added; diff > 0 {
-					t.CounterVec.With(labels).Add(diff)
+					t.With(labels).Add(diff)
 				}
 				return
 			case <-ticker.C:
 				d := time.Since(start)
 				if diff := d.Seconds() - added; diff > 0 {
-					t.CounterVec.With(labels).Add(diff)
+					t.With(labels).Add(diff)
 					added += diff
 				}
 			}
@@ -371,13 +369,13 @@ func (t *TimerContinuousVec) ObserveLabelValues(values ...string) func() {
 			case <-ch:
 				d := time.Since(start)
 				if diff := d.Seconds() - added; diff > 0 {
-					t.CounterVec.WithLabelValues(values...).Add(diff)
+					t.WithLabelValues(values...).Add(diff)
 				}
 				return
 			case <-ticker.C:
 				d := time.Since(start)
 				if diff := d.Seconds() - added; diff > 0 {
-					t.CounterVec.WithLabelValues(values...).Add(diff)
+					t.WithLabelValues(values...).Add(diff)
 					added += diff
 				}
 			}

--- a/prometheus/timer.go
+++ b/prometheus/timer.go
@@ -13,7 +13,9 @@
 
 package prometheus
 
-import "time"
+import (
+	"time"
+)
 
 // Timer is a helper type to time functions. Use NewTimer to create new
 // instances.
@@ -78,4 +80,321 @@ func (t *Timer) ObserveDurationWithExemplar(exemplar Labels) time.Duration {
 		t.observer.Observe(d.Seconds())
 	}
 	return d
+}
+
+// TimerHistogram is a thin convenience wrapper around a Prometheus Histogram
+// that makes it easier to time code paths in an idiomatic Go-style:
+//
+//	defer timer.Observe()()   // <-- starts the timer and defers the stop
+type TimerHistogram struct {
+	Histogram
+}
+
+func NewTimerHistogram(opts HistogramOpts) *TimerHistogram {
+	t := &TimerHistogram{
+		Histogram: NewHistogram(opts),
+	}
+	return t
+}
+
+// Observe starts a prom.Timer that records into the embedded Histogram and
+// returns a “stop” callback.  Best used with defer:
+//
+//	defer timer.Observe()()
+//
+// The inner closure calls ObserveDuration on the hidden prom.Timer, recording
+// the elapsed seconds into the histogram’s current bucket.
+func (t *TimerHistogram) Observe() func() {
+	timer := NewTimer(t.Histogram)
+	return func() {
+		timer.ObserveDuration()
+	}
+}
+
+// Wrap executes fn() and records the time it took.  Equivalent to:
+// Use when you don't need a defer chain (e.g., inside small helpers).
+func (t *TimerHistogram) Wrap(fn func()) {
+	defer t.Observe()()
+	fn()
+}
+
+type TimerHistogramVec struct {
+	*HistogramVec
+}
+
+func NewTimerHistogramVec(opts HistogramOpts, labelNames []string) *TimerHistogramVec {
+	t := &TimerHistogramVec{
+		HistogramVec: NewHistogramVec(opts, labelNames),
+	}
+
+	return t
+}
+
+// Observe return func for stop timer and observe value
+// Example
+// defer metric.Observe(map[string]string{"foo": "bar"})()
+func (t *TimerHistogramVec) Observe(labels map[string]string) func() {
+	timeStart := time.Now()
+	return func() {
+		d := time.Since(timeStart)
+		t.HistogramVec.With(labels).Observe(d.Seconds())
+	}
+}
+
+func (t *TimerHistogramVec) ObserveLabelValues(values ...string) func() {
+	timeStart := time.Now()
+	return func() {
+		d := time.Since(timeStart)
+		t.HistogramVec.WithLabelValues(values...).Observe(d.Seconds())
+	}
+}
+
+func (t *TimerHistogramVec) Wrap(labels map[string]string, fn func()) {
+	defer t.Observe(labels)()
+	fn()
+}
+
+func (t *TimerHistogramVec) WrapLV(values []string, fn func()) {
+	defer t.ObserveLabelValues(values...)()
+	fn()
+}
+
+// TimerCounter is a minimal helper that turns a Prometheus **Counter** into a
+// “stop-watch” for wall-clock time.
+//
+// Each call to Observe() starts a timer and, when the returned closure is
+// executed, adds the elapsed seconds to the embedded Counter.  The counter
+// therefore represents **the cumulative running time** across many code paths
+// (e.g. total time spent processing all requests since process start).
+//
+// Compared with a Histogram-based timer you gain:
+//
+//   - A single monotonically-increasing number that is cheap to aggregate or
+//     alert on (e.g. “CPU-seconds spent in GC”).
+//   - Zero bucket management or percentile math.
+//
+// But you lose per-request latency data, so use it when you care about total
+// time rather than distribution.
+type TimerCounter struct {
+	Counter
+}
+
+func NewTimerCounter(opts Opts) *TimerCounter {
+	t := &TimerCounter{
+		Counter: NewCounter(CounterOpts(opts)),
+	}
+
+	return t
+}
+
+// Observe starts a wall-clock timer and returns a “stop” closure.
+//
+// Typical usage:
+//
+//	defer myCounter.Observe()()   // records on function exit
+//
+// When the closure is executed it records the elapsed duration (in seconds)
+// into the Counter.  Thread-safe as long as the underlying Counter is
+// thread-safe (Prometheus counters are).
+func (t *TimerCounter) Observe() func() {
+	start := time.Now()
+
+	return func() {
+		d := time.Since(start)
+		t.Counter.Add(d.Seconds())
+	}
+}
+
+func (t *TimerCounter) Wrap(fn func()) {
+	defer t.Observe()()
+	fn()
+}
+
+type TimerCounterVec struct {
+	*CounterVec
+}
+
+func NewTimerCounterVec(opts Opts, labels []string) *TimerCounterVec {
+	t := &TimerCounterVec{
+		CounterVec: NewCounterVec(CounterOpts(opts), labels),
+	}
+
+	return t
+}
+
+func (t *TimerCounterVec) Observe(labels map[string]string) func() {
+	start := time.Now()
+
+	return func() {
+		d := time.Since(start)
+		t.CounterVec.With(labels).Add(d.Seconds())
+	}
+}
+
+func (t *TimerCounterVec) ObserveLabelValues(values ...string) func() {
+	start := time.Now()
+	return func() {
+		d := time.Since(start)
+		t.CounterVec.WithLabelValues(values...).Add(d.Seconds())
+	}
+}
+
+func (t *TimerCounterVec) Wrap(labels map[string]string, fn func()) {
+	defer t.Observe(labels)()
+	fn()
+}
+
+func (t *TimerCounterVec) WrapLabelValues(values []string, fn func()) {
+	defer t.ObserveLabelValues(values...)()
+	fn()
+}
+
+// TimerContinuous is a variant of the standard Timer that **continuously updates**
+// its underlying Counter while it is running—by default once every second—
+// instead of emitting a single measurement only when the timer stops.
+//
+// Trade-offs
+// ----------
+//   - **Higher overhead** than a one-shot Timer (extra goroutine + ticker).
+//   - **Finer-grained metrics** that are invaluable for long-running or
+//     indeterminate-length activities such as stream processing, background
+//     jobs, or large file transfers.
+//   - **Sensitive to clock skew**—if the system clock is moved **backwards**
+//     while the timer is running, the negative delta is silently discarded
+//     (no panic), so that slice of time is lost from the measurement.
+type TimerContinuous struct {
+	Counter
+	updateInterval time.Duration
+}
+
+func NewTimerContinuous(opts Opts, updateInterval time.Duration) *TimerContinuous {
+	t := &TimerContinuous{
+		Counter:        NewCounter(CounterOpts(opts)),
+		updateInterval: updateInterval,
+	}
+	if t.updateInterval == 0 {
+		t.updateInterval = time.Second
+	}
+
+	return t
+}
+
+func (t *TimerContinuous) Observe() func() {
+	start := time.Now()
+	ch := make(chan struct{})
+
+	go func() {
+		added := float64(0)
+		ticker := time.NewTicker(t.updateInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ch:
+				d := time.Since(start)
+				if diff := d.Seconds() - added; diff > 0 {
+					t.Counter.Add(diff)
+				}
+				return
+			case <-ticker.C:
+				d := time.Since(start)
+				if diff := d.Seconds() - added; diff > 0 {
+					t.Counter.Add(diff)
+					added += diff
+				}
+			}
+		}
+	}()
+
+	return func() {
+		ch <- struct{}{}
+	}
+}
+
+func (t *TimerContinuous) Wrap(fn func()) {
+	defer t.Observe()()
+	fn()
+}
+
+type TimerContinuousVec struct {
+	*CounterVec
+}
+
+func NewTimerContinuousVec(opts Opts, labels []string) *TimerCounterVec {
+	t := &TimerCounterVec{
+		CounterVec: NewCounterVec(CounterOpts(opts), labels),
+	}
+
+	return t
+}
+
+func (t *TimerContinuousVec) Observe(labels map[string]string) func() {
+	start := time.Now()
+	ch := make(chan struct{})
+
+	go func() {
+		added := float64(0)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ch:
+				d := time.Since(start)
+				if diff := d.Seconds() - added; diff > 0 {
+					t.CounterVec.With(labels).Add(diff)
+				}
+				return
+			case <-ticker.C:
+				d := time.Since(start)
+				if diff := d.Seconds() - added; diff > 0 {
+					t.CounterVec.With(labels).Add(diff)
+					added += diff
+				}
+			}
+		}
+	}()
+
+	return func() {
+		ch <- struct{}{}
+	}
+}
+
+func (t *TimerContinuousVec) ObserveLabelValues(values ...string) func() {
+	start := time.Now()
+	ch := make(chan struct{})
+
+	go func() {
+		added := float64(0)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ch:
+				d := time.Since(start)
+				if diff := d.Seconds() - added; diff > 0 {
+					t.CounterVec.WithLabelValues(values...).Add(diff)
+				}
+				return
+			case <-ticker.C:
+				d := time.Since(start)
+				if diff := d.Seconds() - added; diff > 0 {
+					t.CounterVec.WithLabelValues(values...).Add(diff)
+					added += diff
+				}
+			}
+		}
+	}()
+
+	return func() {
+		ch <- struct{}{}
+	}
+}
+
+func (t *TimerContinuousVec) Wrap(labels map[string]string, fn func()) {
+	defer t.Observe(labels)()
+	fn()
+}
+
+func (t *TimerContinuousVec) WrapLabelValues(values []string, fn func()) {
+	defer t.ObserveLabelValues(values...)()
+	fn()
 }


### PR DESCRIPTION
Hello.

I'm proposing to add several helper functions to make working with timers more convenient.
I haven’t brought this up on the mailing list yet, but I’d like to hear your feedback.
**The code is still a draft**; if you like the approach, I’ll add more detailed comments, tests, and documentation.

Here are a few examples of how the new timers could be used:

```go
package prometheus

import (
	"database/sql"
	"time"
)

type Worker struct {
	db                     *sql.DB
	workerChan             chan *Job
	metricDBQueryTime      *TimerObserverVec
	metricWorkingTime      *TimerCounterVec
	metricProcessingTime   *TimerObserver
	metricWaitTime         *TimerCounter
	metricWaitCount        Gauge
	metricModuleUptime     *TimerCounter
	metricModuleUptimeStop func()
}

type Job struct {
	Type          string
	Payload       string // Some Job payload, for example
	waitTimerStop func() // If the queue processing is blocked, for example by jobs with a long running time, then we want to see the metric with the waiting time in live mode - it will increase and show that there are messages that require processing.
}

func NewWorker(db *sql.DB, workerCnt int) *Worker {
	w := &Worker{
		db:                   db,
		workerChan:           make(chan *Job, workerCnt),
		metricDBQueryTime:    NewTimerObserverVec(NewHistogramVec(HistogramOpts{Namespace: "test_module", Subsystem: "database", Name: "query_time_seconds"}, []string{"query_type"})),
		metricWorkingTime:    NewTimerCounterVec(NewCounterVec(CounterOpts{Namespace: "test_module", Subsystem: "worker", Name: "working_time_seconds"}, []string{"job_type"}), 0),
		metricProcessingTime: NewTimerObserver(NewSummary(SummaryOpts{Namespace: "test_module", Subsystem: "worker", Name: "processing_time_seconds"})),
		metricWaitTime:       NewTimerCounter(NewCounter(CounterOpts{Namespace: "test_module", Subsystem: "worker", Name: "wait_time_seconds"}), time.Second),
		metricWaitCount:      NewGauge(GaugeOpts{Namespace: "test_module", Subsystem: "worker", Name: "wait_count"}),
		metricModuleUptime:   NewTimerCounter(NewCounter(CounterOpts{Namespace: "test_module", Subsystem: "worker", Name: "uptime"}), time.Second),
	}

	w.metricModuleUptimeStop = w.metricModuleUptime.Observe()

	for i := 0; i < workerCnt; i++ {
		go w.run()
	}

	return w
}

func (w *Worker) Destroy() {
	close(w.workerChan)
	w.metricModuleUptimeStop()
}

func (w *Worker) Describe(ch chan<- *Desc) {
	DescribeByCollect(w, ch)
}

func (w *Worker) Collect(ch chan<- Metric) {
	w.metricDBQueryTime.Collect(ch)
	w.metricWorkingTime.Collect(ch)
	w.metricProcessingTime.Collect(ch)
	w.metricWaitTime.Collect(ch)
	w.metricWaitCount.Collect(ch)
	w.metricModuleUptime.Collect(ch)
}

func (w *Worker) run() {
	for job := range w.workerChan {
		job.waitTimerStop()
		w.metricWaitCount.Dec()
		func() {
			defer w.metricWorkingTime.ObserveLabelValues(job.Type)()

			var selectResult sql.Result
			var err error
			w.metricDBQueryTime.WrapLabelValues([]string{"SELECT"}, func() {
				selectResult, err = w.db.Exec("SELECT * FROM my_table WHERE payload = ?", job.Payload)
			})
			if err != nil {
				return
			}

			// Processing  result
			stop := w.metricProcessingTime.Observe()
			result := doSomeWork(selectResult)
			stop()

			w.metricDBQueryTime.WrapLabelValues([]string{"INSERT"}, func() {
				selectResult, err = w.db.Exec("INSERT INTO results (payload, result) VALUES (?, ?)", job.Payload, result)
			})
		}()
	}
}

func (w *Worker) AddJob(job *Job) {
	job.waitTimerStop = w.metricWaitTime.Observe()
	w.metricWaitCount.Inc()
	w.workerChan <- job
}

func doSomeWork(selectResult sql.Result) string {
	return ""
}
```