### PR TITLE
fix: correct typos in comments and test error messages

### DIFF
--- a/prometheus/collectors/go_collector_latest_test.go
+++ b/prometheus/collectors/go_collector_latest_test.go
@@ -112,7 +112,7 @@ func TestWithGoCollectorDefault(t *testing.T) {
 	expected := append(withBaseMetrics(memstatMetrics), defaultRuntimeMetrics...)
 	sort.Strings(expected)
 	if diff := cmp.Diff(got, expected); diff != "" {
-		t.Errorf("[IMPORTANT, those are default metrics, can't change in 1.x] missmatch (-want +got):\n%s", diff)
+		t.Errorf("[IMPORTANT, those are default metrics, can't change in 1.x] mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -132,7 +132,7 @@ func TestWithGoCollectorMemStatsMetricsDisabled(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, withBaseMetrics(defaultRuntimeMetrics)); diff != "" {
-		t.Errorf("missmatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -190,7 +190,7 @@ func TestGoCollectorAllowList(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
-				t.Errorf("missmatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -252,7 +252,7 @@ func TestGoCollectorDenyList(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
-				t.Errorf("missmatch (-want +got):\n%s", diff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/prometheus/collectors/version/version_test.go
+++ b/prometheus/collectors/version/version_test.go
@@ -56,13 +56,13 @@ func TestGoVersionCollector(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(lk, defaultLabels); diff != "" {
-			t.Errorf("missmatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 
 	}
 
 	if diff := cmp.Diff(got, []string{"foo_build_info"}); diff != "" {
-		t.Errorf("missmatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -103,12 +103,12 @@ func TestGoVersionCollectorWithLabels(t *testing.T) {
 		labels := append(defaultLabels, "z-mylabel")
 
 		if diff := cmp.Diff(lk, labels); diff != "" {
-			t.Errorf("missmatch (-want +got):\n%s", diff)
+			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 
 	}
 
 	if diff := cmp.Diff(got, []string{"foo_build_info"}); diff != "" {
-		t.Errorf("missmatch (-want +got):\n%s", diff)
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -970,7 +970,7 @@ func (h *histogram) maybeReset(
 	// We are using the possibly mocked h.now() rather than
 	// time.Since(h.lastResetTime) to enable testing.
 	if h.nativeHistogramMinResetDuration == 0 || // No reset configured.
-		h.resetScheduled || // Do not interefere if a reset is already scheduled.
+		h.resetScheduled || // Do not interfere if a reset is already scheduled.
 		h.now().Sub(h.lastResetTime) < h.nativeHistogramMinResetDuration {
 		return false
 	}

--- a/prometheus/internal/difflib.go
+++ b/prometheus/internal/difflib.go
@@ -78,7 +78,7 @@ type OpCode struct {
 // notion, pairing up elements that appear uniquely in each sequence.
 // That, and the method here, appear to yield more intuitive difference
 // reports than does diff.  This method appears to be the least vulnerable
-// to synching up on blocks of "junk lines", though (like blank lines in
+// to syncing up on blocks of "junk lines", though (like blank lines in
 // ordinary text files, or maybe "<P>" lines in HTML files).  That may be
 // because this is the only method of the 3 that has a *concept* of
 // "junk" <wink>.


### PR DESCRIPTION
Fix several typos found with codespell:

- `prometheus/histogram.go`: `interefere` -> `interfere` (code comment)
- `prometheus/internal/difflib.go`: `synching` -> `syncing` (code comment)
- `prometheus/collectors/go_collector_latest_test.go`: `missmatch` -> `mismatch` (4 occurrences in test error messages)
- `prometheus/collectors/version/version_test.go`: `missmatch` -> `mismatch` (4 occurrences in test error messages)

Signed-off-by: maxtaran2010 <ocotifuzo727@gmail.com>