### PR TITLE
Refactor *Vec types

### DIFF
--- a/prometheus/benchmark_test.go
+++ b/prometheus/benchmark_test.go
@@ -19,42 +19,42 @@ import (
 )
 
 func BenchmarkCounter(b *testing.B) {
-	type fns []func(*CounterVec) Counter
+	type fns []func(CounterVec) Counter
 
 	twoConstraint := func(_ string) string {
 		return "two"
 	}
 
-	deLV := func(m *CounterVec) Counter {
+	deLV := func(m CounterVec) Counter {
 		return m.WithLabelValues("eins", "zwei", "drei")
 	}
-	frLV := func(m *CounterVec) Counter {
+	frLV := func(m CounterVec) Counter {
 		return m.WithLabelValues("une", "deux", "trois")
 	}
-	nlLV := func(m *CounterVec) Counter {
+	nlLV := func(m CounterVec) Counter {
 		return m.WithLabelValues("een", "twee", "drie")
 	}
 
-	deML := func(m *CounterVec) Counter {
+	deML := func(m CounterVec) Counter {
 		return m.With(Labels{"two": "zwei", "one": "eins", "three": "drei"})
 	}
-	frML := func(m *CounterVec) Counter {
+	frML := func(m CounterVec) Counter {
 		return m.With(Labels{"two": "deux", "one": "une", "three": "trois"})
 	}
-	nlML := func(m *CounterVec) Counter {
+	nlML := func(m CounterVec) Counter {
 		return m.With(Labels{"two": "twee", "one": "een", "three": "drie"})
 	}
 
 	deLabels := Labels{"two": "zwei", "one": "eins", "three": "drei"}
-	dePML := func(m *CounterVec) Counter {
+	dePML := func(m CounterVec) Counter {
 		return m.With(deLabels)
 	}
 	frLabels := Labels{"two": "deux", "one": "une", "three": "trois"}
-	frPML := func(m *CounterVec) Counter {
+	frPML := func(m CounterVec) Counter {
 		return m.With(frLabels)
 	}
 	nlLabels := Labels{"two": "twee", "one": "een", "three": "drie"}
-	nlPML := func(m *CounterVec) Counter {
+	nlPML := func(m CounterVec) Counter {
 		return m.With(nlLabels)
 	}
 

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -320,41 +320,41 @@ func TestCounterExemplar(t *testing.T) {
 func TestCounterVecCreatedTimestampWithDeletes(t *testing.T) {
 	now := time.Now()
 
-	counterVec := NewCounterVec(CounterOpts{
+	vec := NewCounterVec(CounterOpts{
 		Name: "test",
 		Help: "test help",
 		now:  func() time.Time { return now },
 	}, []string{"label"})
 
 	// First use of "With" should populate CT.
-	counterVec.WithLabelValues("1")
+	vec.WithLabelValues("1")
 	expected := map[string]time.Time{"1": now}
 
 	now = now.Add(1 * time.Hour)
-	expectCTsForMetricVecValues(t, counterVec.MetricVec, dto.MetricType_COUNTER, expected)
+	expectCTsForMetricVecValues(t, vec.(*counterVec).MetricVec, dto.MetricType_COUNTER, expected)
 
 	// Two more labels at different times.
-	counterVec.WithLabelValues("2")
+	vec.WithLabelValues("2")
 	expected["2"] = now
 
 	now = now.Add(1 * time.Hour)
 
-	counterVec.WithLabelValues("3")
+	vec.WithLabelValues("3")
 	expected["3"] = now
 
 	now = now.Add(1 * time.Hour)
-	expectCTsForMetricVecValues(t, counterVec.MetricVec, dto.MetricType_COUNTER, expected)
+	expectCTsForMetricVecValues(t, vec.(*counterVec).MetricVec, dto.MetricType_COUNTER, expected)
 
 	// Recreate metric instance should reset created timestamp to now.
-	counterVec.DeleteLabelValues("1")
-	counterVec.WithLabelValues("1")
+	vec.DeleteLabelValues("1")
+	vec.WithLabelValues("1")
 	expected["1"] = now
 
 	now = now.Add(1 * time.Hour)
-	expectCTsForMetricVecValues(t, counterVec.MetricVec, dto.MetricType_COUNTER, expected)
+	expectCTsForMetricVecValues(t, vec.(*counterVec).MetricVec, dto.MetricType_COUNTER, expected)
 }
 
-func expectCTsForMetricVecValues(t testing.TB, vec *MetricVec, typ dto.MetricType, ctsPerLabelValue map[string]time.Time) {
+func expectCTsForMetricVecValues(t testing.TB, vec MetricVec, typ dto.MetricType, ctsPerLabelValue map[string]time.Time) {
 	t.Helper()
 
 	for val, ct := range ctsPerLabelValue {

--- a/prometheus/example_metricvec_test.go
+++ b/prometheus/example_metricvec_test.go
@@ -49,7 +49,7 @@ func (i Info) Write(out *dto.Metric) error {
 // to do to fully implement a vector for a custom Metric implementation, we do
 // it in this example anyway.
 type InfoVec struct {
-	*prometheus.MetricVec
+	prometheus.MetricVec
 }
 
 func NewInfoVec(name, help string, labelNames []string) *InfoVec {

--- a/prometheus/example_timer_test.go
+++ b/prometheus/example_timer_test.go
@@ -28,7 +28,7 @@ var requestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 
 func ExampleTimer() {
 	// timer times this example function. It uses a Histogram, but a Summary
-	// would also work, as both implement Observer. Check out
+	// would also work, as both implement ObserverMethod. Check out
 	// https://prometheus.io/docs/practices/histograms/ for differences.
 	timer := prometheus.NewTimer(requestDuration)
 	defer timer.ObserveDuration()

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -179,7 +179,7 @@ func (v2) NewGaugeVec(opts GaugeVecOpts) GaugeVec {
 		opts.ConstLabels,
 	)
 	return &gaugeVec{
-		MetricVec: newMetricVec(desc, func(lvs ...string) Metric {
+		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
 			if len(lvs) != len(desc.variableLabels.names) {
 				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, lvs))
 			}

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -1171,7 +1171,7 @@ func (h *histogram) updateExemplar(v float64, bucket int, l Labels) {
 // (e.g. HTTP request latencies, partitioned by status code and method). Create
 // instances with NewHistogramVec.
 type HistogramVec struct {
-	*MetricVec
+	MetricVec
 }
 
 // NewHistogramVec creates a new HistogramVec based on the provided HistogramOpts and
@@ -1192,7 +1192,7 @@ func (v2) NewHistogramVec(opts HistogramVecOpts) *HistogramVec {
 		opts.ConstLabels,
 	)
 	return &HistogramVec{
-		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
+		MetricVec: newMetricVec(desc, func(lvs ...string) Metric {
 			return newHistogram(desc, opts.HistogramOpts, lvs...)
 		}),
 	}
@@ -1222,10 +1222,10 @@ func (v2) NewHistogramVec(opts HistogramVecOpts) *HistogramVec {
 // latter has a much more readable (albeit more verbose) syntax, but it comes
 // with a performance overhead (for creating and processing the Labels map).
 // See also the GaugeVec example.
-func (v *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
+func (v *HistogramVec) GetMetricWithLabelValues(lvs ...string) (ObserverMethod, error) {
 	metric, err := v.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
-		return metric.(Observer), err
+		return metric.(ObserverMethod), err
 	}
 	return nil, err
 }
@@ -1242,10 +1242,10 @@ func (v *HistogramVec) GetMetricWithLabelValues(lvs ...string) (Observer, error)
 // This method is used for the same purpose as
 // GetMetricWithLabelValues(...string). See there for pros and cons of the two
 // methods.
-func (v *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
+func (v *HistogramVec) GetMetricWith(labels Labels) (ObserverMethod, error) {
 	metric, err := v.MetricVec.GetMetricWith(labels)
 	if metric != nil {
-		return metric.(Observer), err
+		return metric.(ObserverMethod), err
 	}
 	return nil, err
 }
@@ -1255,7 +1255,7 @@ func (v *HistogramVec) GetMetricWith(labels Labels) (Observer, error) {
 // error allows shortcuts like
 //
 //	myVec.WithLabelValues("404", "GET").Observe(42.21)
-func (v *HistogramVec) WithLabelValues(lvs ...string) Observer {
+func (v *HistogramVec) WithLabelValues(lvs ...string) ObserverMethod {
 	h, err := v.GetMetricWithLabelValues(lvs...)
 	if err != nil {
 		panic(err)
@@ -1267,7 +1267,7 @@ func (v *HistogramVec) WithLabelValues(lvs ...string) Observer {
 // returned an error. Not returning an error allows shortcuts like
 //
 //	myVec.With(prometheus.Labels{"code": "404", "method": "GET"}).Observe(42.21)
-func (v *HistogramVec) With(labels Labels) Observer {
+func (v *HistogramVec) With(labels Labels) ObserverMethod {
 	h, err := v.GetMetricWith(labels)
 	if err != nil {
 		panic(err)

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -1192,7 +1192,7 @@ func (v2) NewHistogramVec(opts HistogramVecOpts) *HistogramVec {
 		opts.ConstLabels,
 	)
 	return &HistogramVec{
-		MetricVec: newMetricVec(desc, func(lvs ...string) Metric {
+		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
 			return newHistogram(desc, opts.HistogramOpts, lvs...)
 		}),
 	}

--- a/prometheus/observer.go
+++ b/prometheus/observer.go
@@ -13,47 +13,52 @@
 
 package prometheus
 
-// Observer is the interface that wraps the Observe method, which is used by
+// ObserverMethod is the interface that wraps the Observe method, which is used by
 // Histogram and Summary to add observations.
-type Observer interface {
+type ObserverMethod interface {
 	Observe(float64)
+}
+
+type Observer interface {
+	ObserverMethod
+	Collector
+	Metric
 }
 
 // The ObserverFunc type is an adapter to allow the use of ordinary
 // functions as Observers. If f is a function with the appropriate
-// signature, ObserverFunc(f) is an Observer that calls f.
+// signature, ObserverFunc(f) is an ObserverMethod that calls f.
 //
 // This adapter is usually used in connection with the Timer type, and there are
 // two general use cases:
 //
-// The most common one is to use a Gauge as the Observer for a Timer.
+// The most common one is to use a Gauge as the ObserverMethod for a Timer.
 // See the "Gauge" Timer example.
 //
 // The more advanced use case is to create a function that dynamically decides
-// which Observer to use for observing the duration. See the "Complex" Timer
+// which ObserverMethod to use for observing the duration. See the "Complex" Timer
 // example.
 type ObserverFunc func(float64)
 
-// Observe calls f(value). It implements Observer.
+// Observe calls f(value). It implements ObserverMethod.
 func (f ObserverFunc) Observe(value float64) {
 	f(value)
 }
 
 // ObserverVec is an interface implemented by `HistogramVec` and `SummaryVec`.
 type ObserverVec interface {
-	GetMetricWith(Labels) (Observer, error)
-	GetMetricWithLabelValues(lvs ...string) (Observer, error)
-	With(Labels) Observer
-	WithLabelValues(...string) Observer
+	GetMetricWith(Labels) (ObserverMethod, error)
+	GetMetricWithLabelValues(lvs ...string) (ObserverMethod, error)
+	With(Labels) ObserverMethod
+	WithLabelValues(...string) ObserverMethod
 	CurryWith(Labels) (ObserverVec, error)
 	MustCurryWith(Labels) ObserverVec
-
 	Collector
 }
 
 // ExemplarObserver is implemented by Observers that offer the option of
 // observing a value together with an exemplar. Its ObserveWithExemplar method
-// works like the Observe method of an Observer but also replaces the currently
+// works like the Observe method of an ObserverMethod but also replaces the currently
 // saved exemplar (if any) with a new one, created from the provided value, the
 // current time as timestamp, and the provided Labels. Empty Labels will lead to
 // a valid (label-less) exemplar. But if Labels is nil, the current exemplar is

--- a/prometheus/promauto/auto.go
+++ b/prometheus/promauto/auto.go
@@ -172,7 +172,7 @@ func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
 // package but it automatically registers the CounterVec with the
 // prometheus.DefaultRegisterer. If the registration fails, NewCounterVec
 // panics.
-func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) prometheus.CounterVec {
 	return With(prometheus.DefaultRegisterer).NewCounterVec(opts, labelNames)
 }
 
@@ -194,7 +194,7 @@ func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
 // NewGaugeVec works like the function of the same name in the prometheus
 // package but it automatically registers the GaugeVec with the
 // prometheus.DefaultRegisterer. If the registration fails, NewGaugeVec panics.
-func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) prometheus.GaugeVec {
 	return With(prometheus.DefaultRegisterer).NewGaugeVec(opts, labelNames)
 }
 
@@ -270,7 +270,7 @@ func (f Factory) NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
 // NewCounterVec works like the function of the same name in the prometheus
 // package but it automatically registers the CounterVec with the Factory's
 // Registerer.
-func (f Factory) NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+func (f Factory) NewCounterVec(opts prometheus.CounterOpts, labelNames []string) prometheus.CounterVec {
 	c := prometheus.NewCounterVec(opts, labelNames)
 	if f.r != nil {
 		f.r.MustRegister(c)
@@ -302,7 +302,7 @@ func (f Factory) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
 // NewGaugeVec works like the function of the same name in the prometheus
 // package but it automatically registers the GaugeVec with the Factory's
 // Registerer.
-func (f Factory) NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+func (f Factory) NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) prometheus.GaugeVec {
 	g := prometheus.NewGaugeVec(opts, labelNames)
 	if f.r != nil {
 		f.r.MustRegister(g)

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -134,7 +134,7 @@ func HandlerForTransactional(reg prometheus.TransactionalGatherer, opts HandlerO
 		if err := opts.Registry.Register(errCnt); err != nil {
 			are := &prometheus.AlreadyRegisteredError{}
 			if errors.As(err, are) {
-				errCnt = are.ExistingCollector.(*prometheus.CounterVec)
+				errCnt = are.ExistingCollector.(prometheus.CounterVec)
 			} else {
 				panic(err)
 			}
@@ -298,7 +298,7 @@ func InstrumentMetricHandler(reg prometheus.Registerer, handler http.Handler) ht
 	if err := reg.Register(cnt); err != nil {
 		are := &prometheus.AlreadyRegisteredError{}
 		if errors.As(err, are) {
-			cnt = are.ExistingCollector.(*prometheus.CounterVec)
+			cnt = are.ExistingCollector.(prometheus.CounterVec)
 		} else {
 			panic(err)
 		}

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -618,7 +618,7 @@ func BenchmarkCompression(b *testing.B) {
 		for idx := 0; idx < size.labelCount; idx++ {
 			labelValues[idx] = fmt.Sprintf("label_val_%s_%v", strings.Repeat("v", size.labelLength), idx)
 		}
-		metrics := make([]*prometheus.GaugeVec, size.metricCount)
+		metrics := make([]prometheus.GaugeVec, size.metricCount)
 		for idx := 0; idx < size.metricCount; idx++ {
 			gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: fmt.Sprintf("avalanche_metric_%s_%v_%v", strings.Repeat("m", size.metricLength), 0, idx),

--- a/prometheus/promhttp/instrument_client.go
+++ b/prometheus/promhttp/instrument_client.go
@@ -62,7 +62,7 @@ func InstrumentRoundTripperInFlight(gauge prometheus.Gauge, next http.RoundTripp
 // Use with WithExemplarFromContext to instrument the exemplars on the counter of requests.
 //
 // See the example for ExampleInstrumentRoundTripperDuration for example usage.
-func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
+func InstrumentRoundTripperCounter(counter prometheus.CounterVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
 	rtOpts := defaultOptions()
 	for _, o := range opts {
 		o.apply(rtOpts)
@@ -91,7 +91,7 @@ func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.Rou
 // "method". The function panics otherwise. For the "method" label a predefined
 // default label value set is used to filter given values. Values besides
 // predefined values will count as `unknown` method. `WithExtraMethods`
-// can be used to add more methods to the set. The Observe method of the Observer
+// can be used to add more methods to the set. The Observe method of the ObserverMethod
 // in the ObserverVec is called with the request duration in
 // seconds. Partitioning happens by HTTP status code and/or HTTP method if the
 // respective instance label names are present in the ObserverVec. For

--- a/prometheus/promhttp/instrument_server.go
+++ b/prometheus/promhttp/instrument_server.go
@@ -29,8 +29,8 @@ import (
 const magicString = "zZgWfBxLqvG8kc8IMv3POi2Bb0tZI3vAnBx+gBaFi9FyPzB/CzKUer1yufDa"
 
 // observeWithExemplar is a wrapper for [prometheus.ExemplarAdder.ExemplarObserver],
-// which falls back to [prometheus.Observer.Observe] if no labels are provided.
-func observeWithExemplar(obs prometheus.Observer, val float64, labels map[string]string) {
+// which falls back to [prometheus.ObserverMethod.Observe] if no labels are provided.
+func observeWithExemplar(obs prometheus.ObserverMethod, val float64, labels map[string]string) {
 	if labels == nil {
 		obs.Observe(val)
 		return
@@ -69,7 +69,7 @@ func InstrumentHandlerInFlight(g prometheus.Gauge, next http.Handler) http.Handl
 // label a predefined default label value set is used to filter given values.
 // Values besides predefined values will count as `unknown` method.
 // `WithExtraMethods` can be used to add more methods to the set. The Observe
-// method of the Observer in the ObserverVec is called with the request duration
+// method of the ObserverMethod in the ObserverVec is called with the request duration
 // in seconds. Partitioning happens by HTTP status code and/or HTTP method if
 // the respective instance label names are present in the ObserverVec. For
 // unpartitioned observations, use an ObserverVec with zero labels. Note that
@@ -132,7 +132,7 @@ func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler, op
 // If the wrapped Handler panics, the Counter is not incremented.
 //
 // See the example for InstrumentHandlerDuration for example usage.
-func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler, opts ...Option) http.HandlerFunc {
+func InstrumentHandlerCounter(counter prometheus.CounterVec, next http.Handler, opts ...Option) http.HandlerFunc {
 	hOpts := defaultOptions()
 	for _, o := range opts {
 		o.apply(hOpts)
@@ -173,7 +173,7 @@ func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler,
 // function panics otherwise. For the "method" label a predefined default label
 // value set is used to filter given values. Values besides predefined values
 // will count as `unknown` method.`WithExtraMethods` can be used to add more
-// methods to the set. The Observe method of the Observer in the
+// methods to the set. The Observe method of the ObserverMethod in the
 // ObserverVec is called with the request duration in seconds. Partitioning
 // happens by HTTP status code and/or HTTP method if the respective instance
 // label names are present in the ObserverVec. For unpartitioned observations,
@@ -217,7 +217,7 @@ func InstrumentHandlerTimeToWriteHeader(obs prometheus.ObserverVec, next http.Ha
 // label a predefined default label value set is used to filter given values.
 // Values besides predefined values will count as `unknown` method.
 // `WithExtraMethods` can be used to add more methods to the set. The Observe
-// method of the Observer in the ObserverVec is called with the request size in
+// method of the ObserverMethod in the ObserverVec is called with the request size in
 // bytes. Partitioning happens by HTTP status code and/or HTTP method if the
 // respective instance label names are present in the ObserverVec. For
 // unpartitioned observations, use an ObserverVec with zero labels. Note that
@@ -271,7 +271,7 @@ func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler,
 // label a predefined default label value set is used to filter given values.
 // Values besides predefined values will count as `unknown` method.
 // `WithExtraMethods` can be used to add more methods to the set. The Observe
-// method of the Observer in the ObserverVec is called with the response size in
+// method of the ObserverMethod in the ObserverVec is called with the response size in
 // bytes. Partitioning happens by HTTP status code and/or HTTP method if the
 // respective instance label names are present in the ObserverVec. For
 // unpartitioned observations, use an ObserverVec with zero labels. Note that
@@ -375,7 +375,7 @@ func isLabelCurried(c prometheus.Collector, label string) bool {
 	// But for that, we need to type-convert to the two
 	// types we use here, ObserverVec or *CounterVec.
 	switch v := c.(type) {
-	case *prometheus.CounterVec:
+	case prometheus.CounterVec:
 		if _, err := v.CurryWith(prometheus.Labels{label: "dummy"}); err == nil {
 			return false
 		}

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -580,7 +580,7 @@ func (v2) NewSummaryVec(opts SummaryVecOpts) *SummaryVec {
 		opts.ConstLabels,
 	)
 	return &SummaryVec{
-		MetricVec: newMetricVec(desc, func(lvs ...string) Metric {
+		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
 			return newSummary(desc, opts.SummaryOpts, lvs...)
 		}),
 	}

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -550,7 +550,7 @@ func (s quantSort) Less(i, j int) bool {
 // (e.g. HTTP request latencies, partitioned by status code and method). Create
 // instances with NewSummaryVec.
 type SummaryVec struct {
-	*MetricVec
+	MetricVec
 }
 
 // NewSummaryVec creates a new SummaryVec based on the provided SummaryOpts and
@@ -580,7 +580,7 @@ func (v2) NewSummaryVec(opts SummaryVecOpts) *SummaryVec {
 		opts.ConstLabels,
 	)
 	return &SummaryVec{
-		MetricVec: NewMetricVec(desc, func(lvs ...string) Metric {
+		MetricVec: newMetricVec(desc, func(lvs ...string) Metric {
 			return newSummary(desc, opts.SummaryOpts, lvs...)
 		}),
 	}
@@ -610,10 +610,10 @@ func (v2) NewSummaryVec(opts SummaryVecOpts) *SummaryVec {
 // latter has a much more readable (albeit more verbose) syntax, but it comes
 // with a performance overhead (for creating and processing the Labels map).
 // See also the GaugeVec example.
-func (v *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
+func (v *SummaryVec) GetMetricWithLabelValues(lvs ...string) (ObserverMethod, error) {
 	metric, err := v.MetricVec.GetMetricWithLabelValues(lvs...)
 	if metric != nil {
-		return metric.(Observer), err
+		return metric.(ObserverMethod), err
 	}
 	return nil, err
 }
@@ -630,10 +630,10 @@ func (v *SummaryVec) GetMetricWithLabelValues(lvs ...string) (Observer, error) {
 // This method is used for the same purpose as
 // GetMetricWithLabelValues(...string). See there for pros and cons of the two
 // methods.
-func (v *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
+func (v *SummaryVec) GetMetricWith(labels Labels) (ObserverMethod, error) {
 	metric, err := v.MetricVec.GetMetricWith(labels)
 	if metric != nil {
-		return metric.(Observer), err
+		return metric.(ObserverMethod), err
 	}
 	return nil, err
 }
@@ -643,7 +643,7 @@ func (v *SummaryVec) GetMetricWith(labels Labels) (Observer, error) {
 // error allows shortcuts like
 //
 //	myVec.WithLabelValues("404", "GET").Observe(42.21)
-func (v *SummaryVec) WithLabelValues(lvs ...string) Observer {
+func (v *SummaryVec) WithLabelValues(lvs ...string) ObserverMethod {
 	s, err := v.GetMetricWithLabelValues(lvs...)
 	if err != nil {
 		panic(err)
@@ -655,7 +655,7 @@ func (v *SummaryVec) WithLabelValues(lvs ...string) Observer {
 // returned an error. Not returning an error allows shortcuts like
 //
 //	myVec.With(prometheus.Labels{"code": "404", "method": "GET"}).Observe(42.21)
-func (v *SummaryVec) With(labels Labels) Observer {
+func (v *SummaryVec) With(labels Labels) ObserverMethod {
 	s, err := v.GetMetricWith(labels)
 	if err != nil {
 		panic(err)

--- a/prometheus/timer.go
+++ b/prometheus/timer.go
@@ -19,11 +19,11 @@ import "time"
 // instances.
 type Timer struct {
 	begin    time.Time
-	observer Observer
+	observer ObserverMethod
 }
 
-// NewTimer creates a new Timer. The provided Observer is used to observe a
-// duration in seconds. If the Observer implements ExemplarObserver, passing exemplar
+// NewTimer creates a new Timer. The provided ObserverMethod is used to observe a
+// duration in seconds. If the ObserverMethod implements ExemplarObserver, passing exemplar
 // later on will be also supported.
 // Timer is usually used to time a function call in the
 // following way:
@@ -41,7 +41,7 @@ type Timer struct {
 //		    defer timer.ObserveDurationWithExemplar(exemplar)
 //		    // Do actual work.
 //		}
-func NewTimer(o Observer) *Timer {
+func NewTimer(o ObserverMethod) *Timer {
 	return &Timer{
 		begin:    time.Now(),
 		observer: o,
@@ -49,7 +49,7 @@ func NewTimer(o Observer) *Timer {
 }
 
 // ObserveDuration records the duration passed since the Timer was created with
-// NewTimer. It calls the Observe method of the Observer provided during
+// NewTimer. It calls the Observe method of the ObserverMethod provided during
 // construction with the duration in seconds as an argument. The observed
 // duration is also returned. ObserveDuration is usually called with a defer
 // statement.
@@ -65,7 +65,7 @@ func (t *Timer) ObserveDuration() time.Duration {
 }
 
 // ObserveDurationWithExemplar is like ObserveDuration, but it will also
-// observe exemplar with the duration unless exemplar is nil or provided Observer can't
+// observe exemplar with the duration unless exemplar is nil or provided ObserverMethod can't
 // be casted to ExemplarObserver.
 func (t *Timer) ObserveDurationWithExemplar(exemplar Labels) time.Duration {
 	d := time.Since(t.begin)

--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -57,7 +57,8 @@ type metricVec struct {
 	hashAddByte func(h uint64, b byte) uint64
 }
 
-func newMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) *metricVec {
+// NewMetricVec returns an initialized metricVec.
+func NewMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) MetricVec {
 	return &metricVec{
 		metricMap: &metricMap{
 			metrics:   map[uint64][]metricWithLabelValues{},
@@ -67,11 +68,6 @@ func newMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) *metricVec {
 		hashAdd:     hashAdd,
 		hashAddByte: hashAddByte,
 	}
-}
-
-// NewMetricVec returns an initialized metricVec.
-func NewMetricVec(desc *Desc, newMetric func(lvs ...string) Metric) MetricVec {
-	return newMetricVec(desc, newMetric)
 }
 
 // DeleteLabelValues removes the metric where the variable labels are the same


### PR DESCRIPTION
Hello.
While working on https://github.com/prometheus/client_golang/pull/1854 I ran into a few typing issues that got in the way:

1. Most types like `Counter`, `Gauge`, `Histogram`, and `Summary` have both an interface and a concrete private implementation (`counter`, `gauge`, etc.) that implements it. But for the vector types (`CounterVec`, `GaugeVec`) there’s no interface — they’re implemented directly. I introduced interfaces for these vector types and moved the implementations into private types (`counterVec`, `gaugeVec`).

2. The `ObserverVec` interface for `HistogramVec` and `SummaryVec` implements all its methods and also satisfies `Collector`. However, for `Histogram` and `Summary`, the `Observer` interface only defines `Observe(float64)`. This prevents creating a generic interface for `Histogram` and `Summary` in places that require a `Collector` implementation. I added the missing methods to `Observer` and introduced a new `ObserverMetod` interface.

3. Added the missing methods to `ObserverVec`.

4. All *Vec types use `MetricVec` under the hood. I also turned `MetricVec` into an interface.

5. I tried to maintain maximum backward compatibility to minimize the likelihood of changes in existing projects.
In most cases, everything will work without changes or with minimal changes (for example, replacing type from pointer to the interface -- `*CounerVec` => `CounerVec`)