### PR TITLE
README: document the OpenTelemetry OTLP push bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ The
 [`examples` directory](https://github.com/prometheus/client_golang/tree/main/examples)
 contains simple examples of instrumented code.
 
+## Pushing metrics via OpenTelemetry OTLP
+
+Applications instrumented with `client_golang` can also export their
+metrics via the OpenTelemetry OTLP push protocol without re-instrumenting
+against a different metric API. The
+[`go.opentelemetry.io/contrib/bridges/prometheus`](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/prometheus)
+module wraps a `prometheus.Registry` as an OpenTelemetry metric producer,
+which an OTLP exporter (HTTP or gRPC) can then push to an OTel collector
+or OTLP-accepting backend. This is useful for batch jobs or environments
+where pull-based `/metrics` scraping is not an option.
+
+Pull-based collection via `promhttp` remains the recommended default for
+reliability, central discovery, and failover. The bridge is intended as
+an additional option, not a replacement.
+
+See the [bridge's Go reference](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/prometheus)
+and [source](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/bridges/prometheus)
+for setup details.
+
 ## Client for the Prometheus HTTP API
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/prometheus/client_golang/api.svg)](https://pkg.go.dev/github.com/prometheus/client_golang/api)


### PR DESCRIPTION
Closes #1495.

The OTel contrib bridge at [`go.opentelemetry.io/contrib/bridges/prometheus`](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/prometheus) has been shipped for a while, but there's no mention of it in `client_golang`'s README, so users who want OTLP push from an app already instrumented with `prometheus.Registry` don't know it exists and end up double-instrumenting or running the OTel collector's Prometheus receiver.

This adds a short "Pushing metrics via OpenTelemetry OTLP" section to the README after "Instrumenting applications". It:

- points at the bridge module (both `pkg.go.dev` and the `opentelemetry-go-contrib` source),
- names the two useful cases (batch jobs, push-only environments),
- and keeps the upstream recommendation that pull-based `promhttp` is still the default and the bridge is an additional option, not a replacement -- per the wording in the issue body.

No code changes; doc-only.

### Notes

- I did not add a standalone example under `docs/` — a contributor mentioned planning a fuller guide there and that's orthogonal to the "link exists from the README" gap this PR closes. If the longer guide lands, this short section can point to it with a single edit.
- The two bridge URLs return HTTP 200 at time of writing.