### PR TITLE
fix(prometheus): stabilize label maps in MetricVec.GetMetricWith

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -238,15 +238,17 @@ func (m *MetricVec) GetMetricWithLabelValues(lvs ...string) (Metric, error) {
 // around MetricVec, implementing a vector for a specific Metric implementation,
 // for example GaugeVec.
 func (m *MetricVec) GetMetricWith(labels Labels) (Metric, error) {
-	labels, closer := constrainLabels(m.desc, labels)
-	defer closer()
-
-	h, err := m.hashLabels(labels)
+	lvs, err := extractLabelValuesFromLabels(m.desc, labels, m.curry)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.getOrCreateMetricWithLabels(h, labels, m.curry), nil
+	h, err := m.hashLabelValues(lvs)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.getOrCreateMetricWithLabelValues(h, lvs, m.curry), nil
 }
 
 func (m *MetricVec) hashLabelValues(vals []string) (uint64, error) {
@@ -509,31 +511,6 @@ func (m *metricMap) getOrCreateMetricWithLabelValues(
 	return metric
 }
 
-// getOrCreateMetricWithLabels retrieves the metric by hash and label value
-// or creates it and returns the new one.
-//
-// This function holds the mutex.
-func (m *metricMap) getOrCreateMetricWithLabels(
-	hash uint64, labels Labels, curry []curriedLabelValue,
-) Metric {
-	m.mtx.RLock()
-	metric, ok := m.getMetricWithHashAndLabels(hash, labels, curry)
-	m.mtx.RUnlock()
-	if ok {
-		return metric
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	metric, ok = m.getMetricWithHashAndLabels(hash, labels, curry)
-	if !ok {
-		lvs := extractLabelValues(m.desc, labels, curry)
-		metric = m.newMetric(lvs...)
-		m.metrics[hash] = append(m.metrics[hash], metricWithLabelValues{values: lvs, metric: metric})
-	}
-	return metric
-}
-
 // getMetricWithHashAndLabelValues gets a metric while handling possible
 // collisions in the hash space. Must be called while holding the read mutex.
 func (m *metricMap) getMetricWithHashAndLabelValues(
@@ -542,20 +519,6 @@ func (m *metricMap) getMetricWithHashAndLabelValues(
 	metrics, ok := m.metrics[h]
 	if ok {
 		if i := findMetricWithLabelValues(metrics, lvs, curry); i < len(metrics) {
-			return metrics[i].metric, true
-		}
-	}
-	return nil, false
-}
-
-// getMetricWithHashAndLabels gets a metric while handling possible collisions in
-// the hash space. Must be called while holding read mutex.
-func (m *metricMap) getMetricWithHashAndLabels(
-	h uint64, labels Labels, curry []curriedLabelValue,
-) (Metric, bool) {
-	metrics, ok := m.metrics[h]
-	if ok {
-		if i := findMetricWithLabels(m.desc, metrics, labels, curry); i < len(metrics) {
 			return metrics[i].metric, true
 		}
 	}
@@ -629,18 +592,30 @@ func matchLabels(desc *Desc, values []string, labels Labels, curry []curriedLabe
 	return true
 }
 
-func extractLabelValues(desc *Desc, labels Labels, curry []curriedLabelValue) []string {
-	labelValues := make([]string, len(labels)+len(curry))
-	iCurry := 0
-	for i, k := range desc.variableLabels.names {
+func extractLabelValuesFromLabels(desc *Desc, labels Labels, curry []curriedLabelValue) ([]string, error) {
+	if err := validateValuesInLabels(labels, len(desc.variableLabels.names)-len(curry)); err != nil {
+		return nil, err
+	}
+
+	labelValues := make([]string, len(labels))
+	var iCurry, iLabel int
+	for i, labelName := range desc.variableLabels.names {
+		val, ok := labels[labelName]
 		if iCurry < len(curry) && curry[iCurry].index == i {
-			labelValues[i] = curry[iCurry].value
+			if ok {
+				return nil, fmt.Errorf("label name %q is already curried", labelName)
+			}
 			iCurry++
 			continue
 		}
-		labelValues[i] = labels[k]
+		if !ok {
+			return nil, fmt.Errorf("label name %q missing in label map", labelName)
+		}
+		labelValues[iLabel] = desc.variableLabels.constrain(labelName, val)
+		iLabel++
 	}
-	return labelValues
+
+	return labelValues, nil
 }
 
 func inlineLabelValues(lvs []string, curry []curriedLabelValue) []string {

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -363,6 +363,9 @@ func testConstrainedMetricVec(t *testing.T, vec *GaugeVec, constrain func(string
 	// Keep track of metrics.
 	expected := map[[2]string]int{}
 
+	expected[[2]string{"mapped", constrain("labels")}]++
+	vec.With(Labels{"l1": "mapped", "l2": "labels"}).Inc()
+
 	for i := 0; i < 1000; i++ {
 		pair[0], pair[1] = strconv.Itoa(i%4), strconv.Itoa(i%5) // Varying combinations multiples.
 		expected[[2]string{pair[0], constrain(pair[1])}]++
@@ -410,6 +413,39 @@ func testConstrainedMetricVec(t *testing.T, vec *GaugeVec, constrain func(string
 
 	if len(vec.metrics) > 0 {
 		t.Fatalf("reset failed")
+	}
+}
+
+func TestMetricVecWithLabelsKeepsLabelValuesStable(t *testing.T) {
+	vec := NewGaugeVec(
+		GaugeOpts{
+			Name: "test",
+			Help: "helpless",
+		},
+		[]string{"l1", "l2"},
+	)
+
+	labels := Labels{"l1": "v1", "l2": "v2"}
+	hashCalls := 0
+	origHashAddByte := vec.hashAddByte
+	vec.hashAddByte = func(h uint64, b byte) uint64 {
+		hashCalls++
+		if hashCalls == len(vec.desc.variableLabels.names) {
+			labels["l2"] = "v3"
+		}
+		return origHashAddByte(h, b)
+	}
+
+	vec.With(labels).Set(1)
+	vec.hashAddByte = origHashAddByte
+	vec.WithLabelValues("v1", "v3").Set(2)
+
+	reg := NewRegistry()
+	if err := reg.Register(vec); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Gather(); err != nil {
+		t.Fatalf("gather failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
fixes #1951

cc @vesari

`GetMetricWith(Labels)` could hash one label set, then store another if the same map gets mutated while the metric is being created. that can bubble up as `collected before with the same name and label values`, kind of nasty.

This stabilizes the map input first, then reuses the label values path. `WithLabelValues(...)` stays as is.

Repro:
1. check out the parent of this commit
2. run `go test ./prometheus -run TestMetricVecWithLabelsKeepsLabelValuesStable -count=1`
3. it fails with `collected metric "test" ... was collected before with the same name and label values`
4. run the same command on this branch
5. it passes

Checks:
- `go test ./...`
- `cd exp && go test ./...`
- `go test -race ./prometheus -run 'TestMetricVecWithLabelsKeepsLabelValuesStable|TestMetricVecWithConstraints|TestCurryVec|TestCurryVecWithConstraints|TestDelete|TestDeleteLabelValues|TestDeletePartialMatch' -count=1`
