### PR TITLE
Return info annotations in addition to warnings in the API

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -477,13 +477,13 @@ type API interface {
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
 	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
-	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, Infos, error)
 	// LabelValues performs a query for the values of the given label, time range and matchers.
-	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
+	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, Infos, error)
 	// Query performs a query for the given time.
-	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error)
+	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, Infos, error)
 	// QueryRange performs a query for the given range.
-	QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error)
+	QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, Infos, error)
 	// QueryExemplars performs a query for exemplars by the given query and time range.
 	QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]ExemplarQueryResult, error)
 	// Buildinfo returns various build information properties about the Prometheus server
@@ -491,7 +491,7 @@ type API interface {
 	// Runtimeinfo returns the various runtime information properties about the Prometheus server.
 	Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error)
 	// Series finds series by label matchers.
-	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error)
+	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, Infos, error)
 	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
 	// under the TSDB's data directory and returns the directory as response.
 	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
@@ -1064,7 +1064,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 	return res, err
 }
 
-func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error) {
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, Infos, error) {
 	u := h.client.URL(epLabels, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1078,16 +1078,16 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 		q.Add("match[]", m)
 	}
 
-	_, body, w, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, w, i, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, w, err
+		return nil, w, i, err
 	}
 	var labelNames model.LabelNames
 	err = json.Unmarshal(body, &labelNames)
-	return labelNames, w, err
+	return labelNames, w, i, err
 }
 
-func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error) {
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, Infos, error) {
 	u := h.client.URL(epLabelValues, map[string]string{"name": label})
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1105,15 +1105,15 @@ func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []strin
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	_, body, w, _, err := h.client.Do(ctx, req)
+	_, body, w, i, err := h.client.Do(ctx, req)
 	if err != nil {
-		return nil, w, err
+		return nil, w, i, err
 	}
 	var labelValues model.LabelValues
 	err = json.Unmarshal(body, &labelValues)
-	return labelValues, w, err
+	return labelValues, w, i, err
 }
 
 // StatsValue is a type for `stats` query parameter.
@@ -1192,7 +1192,7 @@ func addOptionalURLParams(q url.Values, opts []Option) url.Values {
 	return q
 }
 
-func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, Infos, error) {
 	u := h.client.URL(epQuery, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1201,16 +1201,16 @@ func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ..
 		q.Set("time", formatTime(ts))
 	}
 
-	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, warnings, infos, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, warnings, err
+		return nil, warnings, infos, err
 	}
 
 	var qres queryResult
-	return qres.v, warnings, json.Unmarshal(body, &qres)
+	return qres.v, warnings, infos, json.Unmarshal(body, &qres)
 }
 
-func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error) {
+func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, Infos, error) {
 	u := h.client.URL(epQueryRange, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1219,16 +1219,16 @@ func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ..
 	q.Set("end", formatTime(r.End))
 	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
 
-	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, warnings, infos, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, warnings, err
+		return nil, warnings, infos, err
 	}
 
 	var qres queryResult
-	return qres.v, warnings, json.Unmarshal(body, &qres)
+	return qres.v, warnings, infos, json.Unmarshal(body, &qres)
 }
 
-func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error) {
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, Infos, error) {
 	u := h.client.URL(epSeries, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1243,13 +1243,13 @@ func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTi
 		q.Set("end", formatTime(endTime))
 	}
 
-	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, warnings, infos, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, warnings, err
+		return nil, warnings, infos, err
 	}
 
 	var mset []model.LabelSet
-	return mset, warnings, json.Unmarshal(body, &mset)
+	return mset, warnings, infos, json.Unmarshal(body, &mset)
 }
 
 func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
@@ -1435,7 +1435,7 @@ func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, e
 		q.Set("end", formatTime(endTime))
 	}
 
-	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, _, _, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return nil, err
 	}
@@ -1450,7 +1450,7 @@ func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error)
 	q := u.Query()
 	q.Set("query", query)
 
-	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, _, _, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return "", err
 	}
@@ -1469,7 +1469,7 @@ type Infos []string
 type apiClient interface {
 	URL(ep string, args map[string]string) *url.URL
 	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, Infos, error)
-	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error)
+	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, Infos, error)
 }
 
 type apiClientImpl struct {
@@ -1551,11 +1551,11 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 
 // DoGetFallback will attempt to do the request as-is, and on a 403, 405, or
 // 501 it will fallback to a GET request.
-func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, Infos, error) {
 	encodedArgs := args.Encode()
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	// Following comment originates from https://pkg.go.dev/net/http#Transport
@@ -1567,17 +1567,16 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	// the header is not sent on the wire.
 	req.Header["Idempotency-Key"] = nil
 
-	resp, body, warnings, _, err := h.Do(ctx, req)
+	resp, body, warnings, infos, err := h.Do(ctx, req)
 	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
 		u.RawQuery = encodedArgs
 		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {
-			return nil, nil, warnings, err
+			return nil, nil, warnings, infos, err
 		}
-		resp, body, warnings, _, err = h.Do(ctx, req)
-		return resp, body, warnings, err
+		return h.Do(ctx, req)
 	}
-	return resp, body, warnings, err
+	return resp, body, warnings, infos, err
 }
 
 func formatTime(t time.Time) string {

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1479,6 +1479,7 @@ type apiResponse struct {
 	ErrorType ErrorType       `json:"errorType"`
 	Error     string          `json:"error"`
 	Warnings  []string        `json:"warnings,omitempty"`
+	Infos     []string        `json:"infos,omitempty"`
 }
 
 func apiError(code int) bool {
@@ -1542,7 +1543,7 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 		}
 	}
 
-	return resp, []byte(result.Data), result.Warnings, err
+	return resp, []byte(result.Data), append(result.Warnings, result.Infos...), err
 }
 
 // DoGetFallback will attempt to do the request as-is, and on a 403, 405, or

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -926,7 +926,7 @@ func (h *httpAPI) Alerts(ctx context.Context) (AlertsResult, error) {
 		return AlertsResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return AlertsResult{}, err
 	}
@@ -944,7 +944,7 @@ func (h *httpAPI) AlertManagers(ctx context.Context) (AlertManagersResult, error
 		return AlertManagersResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return AlertManagersResult{}, err
 	}
@@ -962,7 +962,7 @@ func (h *httpAPI) CleanTombstones(ctx context.Context) error {
 		return err
 	}
 
-	_, _, _, err = h.client.Do(ctx, req)
+	_, _, _, _, err = h.client.Do(ctx, req)
 	return err
 }
 
@@ -974,7 +974,7 @@ func (h *httpAPI) Config(ctx context.Context) (ConfigResult, error) {
 		return ConfigResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return ConfigResult{}, err
 	}
@@ -1006,7 +1006,7 @@ func (h *httpAPI) DeleteSeries(ctx context.Context, matches []string, startTime,
 		return err
 	}
 
-	_, _, _, err = h.client.Do(ctx, req)
+	_, _, _, _, err = h.client.Do(ctx, req)
 	return err
 }
 
@@ -1018,7 +1018,7 @@ func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
 		return FlagsResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return FlagsResult{}, err
 	}
@@ -1036,7 +1036,7 @@ func (h *httpAPI) Buildinfo(ctx context.Context) (BuildinfoResult, error) {
 		return BuildinfoResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return BuildinfoResult{}, err
 	}
@@ -1054,7 +1054,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 		return RuntimeinfoResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return RuntimeinfoResult{}, err
 	}
@@ -1107,7 +1107,7 @@ func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []strin
 	if err != nil {
 		return nil, nil, err
 	}
-	_, body, w, err := h.client.Do(ctx, req)
+	_, body, w, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, w, err
 	}
@@ -1265,7 +1265,7 @@ func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, 
 		return SnapshotResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return SnapshotResult{}, err
 	}
@@ -1290,7 +1290,7 @@ func (h *httpAPI) Rules(ctx context.Context, matches []string) (RulesResult, err
 		return RulesResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return RulesResult{}, err
 	}
@@ -1308,7 +1308,7 @@ func (h *httpAPI) Targets(ctx context.Context) (TargetsResult, error) {
 		return TargetsResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return TargetsResult{}, err
 	}
@@ -1333,7 +1333,7 @@ func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limi
 		return nil, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,7 +1357,7 @@ func (h *httpAPI) Metadata(ctx context.Context, metric, limit string) (map[strin
 		return nil, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -1377,7 +1377,7 @@ func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) 
 		return TSDBResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return TSDBResult{}, err
 	}
@@ -1395,7 +1395,7 @@ func (h *httpAPI) TSDBBlocks(ctx context.Context) (TSDBBlocksResult, error) {
 		return TSDBBlocksResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return TSDBBlocksResult{}, err
 	}
@@ -1413,7 +1413,7 @@ func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
 		return WalReplayStatus{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return WalReplayStatus{}, err
 	}
@@ -1458,14 +1458,17 @@ func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error)
 	return string(body), nil
 }
 
-// Warnings is an array of non critical errors
+// Warnings is an array of non-critical errors.
 type Warnings []string
+
+// Infos is an array of informational messages.
+type Infos []string
 
 // apiClient wraps a regular client and processes successful API responses.
 // Successful also includes responses that errored at the API level.
 type apiClient interface {
 	URL(ep string, args map[string]string) *url.URL
-	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
+	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, Infos, error)
 	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error)
 }
 
@@ -1501,17 +1504,17 @@ func (h *apiClientImpl) URL(ep string, args map[string]string) *url.URL {
 	return h.client.URL(ep, args)
 }
 
-func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, Infos, error) {
 	resp, body, err := h.client.Do(ctx, req)
 	if err != nil {
-		return resp, body, nil, err
+		return resp, body, nil, nil, err
 	}
 
 	code := resp.StatusCode
 
 	if code/100 != 2 && !apiError(code) {
 		errorType, errorMsg := errorTypeAndMsgFor(resp)
-		return resp, body, nil, &Error{
+		return resp, body, nil, nil, &Error{
 			Type:   errorType,
 			Msg:    errorMsg,
 			Detail: string(body),
@@ -1522,7 +1525,7 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 
 	if http.StatusNoContent != code {
 		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
-			return resp, body, nil, &Error{
+			return resp, body, nil, nil, &Error{
 				Type: ErrBadResponse,
 				Msg:  jsonErr.Error(),
 			}
@@ -1543,7 +1546,7 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 		}
 	}
 
-	return resp, []byte(result.Data), append(result.Warnings, result.Infos...), err
+	return resp, []byte(result.Data), result.Warnings, result.Infos, err
 }
 
 // DoGetFallback will attempt to do the request as-is, and on a 403, 405, or
@@ -1564,14 +1567,15 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	// the header is not sent on the wire.
 	req.Header["Idempotency-Key"] = nil
 
-	resp, body, warnings, err := h.Do(ctx, req)
+	resp, body, warnings, _, err := h.Do(ctx, req)
 	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
 		u.RawQuery = encodedArgs
 		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {
 			return nil, nil, warnings, err
 		}
-		return h.Do(ctx, req)
+		resp, body, warnings, _, err = h.Do(ctx, req)
+		return resp, body, warnings, err
 	}
 	return resp, body, warnings, err
 }

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -62,7 +62,7 @@ func (c *apiTestClient) URL(ep string, args map[string]string) *url.URL {
 	return u
 }
 
-func (c *apiTestClient) Do(_ context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+func (c *apiTestClient) Do(_ context.Context, req *http.Request) (*http.Response, []byte, Warnings, Infos, error) {
 	test := c.curTest
 
 	if req.URL.Path != test.reqPath {
@@ -86,7 +86,7 @@ func (c *apiTestClient) Do(_ context.Context, req *http.Request) (*http.Response
 		resp.StatusCode = http.StatusOK
 	}
 
-	return resp, b, test.inWarnings, test.inErr
+	return resp, b, test.inWarnings, nil, test.inErr
 }
 
 func (c *apiTestClient) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
@@ -94,7 +94,8 @@ func (c *apiTestClient) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return c.Do(ctx, req)
+	resp, body, warnings, _, err := c.Do(ctx, req)
+	return resp, body, warnings, err
 }
 
 func TestAPIs(t *testing.T) {
@@ -1568,7 +1569,7 @@ func TestAPIClientDo(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			tc.ch <- test
 
-			_, body, warnings, err := client.Do(context.Background(), tc.req)
+			_, body, warnings, _, err := client.Do(context.Background(), tc.req)
 
 			if test.expectedWarnings != nil {
 				if !reflect.DeepEqual(test.expectedWarnings, warnings) {

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -33,8 +33,9 @@ import (
 )
 
 type apiTest struct {
-	do           func() (any, Warnings, error)
+	do           func() (any, Warnings, Infos, error)
 	inWarnings   []string
+	inInfos      []string
 	inErr        error
 	inStatusCode int
 	inRes        any
@@ -86,16 +87,15 @@ func (c *apiTestClient) Do(_ context.Context, req *http.Request) (*http.Response
 		resp.StatusCode = http.StatusOK
 	}
 
-	return resp, b, test.inWarnings, nil, test.inErr
+	return resp, b, test.inWarnings, test.inInfos, test.inErr
 }
 
-func (c *apiTestClient) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+func (c *apiTestClient) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, Infos, error) {
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	resp, body, warnings, _, err := c.Do(ctx, req)
-	return resp, body, warnings, err
+	return c.Do(ctx, req)
 }
 
 func TestAPIs(t *testing.T) {
@@ -108,150 +108,150 @@ func TestAPIs(t *testing.T) {
 		client: tc,
 	}
 
-	doAlertManagers := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doAlertManagers := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.AlertManagers(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doCleanTombstones := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
-			return nil, nil, promAPI.CleanTombstones(context.Background())
+	doCleanTombstones := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
+			return nil, nil, nil, promAPI.CleanTombstones(context.Background())
 		}
 	}
 
-	doConfig := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doConfig := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Config(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doDeleteSeries := func(matcher string, startTime, endTime time.Time) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
-			return nil, nil, promAPI.DeleteSeries(context.Background(), []string{matcher}, startTime, endTime)
+	doDeleteSeries := func(matcher string, startTime, endTime time.Time) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
+			return nil, nil, nil, promAPI.DeleteSeries(context.Background(), []string{matcher}, startTime, endTime)
 		}
 	}
 
-	doFlags := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doFlags := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Flags(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doBuildinfo := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doBuildinfo := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Buildinfo(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doRuntimeinfo := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doRuntimeinfo := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Runtimeinfo(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doLabelNames := func(matches []string, startTime, endTime time.Time, opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doLabelNames := func(matches []string, startTime, endTime time.Time, opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			return promAPI.LabelNames(context.Background(), matches, startTime, endTime, opts...)
 		}
 	}
 
-	doLabelValues := func(matches []string, label string, startTime, endTime time.Time, opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doLabelValues := func(matches []string, label string, startTime, endTime time.Time, opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			return promAPI.LabelValues(context.Background(), label, matches, startTime, endTime, opts...)
 		}
 	}
 
-	doQuery := func(q string, ts time.Time, opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doQuery := func(q string, ts time.Time, opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			return promAPI.Query(context.Background(), q, ts, opts...)
 		}
 	}
 
-	doQueryRange := func(q string, rng Range, opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doQueryRange := func(q string, rng Range, opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			return promAPI.QueryRange(context.Background(), q, rng, opts...)
 		}
 	}
 
-	doSeries := func(matcher string, startTime, endTime time.Time, opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doSeries := func(matcher string, startTime, endTime time.Time, opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			return promAPI.Series(context.Background(), []string{matcher}, startTime, endTime, opts...)
 		}
 	}
 
-	doSnapshot := func(skipHead bool) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doSnapshot := func(skipHead bool) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Snapshot(context.Background(), skipHead)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doRules := func(matches []string) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doRules := func(matches []string) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Rules(context.Background(), matches)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doTargets := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doTargets := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Targets(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doTargetsMetadata := func(matchTarget, metric, limit string) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doTargetsMetadata := func(matchTarget, metric, limit string) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.TargetsMetadata(context.Background(), matchTarget, metric, limit)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doMetadata := func(metric, limit string) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doMetadata := func(metric, limit string) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.Metadata(context.Background(), metric, limit)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doTSDB := func(opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doTSDB := func(opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.TSDB(context.Background(), opts...)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doTSDBBlocks := func(opts ...Option) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doTSDBBlocks := func(opts ...Option) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.TSDBBlocks(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doWalReply := func() func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doWalReply := func() func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.WalReplay(context.Background())
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doQueryExemplars := func(query string, startTime, endTime time.Time) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doQueryExemplars := func(query string, startTime, endTime time.Time) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.QueryExemplars(context.Background(), query, startTime, endTime)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
-	doFormatQuery := func(query string) func() (any, Warnings, error) {
-		return func() (any, Warnings, error) {
+	doFormatQuery := func(query string) func() (any, Warnings, Infos, error) {
+		return func() (any, Warnings, Infos, error) {
 			v, err := promAPI.FormatQuery(context.Background(), query)
-			return v, nil, err
+			return v, nil, nil, err
 		}
 	}
 
@@ -1351,10 +1351,14 @@ func TestAPIs(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			tc.curTest = test
 
-			res, warnings, err := test.do()
+			res, warnings, infos, err := test.do()
 
 			if (test.inWarnings == nil) != (warnings == nil) && !reflect.DeepEqual(test.inWarnings, warnings) {
 				t.Fatalf("mismatch in warnings expected=%v actual=%v", test.inWarnings, warnings)
+			}
+
+			if (test.inInfos == nil) != (infos == nil) && !reflect.DeepEqual(test.inInfos, infos) {
+				t.Fatalf("mismatch in infos expected=%v actual=%v", test.inInfos, infos)
 			}
 
 			if test.err != nil {
@@ -1397,6 +1401,7 @@ type apiClientTest struct {
 	expectedBody     string
 	expectedErr      *Error
 	expectedWarnings Warnings
+	expectedInfos    Infos
 }
 
 func (c *testClient) URL(ep string, args map[string]string) *url.URL {
@@ -1554,6 +1559,38 @@ func TestAPIClientDo(t *testing.T) {
 			},
 			expectedWarnings: []string{"a"},
 		},
+		{
+			code: http.StatusOK,
+			response: &apiResponse{
+				Status:    "error",
+				Data:      json.RawMessage(`"test"`),
+				ErrorType: ErrTimeout,
+				Error:     "timed out",
+				Infos:     []string{"b"},
+			},
+			expectedErr: &Error{
+				Type: ErrTimeout,
+				Msg:  "timed out",
+			},
+			expectedInfos: []string{"b"},
+		},
+		{
+			code: http.StatusOK,
+			response: &apiResponse{
+				Status:    "error",
+				Data:      json.RawMessage(`"test"`),
+				ErrorType: ErrTimeout,
+				Error:     "timed out",
+				Warnings:  []string{"a"},
+				Infos:     []string{"b"},
+			},
+			expectedErr: &Error{
+				Type: ErrTimeout,
+				Msg:  "timed out",
+			},
+			expectedWarnings: []string{"a"},
+			expectedInfos:    []string{"b"},
+		},
 	}
 
 	tc := &testClient{
@@ -1569,7 +1606,7 @@ func TestAPIClientDo(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			tc.ch <- test
 
-			_, body, warnings, _, err := client.Do(context.Background(), tc.req)
+			_, body, warnings, infos, err := client.Do(context.Background(), tc.req)
 
 			if test.expectedWarnings != nil {
 				if !reflect.DeepEqual(test.expectedWarnings, warnings) {
@@ -1578,6 +1615,16 @@ func TestAPIClientDo(t *testing.T) {
 			} else {
 				if warnings != nil {
 					t.Fatalf("unexpected warnings: %v", warnings)
+				}
+			}
+
+			if test.expectedInfos != nil {
+				if !reflect.DeepEqual(test.expectedInfos, infos) {
+					t.Fatalf("mismatch in infos expected=%v actual=%v", test.expectedInfos, infos)
+				}
+			} else {
+				if infos != nil {
+					t.Fatalf("unexpected infos: %v", infos)
 				}
 			}
 
@@ -1958,7 +2005,7 @@ func TestDoGetFallback(t *testing.T) {
 	}
 
 	// Do a post, and ensure that the post succeeds.
-	_, b, _, err := api.DoGetFallback(context.TODO(), u, v)
+	_, b, _, _, err := api.DoGetFallback(context.TODO(), u, v)
 	if err != nil {
 		t.Fatalf("Error doing local request: %v", err)
 	}
@@ -1975,7 +2022,7 @@ func TestDoGetFallback(t *testing.T) {
 
 	// Do a fallback to a get on 403.
 	u.Path = "/blockPost403"
-	_, b, _, err = api.DoGetFallback(context.TODO(), u, v)
+	_, b, _, _, err = api.DoGetFallback(context.TODO(), u, v)
 	if err != nil {
 		t.Fatalf("Error doing local request: %v", err)
 	}
@@ -1991,7 +2038,7 @@ func TestDoGetFallback(t *testing.T) {
 
 	// Do a fallback to a get on 405.
 	u.Path = "/blockPost405"
-	_, b, _, err = api.DoGetFallback(context.TODO(), u, v)
+	_, b, _, _, err = api.DoGetFallback(context.TODO(), u, v)
 	if err != nil {
 		t.Fatalf("Error doing local request: %v", err)
 	}
@@ -2007,7 +2054,7 @@ func TestDoGetFallback(t *testing.T) {
 
 	// Do a fallback to a get on 501.
 	u.Path = "/blockPost501"
-	_, b, _, err = api.DoGetFallback(context.TODO(), u, v)
+	_, b, _, _, err = api.DoGetFallback(context.TODO(), u, v)
 	if err != nil {
 		t.Fatalf("Error doing local request: %v", err)
 	}

--- a/api/prometheus/v1/example_test.go
+++ b/api/prometheus/v1/example_test.go
@@ -42,13 +42,16 @@ func ExampleAPI_query() {
 	v1api := v1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result, warnings, err := v1api.Query(ctx, "up", time.Now(), v1.WithTimeout(5*time.Second))
+	result, warnings, infos, err := v1api.Query(ctx, "up", time.Now(), v1.WithTimeout(5*time.Second))
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Printf("Result:\n%v\n", result)
 }
@@ -70,13 +73,16 @@ func ExampleAPI_queryRange() {
 		End:   time.Now(),
 		Step:  time.Minute,
 	}
-	result, warnings, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r, v1.WithTimeout(5*time.Second))
+	result, warnings, infos, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r, v1.WithTimeout(5*time.Second))
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Printf("Result:\n%v\n", result)
 }
@@ -122,13 +128,16 @@ func ExampleAPI_queryRangeWithUserAgent() {
 		End:   time.Now(),
 		Step:  time.Minute,
 	}
-	result, warnings, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
+	result, warnings, infos, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Printf("Result:\n%v\n", result)
 }
@@ -156,13 +165,16 @@ func ExampleAPI_queryRangeWithBasicAuth() {
 		End:   time.Now(),
 		Step:  time.Minute,
 	}
-	result, warnings, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
+	result, warnings, infos, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Printf("Result:\n%v\n", result)
 }
@@ -190,13 +202,16 @@ func ExampleAPI_queryRangeWithAuthBearerToken() {
 		End:   time.Now(),
 		Step:  time.Minute,
 	}
-	result, warnings, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
+	result, warnings, infos, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Printf("Result:\n%v\n", result)
 }
@@ -229,13 +244,16 @@ func ExampleAPI_queryRangeWithAuthBearerTokenHeadersRoundTripper() {
 		End:   time.Now(),
 		Step:  time.Minute,
 	}
-	result, warnings, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
+	result, warnings, infos, err := v1api.QueryRange(ctx, "rate(prometheus_tsdb_head_samples_appended_total[5m])", r)
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		os.Exit(1)
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Printf("Result:\n%v\n", result)
 }
@@ -252,7 +270,7 @@ func ExampleAPI_series() {
 	v1api := v1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	lbls, warnings, err := v1api.Series(ctx, []string{
+	lbls, warnings, infos, err := v1api.Series(ctx, []string{
 		"{__name__=~\"scrape_.+\",job=\"node\"}",
 		"{__name__=~\"scrape_.+\",job=\"prometheus\"}",
 	}, time.Now().Add(-time.Hour), time.Now())
@@ -262,6 +280,9 @@ func ExampleAPI_series() {
 	}
 	if len(warnings) > 0 {
 		fmt.Printf("Warnings: %v\n", warnings)
+	}
+	if len(infos) > 0 {
+		fmt.Printf("Infos: %v\n", infos)
 	}
 	fmt.Println("Result:")
 	for _, lbl := range lbls {


### PR DESCRIPTION
Now that Prometheus API returns infos as well as warnings, see [here](github.com/prometheus/prometheus/pull/14327/changes#diff-315f251cdd7e93fcec1e7e9505744da1d1828f30d2b61d1f4ce963fa26bf1909), we should add that here as well. This is the non-breaking change version, please let me know if you'd prefer to change the API here as well to have infos as a separate field.