### PR TITLE
remote: simplified Store interface; renamed Handler to WriteHandler

### DIFF
--- a/exp/api/remote/remote_api_test.go
+++ b/exp/api/remote/remote_api_test.go
@@ -71,8 +71,8 @@ type mockStorage struct {
 	mockErr  error
 }
 
-func (m *mockStorage) Store(_ context.Context, msgType WriteMessageType, req *http.Request) (*WriteResponse, error) {
-	w := &WriteResponse{}
+func (m *mockStorage) Store(req *http.Request, msgType WriteMessageType) (*WriteResponse, error) {
+	w := NewWriteResponse()
 	if m.mockErr != nil {
 		if m.mockCode != nil {
 			w.SetStatusCode(*m.mockCode)
@@ -147,7 +147,7 @@ func TestRemoteAPI_Write_WithHandler(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tLogger := slog.Default()
 		mStore := &mockStorage{}
-		srv := httptest.NewServer(NewHandler(mStore, MessageTypes{WriteV2MessageType}, WithHandlerLogger(tLogger)))
+		srv := httptest.NewServer(NewWriteHandler(mStore, MessageTypes{WriteV2MessageType}, WithWriteHandlerLogger(tLogger)))
 		t.Cleanup(srv.Close)
 
 		client, err := NewAPI(srv.URL,
@@ -182,7 +182,7 @@ func TestRemoteAPI_Write_WithHandler(t *testing.T) {
 			mockErr:  errors.New("storage error"),
 			mockCode: &mockCode,
 		}
-		srv := httptest.NewServer(NewHandler(mStore, MessageTypes{WriteV2MessageType}, WithHandlerLogger(tLogger)))
+		srv := httptest.NewServer(NewWriteHandler(mStore, MessageTypes{WriteV2MessageType}, WithWriteHandlerLogger(tLogger)))
 		t.Cleanup(srv.Close)
 
 		client, err := NewAPI(srv.URL,

--- a/exp/api/remote/remote_headers.go
+++ b/exp/api/remote/remote_headers.go
@@ -125,29 +125,19 @@ func (w *WriteResponse) SetStatusCode(code int) {
 	w.statusCode = code
 }
 
-// StatusCode returns the current HTTP status code.
-func (w *WriteResponse) StatusCode() int {
-	return w.statusCode
-}
-
 // SetExtraHeader adds additional headers to be set in the response (apart from stats headers)
 func (w *WriteResponse) SetExtraHeader(key, value string) {
 	w.extraHeaders.Set(key, value)
 }
 
-// ExtraHeaders returns all additional headers to be set in the response (apart from stats headers).
-func (w *WriteResponse) ExtraHeaders() http.Header {
-	return w.extraHeaders
-}
-
-// SetHeaders sets response headers in a given response writer.
+// writeHeaders sets response headers in a given response writer.
 // Make sure to use it before http.ResponseWriter.WriteHeader and .Write.
-func (r *WriteResponse) SetHeaders(w http.ResponseWriter) {
-	h := w.Header()
-	h.Set(writtenSamplesHeader, strconv.Itoa(r.Samples))
-	h.Set(writtenHistogramsHeader, strconv.Itoa(r.Histograms))
-	h.Set(writtenExemplarsHeader, strconv.Itoa(r.Exemplars))
-	for k, v := range r.ExtraHeaders() {
+func (w *WriteResponse) writeHeaders(rw http.ResponseWriter) {
+	h := rw.Header()
+	h.Set(writtenSamplesHeader, strconv.Itoa(w.Samples))
+	h.Set(writtenHistogramsHeader, strconv.Itoa(w.Histograms))
+	h.Set(writtenExemplarsHeader, strconv.Itoa(w.Exemplars))
+	for k, v := range w.extraHeaders {
 		for _, vv := range v {
 			h.Add(k, vv)
 		}

--- a/exp/api/remote/remote_headers_test.go
+++ b/exp/api/remote/remote_headers_test.go
@@ -25,16 +25,16 @@ import (
 func TestWriteResponse(t *testing.T) {
 	t.Run("new response has empty headers", func(t *testing.T) {
 		resp := NewWriteResponse()
-		if len(resp.ExtraHeaders()) != 0 {
-			t.Errorf("expected empty headers, got %v", resp.ExtraHeaders())
+		if len(resp.extraHeaders) != 0 {
+			t.Errorf("expected empty headers, got %v", resp.extraHeaders)
 		}
 	})
 
-	t.Run("setters and getters", func(t *testing.T) {
+	t.Run("setters", func(t *testing.T) {
 		resp := NewWriteResponse()
 
 		resp.SetStatusCode(http.StatusOK)
-		if got := resp.StatusCode(); got != http.StatusOK {
+		if got := resp.statusCode; got != http.StatusOK {
 			t.Errorf("expected status code %d, got %d", http.StatusOK, got)
 		}
 
@@ -66,12 +66,12 @@ func TestWriteResponse(t *testing.T) {
 		}
 
 		resp.SetExtraHeader("Test-Header", "test-value")
-		if got := resp.ExtraHeaders().Get("Test-Header"); got != "test-value" {
+		if got := resp.extraHeaders.Get("Test-Header"); got != "test-value" {
 			t.Errorf("expected header value %q, got %q", "test-value", got)
 		}
 	})
 
-	t.Run("set headers on response writer", func(t *testing.T) {
+	t.Run("writeHeaders", func(t *testing.T) {
 		resp := NewWriteResponse()
 		resp.Add(WriteResponseStats{
 			Samples:    10,
@@ -82,7 +82,7 @@ func TestWriteResponse(t *testing.T) {
 		resp.SetExtraHeader("Custom-Header", "custom-value")
 
 		w := httptest.NewRecorder()
-		resp.SetHeaders(w)
+		resp.writeHeaders(w)
 
 		expectedHeaders := map[string]string{
 			"Custom-Header": "custom-value",


### PR DESCRIPTION
* Re store: We don't need to pass context - you have it in http.Request.Context()
* Re rename: Technically we have API and Handler is only for remote write, not read, thus making space for "read" one day.

I also:
*  touched write response: I made read flow private, otherwise it's confusing how to use this structure from outside.
* renamed snappy decoder to SnappyDecodeMiddleware (tighter name)