### PR TITLE
promhttp: add regression test for concurrent map writes (#1274)

### DIFF
--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -521,6 +522,59 @@ func TestInterfaceUpgrade(t *testing.T) {
 	if _, ok := d.(http.Hijacker); ok {
 		t.Error("delegator unexpectedly implements http.Hijacker")
 	}
+}
+
+func TestInstrumentHandlerLabelFromCtxConcurrent(t *testing.T) {
+	const (
+		workers           = 32
+		requestsPerWorker = 200
+	)
+
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "test_requests_total",
+			Help: "A counter for requests to the wrapped handler.",
+		},
+		[]string{"dyn"},
+	)
+	histogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "test_request_duration_seconds",
+			Help: "A histogram of latencies for requests to the wrapped handler.",
+		},
+		[]string{"dyn"},
+	)
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(counter, histogram)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	dyn := WithLabelFromCtx("dyn", func(_ context.Context) string {
+		return "v"
+	})
+
+	chain := InstrumentHandlerCounter(
+		counter,
+		InstrumentHandlerDuration(histogram, next, dyn),
+		dyn,
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < requestsPerWorker; j++ {
+				req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+				rec := httptest.NewRecorder()
+				chain.ServeHTTP(rec, req)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func ExampleInstrumentHandlerDuration() {

--- a/prometheus/promhttp/instrument_server_test.go
+++ b/prometheus/promhttp/instrument_server_test.go
@@ -524,6 +524,7 @@ func TestInterfaceUpgrade(t *testing.T) {
 	}
 }
 
+// Regression test against https://github.com/prometheus/client_golang/pull/1318
 func TestInstrumentHandlerLabelFromCtxConcurrent(t *testing.T) {
 	const (
 		workers           = 32


### PR DESCRIPTION
Closes #1274.

Without the fix in #1318, instrumenting a metric vec partitioned only by labels supplied via `WithLabelFromCtx` (i.e. with no `code` or `method` label) would cause concurrent requests to share and mutate the single package-level `emptyLabels` map returned by `labels()`, producing `fatal error: concurrent map writes` under load.

#1318 made `labels()` allocate a fresh map on every call, but as @bwplotka noted on that PR (`> Can we add regression test? This will make sure we don't reintroduce same bug.`) no regression test was added. This adds it.

The test wires up `InstrumentHandlerCounter(InstrumentHandlerDuration(...))` around metrics whose only label is supplied via `WithLabelFromCtx`, then drives the chain from 32 goroutines × 200 requests = 6,400 concurrent `ServeHTTP` calls. Either `go test -race` or the runtime's concurrent-map-writes detector will fire if the shared-empty-map regression returns.

### Verification

```
$ go test -v -count=1 -race -run TestInstrumentHandlerLabelFromCtxConcurrent ./prometheus/promhttp
=== RUN   TestInstrumentHandlerLabelFromCtxConcurrent
--- PASS: TestInstrumentHandlerLabelFromCtxConcurrent (0.05s)
PASS
ok  github.com/prometheus/client_golang/prometheus/promhttp  1.077s
```

I also locally re-introduced the pre-#1318 `labels()` (returning the package-level `emptyLabels` map) and confirmed the test fails as expected — the race detector reports a data race on the shared `prometheus.Labels` map and the run aborts. Reverting that one-file change makes the test pass again.

The full package suite stays green with `-race`.