### PR TITLE
Fix bug unit cpu-seconds not a suffix of metric go_cpu_classes_gc_mark_assist_cpu_seconds

### DIFF
--- a/prometheus/go_collector_latest.go
+++ b/prometheus/go_collector_latest.go
@@ -211,9 +211,13 @@ func NewGoCollector(opts ...func(o *internal.GoCollectorOptions)) Collector {
 		sampleMap[d.Name] = &sampleBuf[len(sampleBuf)-1]
 
 		// Extract unit from the runtime/metrics name (e.g., "/gc/heap/allocs:bytes" -> "bytes")
+		// and sanitize to match Prometheus naming conventions (e.g., "cpu-seconds" -> "cpu_seconds")
 		var unit string
 		if idx := strings.IndexRune(d.Name, ':'); idx >= 0 {
 			unit = d.Name[idx+1:]
+			unit = strings.ReplaceAll(unit, "-", "_")
+			unit = strings.ReplaceAll(unit, "*", "_")
+			unit = strings.ReplaceAll(unit, "/", "_per_")
 		}
 
 		var m collectorMetric

--- a/prometheus/go_collector_latest_test.go
+++ b/prometheus/go_collector_latest_test.go
@@ -434,6 +434,8 @@ func TestGoCollectorRuntimeMetricsUnit(t *testing.T) {
 		{"go_gc_heap_frees_bytes_total", "bytes"},
 		{"go_sched_goroutines_goroutines", "goroutines"},
 		{"go_gc_gomemlimit_bytes", "bytes"},
+		{"go_cpu_classes_gc_mark_assist_cpu_seconds_total", "cpu_seconds"},
+		{"go_gc_cycles_total_gc_cycles_total", "gc_cycles"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Hot fix for https://github.com/prometheus/client_golang/issues/1990 + relative tests.