### PR TITLE
prometheus: DeletePartialMatch no longer deletes colliding non-matching metrics

### DIFF
--- a/prometheus/vec.go
+++ b/prometheus/vec.go
@@ -416,13 +416,26 @@ func (m *metricMap) deleteByLabels(labels Labels, curry []curriedLabelValue) int
 	var numDeleted int
 
 	for h, metrics := range m.metrics {
-		i := findMetricWithPartialLabels(m.desc, metrics, labels, curry)
-		if i >= len(metrics) {
-			// Didn't find matching labels in this metric slice.
-			continue
+		// A single hash bucket can hold more than one distinct metric on a
+		// hash collision, so remove only the elements that actually match
+		// instead of dropping the whole bucket.
+		for {
+			i := findMetricWithPartialLabels(m.desc, metrics, labels, curry)
+			if i >= len(metrics) {
+				// No (more) matching labels in this metric slice.
+				break
+			}
+			if len(metrics) > 1 {
+				old := metrics
+				metrics = append(metrics[:i], metrics[i+1:]...)
+				old[len(old)-1] = metricWithLabelValues{}
+				m.metrics[h] = metrics
+			} else {
+				delete(m.metrics, h)
+				metrics = nil
+			}
+			numDeleted++
 		}
-		delete(m.metrics, h)
-		numDeleted++
 	}
 
 	return numDeleted

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -260,6 +260,51 @@ func testDeletePartialMatch(t *testing.T, baseVec *GaugeVec) {
 	assertNoMetric(t)
 }
 
+// TestDeletePartialMatchWithCollisions forces two distinct series to share a
+// single hash bucket and verifies DeletePartialMatch removes only the matching
+// series, leaving the colliding non-matching series untouched, and that the
+// returned count reflects every match in a bucket. Regression test for #1810.
+func TestDeletePartialMatchWithCollisions(t *testing.T) {
+	vec := NewGaugeVec(
+		GaugeOpts{
+			Name: "test",
+			Help: "helpless",
+		},
+		[]string{"l1", "l2"},
+	)
+	vec.hashAdd = func(h uint64, s string) uint64 { return 1 }
+	vec.hashAddByte = func(h uint64, b byte) uint64 { return 1 }
+
+	// Two distinct series that collide into the same bucket.
+	vec.With(Labels{"l1": "delete-me", "l2": "x"}).Set(1)
+	vec.With(Labels{"l1": "keep-me", "l2": "y"}).Set(2)
+
+	// Delete only the matching series.
+	if got, want := vec.DeletePartialMatch(Labels{"l1": "delete-me"}), 1; got != want {
+		t.Errorf("DeletePartialMatch count: got %v, want %v", got, want)
+	}
+
+	// The colliding non-matching series must still be present with its value.
+	m := &dto.Metric{}
+	if err := vec.With(Labels{"l1": "keep-me", "l2": "y"}).Write(m); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := m.GetGauge().GetValue(), 2.0; got != want {
+		t.Errorf("colliding metric was deleted: got value %v, want %v", got, want)
+	}
+
+	// Two matching series in the same bucket should both be deleted and counted.
+	vec.Reset()
+	vec.With(Labels{"l1": "delete-me", "l2": "a"}).Set(1)
+	vec.With(Labels{"l1": "delete-me", "l2": "b"}).Set(2)
+	if got, want := vec.DeletePartialMatch(Labels{"l1": "delete-me"}), 2; got != want {
+		t.Errorf("DeletePartialMatch count for multiple matches in one bucket: got %v, want %v", got, want)
+	}
+	if n := len(vec.metrics); n != 0 {
+		t.Errorf("expected no metrics after deleting all matches, got %v", n)
+	}
+}
+
 func TestMetricVec(t *testing.T) {
 	vec := NewGaugeVec(
 		GaugeOpts{


### PR DESCRIPTION
When two series hash into the same bucket and you call DeletePartialMatch with labels that only match one of them, the other one gets deleted too. deleteByLabels drops the whole bucket on any partial match instead of removing just the matching entry, so a colliding series that should have stayed is silently wiped, and the returned count is off when a single bucket holds more than one match. This is likely part of what the reporter saw in #1810, so I framed it as the concrete data-loss bug rather than claiming it is the entire cause of that memory growth.

The fix mirrors what deleteByHashWithLabels already does: splice out only the matching element when the bucket has more than one metric, delete the bucket only when it holds a single element, and count every metric actually removed.

I added TestDeletePartialMatchWithCollisions, which forces a collision and checks the non-matching series survives with its value and that multiple matches in one bucket are all counted. It fails before the change and passes after; the full prometheus package still passes with -race.

@vesari would you mind taking a look? Thanks.
