### PR TITLE
Public backoff config to allow usage of WithAPIBackoff

### DIFF
--- a/exp/api/remote/remote_api.go
+++ b/exp/api/remote/remote_api.go
@@ -114,8 +114,9 @@ func WithAPINoRetryOnRateLimit() APIOption {
 	}
 }
 
-// WithAPIBackoffConfig returns APIOption that allows overriding backoff configuration.
-func WithAPIBackoffConfig(cfg BackoffConfig) APIOption {
+// WithAPIBackoff returns APIOption that allows configuring backoff.
+// By default, exponential backoff with jitter is used (see defaultAPIOpts).
+func WithAPIBackoff(cfg BackoffConfig) APIOption {
 	return func(o *apiOpts) error {
 		o.backoffConfig = cfg
 		return nil

--- a/exp/api/remote/remote_api_test.go
+++ b/exp/api/remote/remote_api_test.go
@@ -188,7 +188,7 @@ func TestRemoteAPI_Write_WithHandler(t *testing.T) {
 			WithAPIHTTPClient(srv.Client()),
 			WithAPILogger(tLogger),
 			WithAPIPath("api/v1/write"),
-			WithAPIBackoffConfig(BackoffConfig{
+			WithAPIBackoff(BackoffConfig{
 				Min:        1 * time.Second,
 				Max:        1 * time.Second,
 				MaxRetries: 2,
@@ -225,7 +225,7 @@ func TestRemoteAPI_Write_WithHandler(t *testing.T) {
 			WithAPIHTTPClient(srv.Client()),
 			WithAPILogger(tLogger),
 			WithAPIPath("api/v1/write"),
-			WithAPIBackoffConfig(BackoffConfig{
+			WithAPIBackoff(BackoffConfig{
 				Min:        1 * time.Millisecond,
 				Max:        1 * time.Millisecond,
 				MaxRetries: 3,


### PR DESCRIPTION
#### What Issue is this fixing ? 
- Expose backoff directory so that we could use the function ` func WithAPIBackoff(cfg BackoffConfig) ` without the error: "Use of the internal package is not allowed"

#### Changes
- Create a BackoffConfig public struct that serve as a public layer to internal backoff.Config