### PR TITLE
fix(api): fall back to GET on forbidden POSTs

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1545,8 +1545,8 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 	return resp, []byte(result.Data), result.Warnings, err
 }
 
-// DoGetFallback will attempt to do the request as-is, and on a 405 or 501 it
-// will fallback to a GET request.
+// DoGetFallback will attempt to do the request as-is, and on a 403, 405, or
+// 501 it will fallback to a GET request.
 func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
 	encodedArgs := args.Encode()
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
@@ -1564,7 +1564,7 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	req.Header["Idempotency-Key"] = nil
 
 	resp, body, warnings, err := h.Do(ctx, req)
-	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
+	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
 		u.RawQuery = encodedArgs
 		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -1922,6 +1922,13 @@ func TestDoGetFallback(t *testing.T) {
 		body, _ := json.Marshal(apiResp)
 
 		if req.Method == http.MethodPost {
+			if req.URL.Path == "/blockPost403" {
+				http.Error(w, string(body), http.StatusForbidden)
+				return
+			}
+		}
+
+		if req.Method == http.MethodPost {
 			if req.URL.Path == "/blockPost405" {
 				http.Error(w, string(body), http.StatusMethodNotAllowed)
 				return
@@ -1959,6 +1966,22 @@ func TestDoGetFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp.Method != http.MethodPost {
+		t.Fatalf("Mismatch method")
+	}
+	if resp.Values != v.Encode() {
+		t.Fatalf("Mismatch in values")
+	}
+
+	// Do a fallback to a get on 403.
+	u.Path = "/blockPost403"
+	_, b, _, err = api.DoGetFallback(context.TODO(), u, v)
+	if err != nil {
+		t.Fatalf("Error doing local request: %v", err)
+	}
+	if err := json.Unmarshal(b, resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Method != http.MethodGet {
 		t.Fatalf("Mismatch method")
 	}
 	if resp.Values != v.Encode() {


### PR DESCRIPTION
cc @bwplotka

Closes #1619.

Tiny fix, but real. Some setups put Prometheus behind an RBAC proxy, so `GET` is allowed but `POST` gets `403`. Right now `DoGetFallback` only retries on `405` and `501`, so read-only calls can just fail there, kinda rough.

This adds `403` to the existing POST to GET fallback path. No new API, just extends the compat behavior already in place.

Repro:
1. Put Prometheus behind a proxy that allows `GET` and denies `POST`.
2. Call a `DoGetFallback` backed read API like `Query`, `QueryRange`, `LabelNames`, `Series`, `QueryExemplars`, or `FormatQuery`.
3. Before this patch it returns `403`, no retry.
4. After this patch it retries with `GET` and works.

Tests:
- `go test ./api/prometheus/v1`
- `go test ./...`
