### PR TITLE
test: fix two flaky tests (darwin start_time regex, memstats HeapReleased drift)

### DIFF
--- a/prometheus/go_collector_latest_test.go
+++ b/prometheus/go_collector_latest_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"runtime/metrics"
 	"strings"
 	"sync"
@@ -270,12 +271,16 @@ func TestMemStatsEquivalence(t *testing.T) {
 		samplesMap[descs[i].Name] = &samples[i]
 	}
 
-	// Force a GC cycle to try to reach a clean slate.
-	runtime.GC()
+	// Reach a stable slate and hold it for a single measurement window.
+	// FreeOSMemory runs a GC and returns freed memory to the OS, leaving the
+	// background scavenger nothing to release; disabling GC for the window
+	// keeps msReal and msFake observing the same runtime state. Without this,
+	// HeapReleased could drift between the two reads and fail the comparison.
+	debug.FreeOSMemory()
+	defer debug.SetGCPercent(debug.SetGCPercent(-1))
 
-	// Populate msReal.
+	// Populate msReal, then msFake back-to-back within the frozen window.
 	runtime.ReadMemStats(&msReal)
-	// Populate msFake and hope that no GC happened in between (:
 	metrics.Read(samples)
 
 	memStatsFromRM(&msFake, samplesMap)

--- a/prometheus/process_collector_darwin_test.go
+++ b/prometheus/process_collector_darwin_test.go
@@ -55,12 +55,12 @@ func TestDarwinProcessCollector(t *testing.T) {
 		regexp.MustCompile("\nprocess_max_fds [1-9]"),
 		regexp.MustCompile("\nprocess_open_fds [1-9]"),
 		regexp.MustCompile("\nprocess_virtual_memory_max_bytes (-1|[1-9])"),
-		regexp.MustCompile("\nprocess_start_time_seconds [0-9.]{10,}"),
+		regexp.MustCompile("\nprocess_start_time_seconds [0-9]"),
 		regexp.MustCompile("\nfoobar_process_cpu_seconds_total [0-9]"),
 		regexp.MustCompile("\nfoobar_process_max_fds [1-9]"),
 		regexp.MustCompile("\nfoobar_process_open_fds [1-9]"),
 		regexp.MustCompile("\nfoobar_process_virtual_memory_max_bytes (-1|[1-9])"),
-		regexp.MustCompile("\nfoobar_process_start_time_seconds [0-9.]{10,}"),
+		regexp.MustCompile("\nfoobar_process_start_time_seconds [0-9]"),
 	} {
 		if !re.Match(buf.Bytes()) {
 			t.Errorf("want body to match %s\n%s", re, buf.String())


### PR DESCRIPTION
Two pre-existing flaky tests, each fixed independently.

Darwin `process_start_time_seconds` (`process_collector_darwin_test.go`): the check used `[0-9.]{10,}`, but expfmt renders large gauges in scientific notation (e.g. `1.783414e+09`), whose leading digit run is only eight characters, so it failed intermittently on macOS. Changed to `[0-9]`, matching the sibling checks in the same test; that is a presence check that does not depend on float formatting.

`TestMemStatsEquivalence` (`go_collector_latest_test.go`): the test read `runtime.ReadMemStats` and `runtime/metrics` separately and compared them within 5%, and the code itself noted it hoped no GC happened in between. `HeapReleased` is driven by the background scavenger and drifted between the two reads, failing on Linux arm64. It now forces a full scavenge with `debug.FreeOSMemory` and disables GC for the measurement window, so both reads observe the same runtime state.

Test plan: `go test -race ./prometheus/...` passes; `TestMemStatsEquivalence` run 200 times with `-race` is stable.
