### PR TITLE
fix metric vec label input aliasing

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -15,6 +15,8 @@ package prometheus
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/prometheus/common/model"
@@ -667,7 +669,7 @@ var labelsPool = &sync.Pool{
 func constrainLabels(desc *Desc, labels Labels) (Labels, func()) {
 	if len(desc.variableLabels.labelConstraints) == 0 {
 		// Fast path when there's no constraints
-		return labels, func() {}
+		return maps.Clone(labels), func() {}
 	}
 
 	constrainedLabels := labelsPool.Get().(Labels)
@@ -686,7 +688,7 @@ func constrainLabels(desc *Desc, labels Labels) (Labels, func()) {
 func constrainLabelValues(desc *Desc, lvs []string, curry []curriedLabelValue) []string {
 	if len(desc.variableLabels.labelConstraints) == 0 {
 		// Fast path when there's no constraints
-		return lvs
+		return slices.Clone(lvs)
 	}
 
 	constrainedValues := make([]string, len(lvs))

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -446,6 +446,79 @@ func TestCounterVecEndToEndWithCollision(t *testing.T) {
 	}
 }
 
+func TestMetricVecGetMetricWithCopiesLabels(t *testing.T) {
+	vec := NewCounterVec(
+		CounterOpts{
+			Name: "test",
+			Help: "helpless",
+		},
+		[]string{"l"},
+	)
+
+	labels := Labels{"l": "bar"}
+	mutated := false
+	vec.hashAdd = func(h uint64, s string) uint64 {
+		if s == "bar" && !mutated {
+			labels["l"] = "cake"
+			mutated = true
+		}
+		return hashAdd(h, s)
+	}
+
+	metric, err := vec.GetMetricWith(labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutated {
+		t.Fatal("test hook was not reached")
+	}
+	assertMetricLabelValue(t, metric, "bar")
+}
+
+func TestMetricVecGetMetricWithLabelValuesCopiesLabelValues(t *testing.T) {
+	vec := NewCounterVec(
+		CounterOpts{
+			Name: "test",
+			Help: "helpless",
+		},
+		[]string{"l"},
+	)
+
+	labelValues := []string{"bar"}
+	mutated := false
+	vec.hashAdd = func(h uint64, s string) uint64 {
+		if s == "bar" && !mutated {
+			labelValues[0] = "cake"
+			mutated = true
+		}
+		return hashAdd(h, s)
+	}
+
+	metric, err := vec.GetMetricWithLabelValues(labelValues...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutated {
+		t.Fatal("test hook was not reached")
+	}
+	assertMetricLabelValue(t, metric, "bar")
+}
+
+func assertMetricLabelValue(t *testing.T, metric Metric, want string) {
+	t.Helper()
+
+	var out dto.Metric
+	if err := metric.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(out.Label); got != 1 {
+		t.Fatalf("got %d labels, want 1", got)
+	}
+	if got := out.Label[0].GetValue(); got != want {
+		t.Fatalf("got label value %q, want %q", got, want)
+	}
+}
+
 func TestCurryVec(t *testing.T) {
 	vec := NewCounterVec(
 		CounterOpts{


### PR DESCRIPTION
## Summary

- clone caller-provided `Labels` maps when `MetricVec` has no label constraints
- clone caller-provided label-value slices in the no-constraint `GetMetricWithLabelValues` path
- add regression tests that mutate caller-owned inputs between hashing and metric creation

## Why

When no label constraints are configured, `constrainLabels` and `constrainLabelValues` returned the caller-owned map or slice directly. `MetricVec` hashes those values first and can then read the same caller-owned input again while creating or matching a metric. If the caller mutates that input concurrently, the internal reads can race and can associate the hash with mutated label values.

Fixes #1951.

## Validation

- `go test -race ./prometheus -run 'TestMetricVecGetMetricWith.*Copies' -count=1`
- `go test -race ./prometheus -run 'TestMetricVec' -count=1`

I also tried `go test -race ./prometheus -count=1`, but my local Go runtime metrics differed from the checked-in Go collector fixtures, causing unrelated `go_collector_latest_test.go` failures.
