### PR TITLE
ci(update-go-versions): declare permissions for the monthly chore PR

### DIFF
--- a/.github/workflows/update-go-versions.yml
+++ b/.github/workflows/update-go-versions.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+# peter-evans/create-pull-request pushes the update-metrics-for-new-go-version
+# branch and opens the chore PR via GITHUB_TOKEN.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-go-versions:
     name: Update Go Versions and Generate Tests


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to the minimum scopes the scheduled `peter-evans/create-pull-request` step actually uses:

```yaml
permissions:
  contents: write       # pushes update-metrics-for-new-go-version branch
  pull-requests: write  # opens the chore PR against main
```

Matches the documented permissions for `peter-evans/create-pull-request` when the action is given `secrets.GITHUB_TOKEN` (as here). YAML validated.