### PR TITLE
Fix typo in remote api err msg

### DIFF
--- a/exp/api/remote/remote_api.go
+++ b/exp/api/remote/remote_api.go
@@ -245,7 +245,7 @@ func (r *API) Write(ctx context.Context, msgType WriteMessageType, msg any) (_ W
 				// TODO(bwplotka): Allow users to disable this check or provide their stats for us to know if it's empty.
 				return accumulatedStats, fmt.Errorf("sent v2 request; "+
 					"got 2xx, but PRW 2.0 response header statistics indicate %v samples, %v histograms "+
-					"and %v exemplars were accepted; assumining failure e.g. the target only supports "+
+					"and %v exemplars were accepted; assuming failure e.g. the target only supports "+
 					"PRW 1.0 prometheus.WriteRequest, but does not check the Content-Type header correctly",
 					accumulatedStats.Samples, accumulatedStats.Histograms, accumulatedStats.Exemplars,
 				)


### PR DESCRIPTION
This PR fixes a typo in the remote api error msg.
`assumining ` to `assuming`