### PR TITLE
feat: expose Desc error through public Err() method

### DIFF
--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -182,6 +182,11 @@ func NewInvalidDesc(err error) *Desc {
 	}
 }
 
+// Err returns an error that occurred during construction, if any.
+func (d *Desc) Err() error {
+	return d.err
+}
+
 func (d *Desc) String() string {
 	lpStrings := make([]string, 0, len(d.constLabelPairs))
 	for _, lp := range d.constLabelPairs {

--- a/prometheus/desc_test.go
+++ b/prometheus/desc_test.go
@@ -17,15 +17,29 @@ import (
 	"testing"
 )
 
-func TestNewDescInvalidLabelValues(t *testing.T) {
+func TestNewDescInvalidConstLabelValues(t *testing.T) {
+	labelValue := "\xFF"
 	desc := NewDesc(
 		"sample_label",
 		"sample label",
 		nil,
-		Labels{"a": "\xFF"},
+		Labels{"a": labelValue},
 	)
-	if desc.err == nil {
-		t.Errorf("NewDesc: expected error because: %s", desc.err)
+	if desc.Err() == nil {
+		t.Errorf("NewDesc: expected error because const label value is invalid: %s", labelValue)
+	}
+}
+
+func TestNewDescInvalidVariableLabelName(t *testing.T) {
+	labelValue := "__label__"
+	desc := NewDesc(
+		"sample_label",
+		"sample label",
+		[]string{labelValue},
+		Labels{"a": "b"},
+	)
+	if desc.Err() == nil {
+		t.Errorf("NewDesc: expected error because variable label name is invalid: %s", labelValue)
 	}
 }
 
@@ -36,8 +50,8 @@ func TestNewDescNilLabelValues(t *testing.T) {
 		nil,
 		nil,
 	)
-	if desc.err != nil {
-		t.Errorf("NewDesc: unexpected error: %s", desc.err)
+	if desc.Err() != nil {
+		t.Errorf("NewDesc: unexpected error: %s", desc.Err())
 	}
 }
 


### PR DESCRIPTION
Adds a public Err() method to Desc type to allow users to check if
an error occurred during descriptor construction. Previously, the error
field was private and inaccessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
