### PR TITLE
feat(promhttp): add CoalesceGather option to deduplicate concurrent Gather calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * [FEATURE] HTTP handlers created by `promhttp` package now support metrics filtering by providing one or more `name[]` query parameters. The default behavior when none are provided remains the same, returning all metrics. #1925
+* [FEATURE] promhttp: Add opt-in `HandlerOpts.CoalesceGather` to deduplicate concurrent `Gather` calls so overlapping scrapes share one collection cycle, preventing goroutine pile-up when the scrape rate outpaces collection time. #1969
 * [BUGFIX] promhttp: `InstrumentHandlerDuration` and `InstrumentHandlerCounter` no longer panic when given an observer/counter that does not implement `ExemplarObserver`/`ExemplarAdder` (e.g. a `SummaryVec`). The exemplar is dropped and the value is recorded via the plain `Observe`/`Add` path, matching the safe-cast already used by `Timer.ObserveDurationWithExemplar`. #2005
 
 ## Unreleased `exp` module

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -37,6 +37,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -96,7 +97,7 @@ type coalescingGatherer struct {
 // gatherCycle tracks a single in-flight Gather and all HTTP handlers sharing it.
 type gatherCycle struct {
 	ready chan struct{}       // closed when Gather completes; happens-before reads of mfs/err/done
-	mfs   []*dto.MetricFamily // set before ready is closed; shared across handlers, must not be mutated
+	mfs   []*dto.MetricFamily // canonical result, set before ready is closed; callers get a slices.Clone, the element values stay shared and must not be mutated
 	err   error               // set before ready is closed
 	done  func()              // underlying done callback; set before ready is closed
 	refs  int                 // number of handlers using this cycle; protected by coalescingGatherer.mu
@@ -107,7 +108,7 @@ var _ prometheus.TransactionalGatherer = (*coalescingGatherer)(nil) // compile-t
 // errGatherPanicked is returned to callers that joined an in-flight coalesced
 // Gather whose underlying gatherer panicked. See the panic guard in Gather for
 // why joiners receive this error instead of the panic itself.
-var errGatherPanicked = errors.New("promhttp: coalesced gather panicked")
+var errGatherPanicked = errors.New("coalesced gather panicked")
 
 func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 	c.mu.Lock()
@@ -116,7 +117,10 @@ func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 		cy.refs++
 		c.mu.Unlock()
 		<-cy.ready
-		return cy.mfs, c.releaseFunc(cy), cy.err
+		// Each caller gets its own slice header so it can filter or reorder
+		// without racing other callers sharing this cycle. The *dto.MetricFamily
+		// values remain shared and must not be mutated in place.
+		return slices.Clone(cy.mfs), c.releaseFunc(cy), cy.err
 	}
 	cy := &gatherCycle{
 		ready: make(chan struct{}),
@@ -136,6 +140,12 @@ func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 	// set cy.err before closing cy.ready so joiners waiting on <-cy.ready fail
 	// with that error instead of silently returning an empty, successful
 	// response, and we clear c.cycle so the next Gather starts a fresh cycle.
+	//
+	// The leader never runs its own releaseFunc on this path, so its ref is
+	// not decremented; that is harmless because the cycle is detached (c.cycle
+	// = nil) and cy.done is still the no-op set at construction (c.g.Gather
+	// panicked before assigning a real done). If cy.done is ever made non-nil
+	// before c.g.Gather runs, this path would need to release it.
 	panicked := true
 	defer func() {
 		if panicked {
@@ -152,7 +162,10 @@ func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 	panicked = false
 	close(cy.ready) // happens-before joiners' reads of cy.mfs/err/done
 
-	return cy.mfs, c.releaseFunc(cy), cy.err
+	// Clone here too so cy.mfs stays the write-once canonical slice: joiners
+	// read it concurrently via slices.Clone, so the leader must not hand out
+	// (and potentially reorder) the same backing array.
+	return slices.Clone(cy.mfs), c.releaseFunc(cy), cy.err
 }
 
 // releaseFunc returns the done callback for one caller sharing cy.
@@ -535,14 +548,23 @@ type HandlerOpts struct {
 	// faster than the time collectors need to produce metrics.
 	//
 	// When enabled, concurrent scrapers share a single metric snapshot per
-	// collection cycle. The returned MetricFamily values are shared and must
-	// not be mutated in place. The built-in handler only reads them, so this
-	// is safe in practice, but custom TransactionalGatherer implementations
-	// that modify the returned families after Gather returns must not use
-	// this option.
+	// collection cycle. Each request receives its own copy of the returned
+	// slice, so filtering or reordering it (for example via name[] query
+	// parameters) is safe. The pointed-to MetricFamily values are still
+	// shared: the built-in handler only reads them, so this is safe in
+	// practice, but a custom TransactionalGatherer that mutates the returned
+	// families in place after Gather returns must not use this option.
 	//
-	// Consider using CoalesceGather together with Timeout to bound both the
-	// scrape response time and the number of concurrent background Gathers.
+	// Because the snapshot is shared, a request that arrives while a cycle is
+	// in flight receives that cycle's result even though collection began
+	// before the request; two scrapers joined to one cycle observe the same
+	// timestamps rather than independently gathered data.
+	//
+	// Consider using CoalesceGather together with Timeout. Timeout bounds the
+	// client-facing response time and keeps at most one collection running at
+	// a time, but it does not cancel the underlying Gather: a joined request
+	// that times out still holds a MaxRequestsInFlight slot until the shared
+	// collection completes.
 	//
 	// Panic handling: a panicking Collector is already turned into an error by
 	// the registry, so joiners receive that error like any other. In the rare

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -104,6 +104,11 @@ type gatherCycle struct {
 
 var _ prometheus.TransactionalGatherer = (*coalescingGatherer)(nil) // compile-time interface check
 
+// errGatherPanicked is returned to callers that joined an in-flight coalesced
+// Gather whose underlying gatherer panicked. See the panic guard in Gather for
+// why joiners receive this error instead of the panic itself.
+var errGatherPanicked = errors.New("promhttp: coalesced gather panicked")
+
 func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 	c.mu.Lock()
 	if cy := c.cycle; cy != nil {
@@ -121,9 +126,16 @@ func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 	c.cycle = cy
 	c.mu.Unlock()
 
-	// Guard against a panic in c.g.Gather: close cy.ready and clear c.cycle
-	// so that any joiners waiting on <-cy.ready are unblocked rather than
-	// deadlocked, and future Gather calls start a fresh cycle.
+	// Guard against a panic in c.g.Gather. The common case, a panicking
+	// Collector, never reaches here: Registry.Gather recovers Collector panics
+	// and returns them as an error. This guard only covers the rare case where
+	// the wrapped gatherer itself panics.
+	//
+	// We deliberately do not recover: the leader's panic propagates and is
+	// handled by net/http exactly as it would be without coalescing. We only
+	// set cy.err before closing cy.ready so joiners waiting on <-cy.ready fail
+	// with that error instead of silently returning an empty, successful
+	// response, and we clear c.cycle so the next Gather starts a fresh cycle.
 	panicked := true
 	defer func() {
 		if panicked {
@@ -132,6 +144,7 @@ func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
 				c.cycle = nil
 			}
 			c.mu.Unlock()
+			cy.err = errGatherPanicked // set before close: happens-before joiners' reads
 			close(cy.ready)
 		}
 	}()
@@ -530,6 +543,12 @@ type HandlerOpts struct {
 	//
 	// Consider using CoalesceGather together with Timeout to bound both the
 	// scrape response time and the number of concurrent background Gathers.
+	//
+	// Panic handling: a panicking Collector is already turned into an error by
+	// the registry, so joiners receive that error like any other. In the rare
+	// case where the wrapped gatherer itself panics, the panicking request's
+	// panic propagates as usual (handled by net/http), while requests that
+	// joined the same cycle receive an error rather than an empty response.
 	CoalesceGather bool
 	// If handling a request takes longer than Timeout, it is responded to
 	// with 503 ServiceUnavailable and a suitable Message. No timeout is

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -41,6 +41,7 @@ import (
 	"sync"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 
 	"github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil"
@@ -77,6 +78,88 @@ var gzipPool = sync.Pool{
 	New: func() any {
 		return gzip.NewWriter(nil)
 	},
+}
+
+// coalescingGatherer wraps a TransactionalGatherer to deduplicate concurrent
+// Gather calls. When a Gather is already in flight, new callers join the
+// existing cycle and receive the same result once it completes. The underlying
+// done function is called exactly once, when the last joined caller releases.
+//
+// This prevents goroutine pile-up when the scrape rate is faster than the
+// time collectors need to produce metrics.
+type coalescingGatherer struct {
+	g     prometheus.TransactionalGatherer
+	mu    sync.Mutex
+	cycle *gatherCycle
+}
+
+// gatherCycle tracks a single in-flight Gather and all HTTP handlers sharing it.
+type gatherCycle struct {
+	ready chan struct{}       // closed when Gather completes; happens-before reads of mfs/err/done
+	mfs   []*dto.MetricFamily // set before ready is closed; shared across handlers, must not be mutated
+	err   error               // set before ready is closed
+	done  func()              // underlying done callback; set before ready is closed
+	refs  int                 // number of handlers using this cycle; protected by coalescingGatherer.mu
+}
+
+var _ prometheus.TransactionalGatherer = (*coalescingGatherer)(nil) // compile-time interface check
+
+func (c *coalescingGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
+	c.mu.Lock()
+	if cy := c.cycle; cy != nil {
+		// c.cycle is non-nil while Gather runs or handlers are still consuming its results.
+		cy.refs++
+		c.mu.Unlock()
+		<-cy.ready
+		return cy.mfs, c.releaseFunc(cy), cy.err
+	}
+	cy := &gatherCycle{
+		ready: make(chan struct{}),
+		done:  func() {},
+		refs:  1,
+	}
+	c.cycle = cy
+	c.mu.Unlock()
+
+	// Guard against a panic in c.g.Gather: close cy.ready and clear c.cycle
+	// so that any joiners waiting on <-cy.ready are unblocked rather than
+	// deadlocked, and future Gather calls start a fresh cycle.
+	panicked := true
+	defer func() {
+		if panicked {
+			c.mu.Lock()
+			if c.cycle == cy {
+				c.cycle = nil
+			}
+			c.mu.Unlock()
+			close(cy.ready)
+		}
+	}()
+	cy.mfs, cy.done, cy.err = c.g.Gather()
+	panicked = false
+	close(cy.ready) // happens-before joiners' reads of cy.mfs/err/done
+
+	return cy.mfs, c.releaseFunc(cy), cy.err
+}
+
+// releaseFunc returns the done callback for one caller sharing cy.
+// When the last caller releases, the underlying done is invoked and the
+// cycle is cleared so the next Gather starts fresh.
+func (c *coalescingGatherer) releaseFunc(cy *gatherCycle) func() {
+	return func() {
+		c.mu.Lock()
+		cy.refs--
+		if cy.refs > 0 {
+			c.mu.Unlock()
+			return
+		}
+		// Last caller.
+		if c.cycle == cy {
+			c.cycle = nil
+		}
+		c.mu.Unlock()
+		cy.done() // called outside the lock to avoid holding it during done
+	}
 }
 
 // Handler returns an http.Handler for the prometheus.DefaultGatherer, using
@@ -125,6 +208,10 @@ func HandlerFor(reg prometheus.Gatherer, opts HandlerOpts) http.Handler {
 // Multiple metric names can be specified by providing the parameter multiple times.
 // When no name[] parameters are provided, all metrics are returned.
 func HandlerForTransactional(reg prometheus.TransactionalGatherer, opts HandlerOpts) http.Handler {
+	if opts.CoalesceGather {
+		reg = &coalescingGatherer{g: reg}
+	}
+
 	var (
 		inFlightSem chan struct{}
 		errCnt      = prometheus.NewCounterVec(
@@ -428,6 +515,22 @@ type HandlerOpts struct {
 	// Service Unavailable and a suitable message in the body. If
 	// MaxRequestsInFlight is 0 or negative, no limit is applied.
 	MaxRequestsInFlight int
+	// CoalesceGather, if true, deduplicates concurrent Gather calls so that
+	// only one collection runs at a time. Additional requests that arrive
+	// while a Gather is in flight will receive the same result once it
+	// completes. This prevents goroutine pile-up when the scrape rate is
+	// faster than the time collectors need to produce metrics.
+	//
+	// When enabled, concurrent scrapers share a single metric snapshot per
+	// collection cycle. The returned MetricFamily values are shared and must
+	// not be mutated in place. The built-in handler only reads them, so this
+	// is safe in practice, but custom TransactionalGatherer implementations
+	// that modify the returned families after Gather returns must not use
+	// this option.
+	//
+	// Consider using CoalesceGather together with Timeout to bound both the
+	// scrape response time and the number of concurrent background Gathers.
+	CoalesceGather bool
 	// If handling a request takes longer than Timeout, it is responded to
 	// with 503 ServiceUnavailable and a suitable Message. No timeout is
 	// applied if Timeout is 0 or negative. Note that with the current
@@ -435,8 +538,9 @@ type HandlerOpts struct {
 	// described above (and even that only if sending of the body hasn't
 	// started yet), while the bulk work of gathering all the metrics keeps
 	// running in the background (with the eventual result to be thrown
-	// away). Until the implementation is improved, it is recommended to
-	// implement a separate timeout in potentially slow Collectors.
+	// away). When CoalesceGather is enabled, only one such background Gather
+	// can be in flight at a time. It is also recommended to implement a
+	// separate timeout in potentially slow Collectors.
 	Timeout time.Duration
 	// If true, the experimental OpenMetrics encoding is added to the
 	// possible options during content negotiation. Note that Prometheus

--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -571,6 +571,9 @@ type HandlerOpts struct {
 	// case where the wrapped gatherer itself panics, the panicking request's
 	// panic propagates as usual (handled by net/http), while requests that
 	// joined the same cycle receive an error rather than an empty response.
+	//
+	// NOTE: This option is experimental and may change or be removed in a
+	// future release.
 	CoalesceGather bool
 	// If handling a request takes longer than Timeout, it is responded to
 	// with 503 ServiceUnavailable and a suitable Message. No timeout is

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -22,12 +22,16 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
 	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/goleak"
 
 	"github.com/prometheus/client_golang/prometheus"
 	_ "github.com/prometheus/client_golang/prometheus/promhttp/zstd"
@@ -873,5 +877,157 @@ func TestHandlerWithMetricFilter(t *testing.T) {
 				t.Errorf("unexpected number of done invokes, want 1, got %d", got)
 			}
 		})
+	}
+}
+
+// syncGatherCounter is a thread-safe TransactionalGatherer wrapper that counts
+// Gather and done invocations. Safe for concurrent use from multiple goroutines,
+// unlike mockTransactionGatherer whose counters are not race-safe.
+type syncGatherCounter struct {
+	g            prometheus.Gatherer
+	gatherCalled atomic.Int64
+	doneCalled   atomic.Int64
+}
+
+func (m *syncGatherCounter) Gather() ([]*dto.MetricFamily, func(), error) {
+	m.gatherCalled.Add(1)
+	mfs, err := m.g.Gather()
+	return mfs, func() { m.doneCalled.Add(1) }, err
+}
+
+// TestCoalesceGatherSequentialInvariant verifies that sequential requests each
+// trigger exactly one Gather call and one done call.
+func TestCoalesceGatherSequentialInvariant(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := &syncGatherCounter{g: reg}
+	handler := HandlerForTransactional(counter, HandlerOpts{CoalesceGather: true})
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add(acceptHeader, acceptTextPlain)
+
+	const n = 3
+	for i := range n {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if got, want := w.Code, http.StatusOK; got != want {
+			t.Fatalf("request %d: HTTP status %d, want %d", i+1, got, want)
+		}
+	}
+	if got, want := counter.gatherCalled.Load(), int64(n); got != want {
+		t.Errorf("Gather called %d times, want %d", got, want)
+	}
+	if got, want := counter.doneCalled.Load(), int64(n); got != want {
+		t.Errorf("done called %d times, want %d", got, want)
+	}
+}
+
+// TestCoalesceGatherDoneCalledExactlyOnce verifies that when concurrent requests
+// share a single Gather cycle, the underlying done callback is called exactly once.
+func TestCoalesceGatherDoneCalledExactlyOnce(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	reg := prometheus.NewRegistry()
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	reg.MustRegister(blockingCollector{CollectStarted: started, Block: block})
+
+	counter := &syncGatherCounter{g: reg}
+	handler := HandlerForTransactional(counter, HandlerOpts{CoalesceGather: true})
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add(acceptHeader, acceptTextPlain)
+
+	// Start request 1 in background; it blocks in Collect.
+	w1 := httptest.NewRecorder()
+	req1Done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(w1, req)
+		close(req1Done)
+	}()
+	<-started // Gather 1 is now in-flight and blocked in Collect.
+
+	// Start request 2; it will join the in-flight Gather cycle.
+	w2 := httptest.NewRecorder()
+	req2Done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(w2, req)
+		close(req2Done)
+	}()
+
+	// Yield to allow request 2 to enter the coalescing wait before releasing.
+	runtime.Gosched()
+	close(block)
+	<-req1Done
+	<-req2Done
+
+	// Key invariant: done() must be called exactly once per Gather cycle.
+	gathers := counter.gatherCalled.Load()
+	dones := counter.doneCalled.Load()
+	if gathers != dones {
+		t.Errorf("Gather called %d times but done called %d times; invariant violated", gathers, dones)
+	}
+	// Coalescing should keep gather count below the number of requests.
+	if gathers > 2 {
+		t.Errorf("Gather called %d times for 2 requests; expected ≤ 2 with coalescing", gathers)
+	}
+	for i, w := range []*httptest.ResponseRecorder{w1, w2} {
+		if got, want := w.Code, http.StatusOK; got != want {
+			t.Errorf("request %d: HTTP status %d, want %d", i+1, got, want)
+		}
+	}
+}
+
+// TestCoalesceGatherGoroutineLeakFree verifies that concurrent requests with a
+// slow collector do not leak goroutines when CoalesceGather is enabled.
+func TestCoalesceGatherGoroutineLeakFree(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	reg := prometheus.NewRegistry()
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	reg.MustRegister(blockingCollector{CollectStarted: started, Block: block})
+
+	handler := HandlerForTransactional(
+		&syncGatherCounter{g: reg},
+		HandlerOpts{CoalesceGather: true},
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add(acceptHeader, acceptTextPlain)
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Go(func() {
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+		})
+	}
+	<-started
+	close(block)
+	wg.Wait()
+	// goleak.VerifyNone (deferred above) asserts no goroutines leaked.
+}
+
+// TestCoalesceGatherNewCycleAfterCompletion verifies that once all handlers of a
+// cycle have released, the next request starts a fresh Gather.
+func TestCoalesceGatherNewCycleAfterCompletion(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := &syncGatherCounter{g: reg}
+	handler := HandlerForTransactional(counter, HandlerOpts{CoalesceGather: true})
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add(acceptHeader, acceptTextPlain)
+
+	// Cycle 1.
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if got, want := counter.gatherCalled.Load(), int64(1); got != want {
+		t.Fatalf("after cycle 1: Gather called %d times, want %d", got, want)
+	}
+	if got, want := counter.doneCalled.Load(), int64(1); got != want {
+		t.Fatalf("after cycle 1: done called %d times, want %d", got, want)
+	}
+
+	// Cycle 2: previous cycle is complete so a fresh Gather must run.
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if got, want := counter.gatherCalled.Load(), int64(2); got != want {
+		t.Errorf("after cycle 2: Gather called %d times, want %d", got, want)
+	}
+	if got, want := counter.doneCalled.Load(), int64(2); got != want {
+		t.Errorf("after cycle 2: done called %d times, want %d", got, want)
 	}
 }

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -1046,13 +1046,18 @@ func (c *coalescingGatherer) inflightRefs() int {
 }
 
 // waitForRefs blocks until cg reports at least want in-flight refs, failing the
-// test if that does not happen promptly.
+// test if that does not happen within a short deadline. It must be called from
+// the test goroutine, as it reports failure via t.Fatalf.
 func waitForRefs(t *testing.T, cg *coalescingGatherer, want int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
-	for cg.inflightRefs() < want {
+	for {
+		got := cg.inflightRefs()
+		if got >= want {
+			return
+		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for %d in-flight refs, have %d", want, cg.inflightRefs())
+			t.Fatalf("timed out waiting for %d in-flight refs, have %d", want, got)
 		}
 		time.Sleep(time.Millisecond)
 	}
@@ -1120,7 +1125,62 @@ func TestCoalesceGatherPanicUnblocksJoinersWithError(t *testing.T) {
 	if res.done != nil {
 		res.done() // must be safe to call: no panic, no double-done.
 	}
+	// inflightRefs reports 0 once c.cycle is detached, which the leader does on
+	// the panic path. This confirms the coalescer starts a fresh cycle next
+	// time; it does not track the orphaned cycle's own ref count (the leader's
+	// ref is intentionally never released there).
 	if got := cg.inflightRefs(); got != 0 {
-		t.Errorf("cycle not cleared after panic: inflightRefs = %d, want 0", got)
+		t.Errorf("cycle not detached after panic: inflightRefs = %d, want 0", got)
+	}
+}
+
+// TestCoalesceGatherCallersGetDistinctSlices verifies that callers sharing one
+// cycle each receive their own slice header, so one caller reordering or
+// filtering its slice cannot race another caller of the same cycle.
+func TestCoalesceGatherCallersGetDistinctSlices(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	reg := prometheus.NewRegistry()
+	cnt := prometheus.NewCounter(prometheus.CounterOpts{Name: "c_total", Help: "help"})
+	cnt.Inc()
+	reg.MustRegister(cnt)
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	reg.MustRegister(blockingCollector{CollectStarted: started, Block: block})
+
+	cg := &coalescingGatherer{g: &syncGatherCounter{g: reg}}
+
+	type result struct {
+		mfs  []*dto.MetricFamily
+		done func()
+	}
+	got := make(chan result, 2)
+	call := func() {
+		mfs, done, err := cg.Gather()
+		if err != nil {
+			t.Errorf("Gather returned error: %v", err)
+		}
+		got <- result{mfs: mfs, done: done}
+	}
+
+	go call()
+	<-started             // leader is in-flight, blocked in Collect.
+	go call()             // second caller joins the same cycle.
+	waitForRefs(t, cg, 2) // both callers share the cycle before release.
+	close(block)
+
+	r1 := <-got
+	r2 := <-got
+	defer r1.done()
+	defer r2.done()
+
+	if len(r1.mfs) == 0 || len(r2.mfs) == 0 {
+		t.Fatalf("expected non-empty metric families, got %d and %d", len(r1.mfs), len(r2.mfs))
+	}
+	// Distinct backing arrays: clearing one caller's slot must not affect the
+	// other. This fails if the coalescer hands out the shared slice directly.
+	r1.mfs[0] = nil
+	if r2.mfs[0] == nil {
+		t.Error("callers share a slice backing array; each caller must get its own copy")
 	}
 }

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -920,8 +919,8 @@ func TestCoalesceGatherSequentialInvariant(t *testing.T) {
 	}
 }
 
-// TestCoalesceGatherDoneCalledExactlyOnce verifies that when concurrent requests
-// share a single Gather cycle, the underlying done callback is called exactly once.
+// TestCoalesceGatherDoneCalledExactlyOnce verifies that when a second request
+// joins an in-flight Gather cycle, exactly one Gather and one done call occur.
 func TestCoalesceGatherDoneCalledExactlyOnce(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
@@ -930,8 +929,12 @@ func TestCoalesceGatherDoneCalledExactlyOnce(t *testing.T) {
 	started := make(chan struct{}, 1)
 	reg.MustRegister(blockingCollector{CollectStarted: started, Block: block})
 
+	// Wrap explicitly so the test can observe when request 2 has joined the
+	// in-flight cycle. HandlerForTransactional with CoalesceGather builds an
+	// equivalent wrapper internally but keeps it hidden from the test.
 	counter := &syncGatherCounter{g: reg}
-	handler := HandlerForTransactional(counter, HandlerOpts{CoalesceGather: true})
+	cg := &coalescingGatherer{g: counter}
+	handler := HandlerForTransactional(cg, HandlerOpts{})
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Add(acceptHeader, acceptTextPlain)
 
@@ -952,21 +955,19 @@ func TestCoalesceGatherDoneCalledExactlyOnce(t *testing.T) {
 		close(req2Done)
 	}()
 
-	// Yield to allow request 2 to enter the coalescing wait before releasing.
-	runtime.Gosched()
+	// Wait until request 2 has joined the cycle (refs == 2) before releasing,
+	// so coalescing is guaranteed rather than dependent on goroutine timing.
+	waitForRefs(t, cg, 2)
 	close(block)
 	<-req1Done
 	<-req2Done
 
-	// Key invariant: done() must be called exactly once per Gather cycle.
-	gathers := counter.gatherCalled.Load()
-	dones := counter.doneCalled.Load()
-	if gathers != dones {
-		t.Errorf("Gather called %d times but done called %d times; invariant violated", gathers, dones)
+	// With request 2 joining an in-flight cycle, both share one Gather and one done.
+	if got := counter.gatherCalled.Load(); got != 1 {
+		t.Errorf("Gather called %d times for 2 coalesced requests, want exactly 1", got)
 	}
-	// Coalescing should keep gather count below the number of requests.
-	if gathers > 2 {
-		t.Errorf("Gather called %d times for 2 requests; expected ≤ 2 with coalescing", gathers)
+	if got := counter.doneCalled.Load(); got != 1 {
+		t.Errorf("done called %d times, want exactly 1", got)
 	}
 	for i, w := range []*httptest.ResponseRecorder{w1, w2} {
 		if got, want := w.Code, http.StatusOK; got != want {
@@ -1029,5 +1030,97 @@ func TestCoalesceGatherNewCycleAfterCompletion(t *testing.T) {
 	}
 	if got, want := counter.doneCalled.Load(), int64(2); got != want {
 		t.Errorf("after cycle 2: done called %d times, want %d", got, want)
+	}
+}
+
+// inflightRefs reports how many callers currently share the in-flight cycle.
+// It lives in the test file so production code carries no test-only hooks; tests
+// use it to wait deterministically until a joiner has entered the cycle.
+func (c *coalescingGatherer) inflightRefs() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cycle == nil {
+		return 0
+	}
+	return c.cycle.refs
+}
+
+// waitForRefs blocks until cg reports at least want in-flight refs, failing the
+// test if that does not happen promptly.
+func waitForRefs(t *testing.T, cg *coalescingGatherer, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for cg.inflightRefs() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d in-flight refs, have %d", want, cg.inflightRefs())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// panicGatherer is a TransactionalGatherer whose Gather panics after signaling
+// that it started and waiting to be released. A panicking Collector cannot reach
+// the panic guard in coalescingGatherer because Registry.Gather recovers
+// Collector panics into errors, so the panic is raised at the gatherer level.
+type panicGatherer struct {
+	started chan struct{}
+	block   chan struct{}
+}
+
+func (p *panicGatherer) Gather() ([]*dto.MetricFamily, func(), error) {
+	close(p.started)
+	<-p.block
+	panic("boom")
+}
+
+// TestCoalesceGatherPanicUnblocksJoinersWithError verifies that when the wrapped
+// gatherer panics, a request that joined the same cycle receives errGatherPanicked
+// instead of a nil error with an empty response, the leader's panic still
+// propagates, and the cycle is cleared afterward.
+func TestCoalesceGatherPanicUnblocksJoinersWithError(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	p := &panicGatherer{started: make(chan struct{}), block: make(chan struct{})}
+	cg := &coalescingGatherer{g: p}
+
+	// Leader creates the cycle and panics once released; recover so the test
+	// goroutine survives, mirroring net/http's per-request panic recovery.
+	leaderPanicked := make(chan any, 1)
+	go func() {
+		defer func() { leaderPanicked <- recover() }()
+		_, done, _ := cg.Gather()
+		if done != nil {
+			done()
+		}
+	}()
+	<-p.started
+
+	// Joiner joins the in-flight cycle and blocks on <-cy.ready.
+	type joinResult struct {
+		done func()
+		err  error
+	}
+	joined := make(chan joinResult, 1)
+	go func() {
+		_, done, err := cg.Gather()
+		joined <- joinResult{done: done, err: err}
+	}()
+
+	// Ensure the joiner has joined the cycle before releasing the panic.
+	waitForRefs(t, cg, 2)
+	close(p.block)
+
+	if r := <-leaderPanicked; r == nil {
+		t.Error("leader Gather did not panic; want the panic to propagate")
+	}
+	res := <-joined
+	if !errors.Is(res.err, errGatherPanicked) {
+		t.Errorf("joiner err = %v, want errGatherPanicked", res.err)
+	}
+	if res.done != nil {
+		res.done() // must be safe to call: no panic, no double-done.
+	}
+	if got := cg.inflightRefs(); got != 0 {
+		t.Errorf("cycle not cleared after panic: inflightRefs = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
## What problem does this solve?

Issue #1477 reports apparent goroutine leaks when using `prometheus/client_golang`. The root cause is **not** a WaitGroup bug — `Registry.Gather()` logic is correct. The real problem:

When a collector's `Collect()` is slower than the scrape interval, each incoming HTTP scrape triggers an independent `Gather()`. Each call spawns its own goroutine pipeline. With no upper bound, concurrent pipelines grow proportionally to `(scrape rate / collection time)` — a goroutine pile-up that looks like a leak but is unbounded concurrent work.

This was originally investigated by @initialed85 in [this comment](https://github.com/prometheus/client_golang/issues/1477#issuecomment-4043521036), who validated the issue and prototyped a "piggybacking" (singleflight) approach. This PR implements that idea cleanly inside the HTTP handler, with zero new public types and zero overhead when disabled.

## Solution

Add `HandlerOpts.CoalesceGather bool`. When `true`, `HandlerForTransactional` wraps the `TransactionalGatherer` in an unexported `coalescingGatherer` that allows only one `Gather()` to run at a time. Concurrent HTTP requests arriving while a gather is in-flight join the existing cycle and receive the same result.

### Usage

```go
http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{
    CoalesceGather: true,
}))
```

## Design decisions

| Decision | Rationale |
|---|---|
| `HandlerOpts` field, not a public wrapper type | Zero new public types; users opt in with one field |
| Per-cycle `gatherCycle` object | Prevents a race where a new cycle overwrites result fields while prior waiters are still reading them |
| Mutex-based ref counting (not atomic) | Ensures `c.cycle = nil` is cleared before `cy.done()` is called, ruling out double-done on a stale pointer |
| `close(cy.ready)` as the visibility barrier | Go memory model guarantees `cy.mfs/err/done` are safely readable after `<-cy.ready` without additional locking |
| Default `false` | Zero overhead; identical code path to today when not enabled |

## Changes

| File | Change |
|---|---|
| `prometheus/promhttp/http.go` | Add unexported `coalescingGatherer` + `gatherCycle` types; add `HandlerOpts.CoalesceGather`; wire into `HandlerForTransactional` |
| `prometheus/promhttp/http_test.go` | Add 4 tests: sequential invariant, done-called-exactly-once, goroutine-leak-free (goleak), fresh-cycle-after-release |

## Test plan

- [x] `go test -race -count=1 ./prometheus/promhttp/...` — all pass, no data races
- [x] `go vet ./prometheus/...` — clean
- [x] `TestCoalesceGatherGoroutineLeakFree` uses `goleak.VerifyNone` to assert no leaked goroutines under concurrent slow-collector load
- [x] `TestCoalesceGatherDoneCalledExactlyOnce` verifies the `TransactionalGatherer` contract: `done()` calls == `Gather()` calls regardless of concurrency

Closes #1477