### PR TITLE
fix(registry): prevent file descriptor leak in WriteToTextfile

### DIFF
--- a/prometheus/registry.go
+++ b/prometheus/registry.go
@@ -641,10 +641,12 @@ func WriteToTextfile(filename string, g Gatherer) error {
 
 	mfs, err := g.Gather()
 	if err != nil {
+		tmp.Close()
 		return err
 	}
 	for _, mf := range mfs {
 		if _, err := expfmt.MetricFamilyToText(tmp, mf); err != nil {
+			tmp.Close()
 			return err
 		}
 	}


### PR DESCRIPTION
In WriteToTextfile, if an error occurs before the explicit tmp.Close() (e.g., Gather fails or MetricFamilyToText fails), the temporary file descriptor is never closed. The deferred os.Remove(tmp.Name()) does not close the file.

Explicitly close the file on all error paths that happen before the final close, ensuring the descriptor is always released.

Additionally, this fixes the issue on Windows where an open file cannot be deleted, preventing the deferred os.Remove from succeeding.

Fixes: 1d54dab ("Add WriteToTextfile test")
Found by PostgresPro.