### PR TITLE
Replace deprecated model.NameValidationScheme with explicit UTF8Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* [CHANGE] prometheus: Name validation now always uses the UTF-8 scheme instead of the deprecated `model.NameValidationScheme` global. Default behavior is unchanged; code that set `NameValidationScheme = LegacyValidation` no longer gets legacy enforcement at metric, label, and push-grouping construction. #2051
 * [FEATURE] HTTP handlers created by `promhttp` package now support metrics filtering by providing one or more `name[]` query parameters. The default behavior when none are provided remains the same, returning all metrics. #1925
 * [BUGFIX] promhttp: `InstrumentHandlerDuration` and `InstrumentHandlerCounter` no longer panic when given an observer/counter that does not implement `ExemplarObserver`/`ExemplarAdder` (e.g. a `SummaryVec`). The exemplar is dropped and the value is recorded via the plain `Observe`/`Add` path, matching the safe-cast already used by `Timer.ObserveDurationWithExemplar`. #2005
 

--- a/prometheus/desc.go
+++ b/prometheus/desc.go
@@ -111,8 +111,7 @@ func (v2) NewDesc(fqName, help string, variableLabels ConstrainableLabels, const
 	for _, opt := range opts {
 		opt(d)
 	}
-	//nolint:staticcheck // TODO: Don't use deprecated model.NameValidationScheme.
-	if !model.NameValidationScheme.IsValidMetricName(fqName) {
+	if !model.UTF8Validation.IsValidMetricName(fqName) {
 		d.err = fmt.Errorf("%q is not a valid metric name", fqName)
 		return d
 	}

--- a/prometheus/labels.go
+++ b/prometheus/labels.go
@@ -184,6 +184,5 @@ func validateLabelValues(vals []string, expectedNumberOfValues int) error {
 }
 
 func checkLabelName(l string) bool {
-	//nolint:staticcheck // TODO: Don't use deprecated model.NameValidationScheme.
-	return model.NameValidationScheme.IsValidLabelName(l) && !strings.HasPrefix(l, reservedLabelPrefix)
+	return model.UTF8Validation.IsValidLabelName(l) && !strings.HasPrefix(l, reservedLabelPrefix)
 }

--- a/prometheus/push/push.go
+++ b/prometheus/push/push.go
@@ -182,8 +182,7 @@ func (p *Pusher) Error() error {
 // For convenience, this method returns a pointer to the Pusher itself.
 func (p *Pusher) Grouping(name, value string) *Pusher {
 	if p.error == nil {
-		//nolint:staticcheck // TODO: Don't use deprecated model.NameValidationScheme.
-		if !model.NameValidationScheme.IsValidLabelName(name) {
+		if !model.UTF8Validation.IsValidLabelName(name) {
 			p.error = fmt.Errorf("grouping label has invalid name: %s", name)
 			return p
 		}


### PR DESCRIPTION
`model.NameValidationScheme` is deprecated in prometheus/common. staticcheck flags each use, and under some golangci-lint cache states the suppressing `//nolint` directives are themselves reported as unused, which makes lint flaky.

This replaces the three uses (`desc.go`, `labels.go`, `push/push.go`) with the explicit `model.UTF8Validation` scheme and removes the `//nolint` directives.

`NameValidationScheme` already defaults to `UTF8Validation`, so default behavior is unchanged. Users who set it to `LegacyValidation` no longer get that enforcement at metric/label/grouping construction; UTF-8 validation is more permissive, so no name that validates today starts failing.

Test plan: `go test -race ./prometheus/... ./prometheus/push/...` passes and `golangci-lint run` is clean.
