### PR TITLE
bug(remote_write): Fix compression buffer pooling

### DIFF
--- a/exp/api/remote/remote_api.go
+++ b/exp/api/remote/remote_api.go
@@ -242,7 +242,7 @@ func (r *API) Write(ctx context.Context, msgType WriteMessageType, msg any) (_ W
 		return WriteResponseStats{}, fmt.Errorf("compressing %w", err)
 	}
 	r.bufPool.Put(buf)
-	r.bufPool.Put(comprBuf)
+	defer r.bufPool.Put(comprBuf)
 
 	// Since we retry writes we need to track the total amount of accepted data
 	// across the various attempts.


### PR DESCRIPTION
The compressed buffer is released before the request is made, which leads to corrupted remote-write payloads being sent to the target.

The compression function uses the pattern where the destination slice can be passed in, and the function returns a reference to it, adjusted for length.