### PR TITLE
Public ParseWriteResponseStats method and Confirmed to reuse in Prometheus

### DIFF
--- a/exp/api/remote/remote_api.go
+++ b/exp/api/remote/remote_api.go
@@ -241,7 +241,7 @@ func (r *API) Write(ctx context.Context, msgType WriteMessageType, msg any) (_ W
 		if err == nil {
 			// Check the case mentioned in PRW 2.0.
 			// https://prometheus.io/docs/specs/remote_write_spec_2_0/#required-written-response-headers.
-			if msgType == WriteV2MessageType && !accumulatedStats.confirmed && accumulatedStats.NoDataWritten() {
+			if msgType == WriteV2MessageType && !accumulatedStats.Confirmed && accumulatedStats.NoDataWritten() {
 				// TODO(bwplotka): Allow users to disable this check or provide their stats for us to know if it's empty.
 				return accumulatedStats, fmt.Errorf("sent v2 request; "+
 					"got 2xx, but PRW 2.0 response header statistics indicate %v samples, %v histograms "+
@@ -329,7 +329,7 @@ func (r *API) attemptWrite(ctx context.Context, compr Compression, msgType Write
 
 	rs := WriteResponseStats{}
 	if msgType == WriteV2MessageType {
-		rs, err = parseWriteResponseStats(resp)
+		rs, err = ParseWriteResponseStats(resp)
 		if err != nil {
 			r.opts.logger.Warn("parsing rw write statistics failed; partial or no stats", "err", err)
 		}

--- a/exp/api/remote/remote_api_test.go
+++ b/exp/api/remote/remote_api_test.go
@@ -134,7 +134,7 @@ func testV2() *writev2.Request {
 }
 
 func stats(req *writev2.Request) (s WriteResponseStats) {
-	s.confirmed = true
+	s.Confirmed = true
 	for _, ts := range req.Timeseries {
 		s.Samples += len(ts.Samples)
 		s.Histograms += len(ts.Histograms)

--- a/exp/api/remote/remote_headers.go
+++ b/exp/api/remote/remote_headers.go
@@ -157,7 +157,7 @@ type WriteResponseStats struct {
 	// of the PRW 2.0 spec. When parsed from headers, it means we got at least one
 	// response header from the Receiver to confirm those numbers, meaning it must
 	// be at least 2.0 Receiver. See ParseWriteResponseStats for details.
-	confirmed bool
+	Confirmed bool
 }
 
 // NoDataWritten returns true if statistics indicate no data was written.
@@ -173,7 +173,7 @@ func (s WriteResponseStats) AllSamples() int {
 // Add adds the given WriteResponseStats to this WriteResponseStats.
 // If this WriteResponseStats is empty, it will be replaced by the given WriteResponseStats.
 func (s *WriteResponseStats) Add(rs WriteResponseStats) {
-	s.confirmed = rs.confirmed
+	s.Confirmed = rs.Confirmed
 	s.Samples += rs.Samples
 	s.Histograms += rs.Histograms
 	s.Exemplars += rs.Exemplars
@@ -187,27 +187,27 @@ func (s *WriteResponseStats) Add(rs WriteResponseStats) {
 // s.Confirmed = true only when see at least on response header.
 //
 // Error is returned when any of the header fails to parse as int64.
-func parseWriteResponseStats(r *http.Response) (s WriteResponseStats, err error) {
+func ParseWriteResponseStats(r *http.Response) (s WriteResponseStats, err error) {
 	var (
 		errs []error
 		h    = r.Header
 	)
 	if v := h.Get(writtenSamplesHeader); v != "" { // Empty means zero.
-		s.confirmed = true
+		s.Confirmed = true
 		if s.Samples, err = strconv.Atoi(v); err != nil {
 			s.Samples = 0
 			errs = append(errs, err)
 		}
 	}
 	if v := h.Get(writtenHistogramsHeader); v != "" { // Empty means zero.
-		s.confirmed = true
+		s.Confirmed = true
 		if s.Histograms, err = strconv.Atoi(v); err != nil {
 			s.Histograms = 0
 			errs = append(errs, err)
 		}
 	}
 	if v := h.Get(writtenExemplarsHeader); v != "" { // Empty means zero.
-		s.confirmed = true
+		s.Confirmed = true
 		if s.Exemplars, err = strconv.Atoi(v); err != nil {
 			s.Exemplars = 0
 			errs = append(errs, err)

--- a/exp/api/remote/remote_headers_test.go
+++ b/exp/api/remote/remote_headers_test.go
@@ -42,7 +42,7 @@ func TestWriteResponse(t *testing.T) {
 			Samples:    10,
 			Histograms: 5,
 			Exemplars:  2,
-			confirmed:  true,
+			Confirmed:  true,
 		}
 		resp.Add(stats)
 		if diff := cmp.Diff(stats, resp.Stats(), cmpopts.IgnoreUnexported(WriteResponseStats{})); diff != "" {
@@ -53,14 +53,14 @@ func TestWriteResponse(t *testing.T) {
 			Samples:    10,
 			Histograms: 5,
 			Exemplars:  2,
-			confirmed:  true,
+			Confirmed:  true,
 		}
 		resp.Add(toAdd)
 		if diff := cmp.Diff(WriteResponseStats{
 			Samples:    20,
 			Histograms: 10,
 			Exemplars:  4,
-			confirmed:  true,
+			Confirmed:  true,
 		}, resp.Stats(), cmpopts.IgnoreUnexported(WriteResponseStats{})); diff != "" {
 			t.Errorf("stats mismatch (-want +got):\n%s", diff)
 		}
@@ -77,7 +77,7 @@ func TestWriteResponse(t *testing.T) {
 			Samples:    10,
 			Histograms: 5,
 			Exemplars:  2,
-			confirmed:  true,
+			Confirmed:  true,
 		})
 		resp.SetExtraHeader("Custom-Header", "custom-value")
 


### PR DESCRIPTION
#### Notes
- This PR is to supports https://github.com/prometheus/prometheus/issues/17192


#### Changes
- Public ParseWriteResponseStats to reuse in https://github.com/prometheus/prometheus/blob/f4b8840f51bee8afa258e0d4e27fc7fc03358760/storage/remote/client.go#L307
- Public Confirmed to reuse in https://github.com/prometheus/prometheus/blob/f4b8840f51bee8afa258e0d4e27fc7fc03358760/storage/remote/queue_manager.go#L1817