### PR TITLE
docs: fix godoc indentation and typos in timer.go and wrap.go

### DIFF
--- a/prometheus/timer.go
+++ b/prometheus/timer.go
@@ -37,10 +37,10 @@ type Timer struct {
 // or
 //
 //	func TimeMeWithExemplar() {
-//		    timer := NewTimer(myHistogram)
-//		    defer timer.ObserveDurationWithExemplar(exemplar)
-//		    // Do actual work.
-//		}
+//	    timer := NewTimer(myHistogram)
+//	    defer timer.ObserveDurationWithExemplar(exemplar)
+//	    // Do actual work.
+//	}
 func NewTimer(o Observer) *Timer {
 	return &Timer{
 		begin:    time.Now(),
@@ -66,7 +66,7 @@ func (t *Timer) ObserveDuration() time.Duration {
 
 // ObserveDurationWithExemplar is like ObserveDuration, but it will also
 // observe exemplar with the duration unless exemplar is nil or provided Observer can't
-// be casted to ExemplarObserver.
+// be cast to ExemplarObserver.
 func (t *Timer) ObserveDurationWithExemplar(exemplar Labels) time.Duration {
 	d := time.Since(t.begin)
 	eo, ok := t.observer.(ExemplarObserver)

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -240,7 +240,7 @@ func wrapDesc(desc *Desc, prefix string, labels Labels) *Desc {
 	}
 	// NewDesc will do remaining validations.
 	newDesc := V2.NewDesc(prefix+desc.fqName, desc.help, desc.variableLabels, constLabels, WithUnit(desc.unit))
-	// Propagate errors if there was any. This will override any errer
+	// Propagate errors if there was any. This will override any error
 	// created by NewDesc above, i.e. earlier errors get precedence.
 	if desc.err != nil {
 		newDesc.err = desc.err


### PR DESCRIPTION
Three small doc fixes:

- timer.go: the TimeMeWithExemplar godoc example has extra tabs, renders with wrong indentation (extra level vs the TimeMe example above it)
- timer.go: "casted" -> "cast", cast is an irregular verb, no -ed needed
- wrap.go: "errer" typo -> "error"

Reproduce the indentation issue:

    go doc github.com/prometheus/client_golang/prometheus.NewTimer

second example block shows up with extra tab indent before this fix ngl

cc @vesari @bwplotka @kakkoyun