### PR TITLE
promhttp: ignore 1xx informational status codes in WriteHeader

### DIFF
--- a/prometheus/promhttp/delegator.go
+++ b/prometheus/promhttp/delegator.go
@@ -53,6 +53,14 @@ func (r *responseWriterDelegator) Written() int64 {
 }
 
 func (r *responseWriterDelegator) WriteHeader(code int) {
+	// 1xx informational responses (e.g. 100 Continue) are not the final
+	// status code.  Delegate them to the underlying ResponseWriter but do
+	// not record them as the response status or call observeWriteHeader,
+	// mirroring the behaviour of net/http's own responseWriter.
+	if code >= 100 && code < 200 {
+		r.ResponseWriter.WriteHeader(code)
+		return
+	}
 	if r.observeWriteHeader != nil && !r.wroteHeader {
 		// Only call observeWriteHeader for the 1st time. It's a bug if
 		// WriteHeader is called more than once, but we want to protect

--- a/prometheus/promhttp/delegator_test.go
+++ b/prometheus/promhttp/delegator_test.go
@@ -54,6 +54,60 @@ func (rw *responseWriter) SetReadDeadline(deadline time.Time) error {
 	return nil
 }
 
+// trackingResponseWriter records every status code passed to WriteHeader so we
+// can verify that 1xx informational codes are forwarded but not recorded as the
+// final status.
+type trackingResponseWriter struct {
+	codes []int
+}
+
+func (rw *trackingResponseWriter) Header() http.Header         { return http.Header{} }
+func (rw *trackingResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (rw *trackingResponseWriter) WriteHeader(code int)        { rw.codes = append(rw.codes, code) }
+
+// TestResponseWriterDelegatorInformationalStatusCode verifies that 1xx
+// responses (e.g. 100 Continue) are forwarded to the underlying
+// ResponseWriter but are NOT recorded as the final status code, mirroring
+// the behaviour of net/http's own responseWriter. See GitHub issue #1772.
+func TestResponseWriterDelegatorInformationalStatusCode(t *testing.T) {
+	var observed []int
+	observe := func(code int) { observed = append(observed, code) }
+
+	inner := &trackingResponseWriter{}
+	rwd := &responseWriterDelegator{
+		ResponseWriter:     inner,
+		observeWriteHeader: observe,
+	}
+
+	// Send 100 Continue first — should pass through to inner but not be
+	// recorded as the final status or trigger observeWriteHeader.
+	rwd.WriteHeader(http.StatusContinue)
+	if rwd.wroteHeader {
+		t.Error("wroteHeader must not be set after a 1xx informational response")
+	}
+	if rwd.status == http.StatusContinue {
+		t.Error("status must not be set to 100 after an informational response")
+	}
+	if len(observed) != 0 {
+		t.Errorf("observeWriteHeader must not be called for 1xx responses, got %v", observed)
+	}
+	if len(inner.codes) != 1 || inner.codes[0] != http.StatusContinue {
+		t.Errorf("100 Continue must be forwarded to the inner ResponseWriter, got %v", inner.codes)
+	}
+
+	// Now send the real response.
+	rwd.WriteHeader(http.StatusOK)
+	if !rwd.wroteHeader {
+		t.Error("wroteHeader must be set after the final response")
+	}
+	if rwd.status != http.StatusOK {
+		t.Errorf("status must be 200 after the final response, got %d", rwd.status)
+	}
+	if len(observed) != 1 || observed[0] != http.StatusOK {
+		t.Errorf("observeWriteHeader must be called once with 200, got %v", observed)
+	}
+}
+
 func TestResponseWriterDelegatorUnwrap(t *testing.T) {
 	w := &responseWriter{}
 	rwd := &responseWriterDelegator{ResponseWriter: w}


### PR DESCRIPTION
## Problem

Fixes #1772

`responseWriterDelegator.WriteHeader` records **any** status code, including `100 Continue`, as the final response status and calls `observeWriteHeader` for it.

A handler that explicitly signals `100 Continue` before writing the body ends up reporting `100` as its final status code instead of `200`, corrupting Prometheus metrics.

## Root cause

The delegator did not mirror what `net/http`'s own `responseWriter` does: [server.go](https://github.com/golang/go/blob/go1.24.1/src/net/http/server.go#L1212-L1228) only records the status and sets `wroteHeader` for non-informational responses.

## Fix

Return early for 1xx codes: delegate to the inner `ResponseWriter` (so the upstream still receives the informational response) but do **not** update `wroteHeader`, `status`, or call `observeWriteHeader`.

```go
// Before
func (r *responseWriterDelegator) WriteHeader(code int) {
    if r.observeWriteHeader != nil && !r.wroteHeader {
        r.observeWriteHeader(code)   // called for 100 Continue ← bug
    }
    r.status = code                  // set to 100 ← bug
    r.wroteHeader = true
    r.ResponseWriter.WriteHeader(code)
}

// After
func (r *responseWriterDelegator) WriteHeader(code int) {
    if code >= 100 && code < 200 {
        r.ResponseWriter.WriteHeader(code)  // forward but don't record
        return
    }
    // ... existing logic unchanged
}
```

## Tests

Added `TestResponseWriterDelegatorInformationalStatusCode` that:
- Sends `100 Continue` and asserts `wroteHeader` is not set, `status` is not 100, and `observeWriteHeader` is not called
- Then sends `200 OK` and asserts all three are correctly recorded