### PR TITLE
back Counter with sharded per-P counters from argc.dev/goexp/sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prometheus/client_golang
 go 1.25.0
 
 require (
+	argc.dev/goexp v0.0.0-20260710001111-8c1f88208172
 	github.com/beorn7/perks v1.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+argc.dev/goexp v0.0.0-20260710001111-8c1f88208172 h1:PET7L5h+6EjqOnYjG2Z5sxuMHx2NFmn4OjA/ls/ywEI=
+argc.dev/goexp v0.0.0-20260710001111-8c1f88208172/go.mod h1:5KW5TTv68+fSFL3H+qywujHM1tkwM9JWcc2+ZtT2Vrc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -15,10 +15,10 @@ package prometheus
 
 import (
 	"errors"
-	"math"
 	"sync/atomic"
 	"time"
 
+	xsync "argc.dev/goexp/sync"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -95,19 +95,29 @@ func NewCounter(opts CounterOpts) Counter {
 	if opts.now == nil {
 		opts.now = time.Now
 	}
-	result := &counter{desc: desc, labelPairs: desc.constLabelPairs, now: opts.now}
+	result := &counter{
+		desc:       desc,
+		labelPairs: desc.constLabelPairs,
+		valBits:    xsync.NewCounter[float64](),
+		valInt:     xsync.NewCounter[int64](),
+		now:        opts.now,
+	}
 	result.init(result) // Init self-collection.
 	result.createdTs = timestamppb.New(opts.now())
 	return result
 }
 
 type counter struct {
-	// valBits contains the bits of the represented float64 value, while
-	// valInt stores values that are exact integers. Both have to go first
-	// in the struct to guarantee alignment for atomic operations.
-	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG
-	valBits uint64
-	valInt  uint64
+	// valInt accumulates the exact integer part of the counter (Inc calls
+	// and Add calls with integral values), while valBits accumulates values
+	// that cannot be represented as an int64. Both are per-P sharded
+	// counters (see argc.dev/goexp/sync): increments happen on hot paths and
+	// are made cheap and contention-free by striping them across processors,
+	// whereas reads (only at collection time) sum the shards. The split
+	// between integer and floating-point tracking is kept for precision, and
+	// the two are added up in the get method.
+	valBits *xsync.Counter[float64]
+	valInt  *xsync.Counter[int64]
 
 	selfCollector
 	desc *Desc
@@ -129,19 +139,13 @@ func (c *counter) Add(v float64) {
 		panic(errors.New("counter cannot decrease in value"))
 	}
 
-	ival := uint64(v)
+	ival := int64(v)
 	if float64(ival) == v {
-		atomic.AddUint64(&c.valInt, ival)
+		c.valInt.Add(ival)
 		return
 	}
 
-	for {
-		oldBits := atomic.LoadUint64(&c.valBits)
-		newBits := math.Float64bits(math.Float64frombits(oldBits) + v)
-		if atomic.CompareAndSwapUint64(&c.valBits, oldBits, newBits) {
-			return
-		}
-	}
+	c.valBits.Add(v)
 }
 
 func (c *counter) AddWithExemplar(v float64, e Labels) {
@@ -150,13 +154,11 @@ func (c *counter) AddWithExemplar(v float64, e Labels) {
 }
 
 func (c *counter) Inc() {
-	atomic.AddUint64(&c.valInt, 1)
+	c.valInt.Add(1)
 }
 
 func (c *counter) get() float64 {
-	fval := math.Float64frombits(atomic.LoadUint64(&c.valBits))
-	ival := atomic.LoadUint64(&c.valInt)
-	return fval + float64(ival)
+	return c.valBits.Value() + float64(c.valInt.Value())
 }
 
 func (c *counter) Write(out *dto.Metric) error {
@@ -216,7 +218,13 @@ func (v2) NewCounterVec(opts CounterVecOpts) *CounterVec {
 			if len(lvs) != len(desc.variableLabels.names) {
 				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, lvs))
 			}
-			result := &counter{desc: desc, labelPairs: MakeLabelPairs(desc, lvs), now: opts.now}
+			result := &counter{
+				desc:       desc,
+				labelPairs: MakeLabelPairs(desc, lvs),
+				valBits:    xsync.NewCounter[float64](),
+				valInt:     xsync.NewCounter[int64](),
+				now:        opts.now,
+			}
 			result.init(result) // Init self-collection.
 			result.createdTs = timestamppb.New(opts.now())
 			return result

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -34,25 +34,25 @@ func TestCounterAdd(t *testing.T) {
 		now:         func() time.Time { return now },
 	}).(*counter)
 	counter.Inc()
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, counter.valBits.Value(); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(1), counter.valInt; expected != got {
+	if expected, got := int64(1), counter.valInt.Value(); expected != got {
 		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 	counter.Add(42)
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, counter.valBits.Value(); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(43), counter.valInt; expected != got {
+	if expected, got := int64(43), counter.valInt.Value(); expected != got {
 		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
 	counter.Add(24.42)
-	if expected, got := 24.42, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 24.42, counter.valBits.Value(); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(43), counter.valInt; expected != got {
+	if expected, got := int64(43), counter.valInt.Value(); expected != got {
 		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
@@ -153,26 +153,26 @@ func TestCounterAddInf(t *testing.T) {
 	}).(*counter)
 
 	counter.Inc()
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, counter.valBits.Value(); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(1), counter.valInt; expected != got {
+	if expected, got := int64(1), counter.valInt.Value(); expected != got {
 		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
 	counter.Add(math.Inf(1))
-	if expected, got := math.Inf(1), math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := math.Inf(1), counter.valBits.Value(); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(1), counter.valInt; expected != got {
+	if expected, got := int64(1), counter.valInt.Value(); expected != got {
 		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 
 	counter.Inc()
-	if expected, got := math.Inf(1), math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := math.Inf(1), counter.valBits.Value(); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(2), counter.valInt; expected != got {
+	if expected, got := int64(2), counter.valInt.Value(); expected != got {
 		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
@@ -203,10 +203,10 @@ func TestCounterAddLarge(t *testing.T) {
 	// large overflows the underlying type and should therefore be stored in valBits.
 	large := math.Nextafter(float64(math.MaxUint64), 1e20)
 	counter.Add(large)
-	if expected, got := large, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := large, counter.valBits.Value(); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(0), counter.valInt; expected != got {
+	if expected, got := int64(0), counter.valInt.Value(); expected != got {
 		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 
@@ -236,10 +236,10 @@ func TestCounterAddSmall(t *testing.T) {
 
 	small := 0.000000000001
 	counter.Add(small)
-	if expected, got := small, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := small, counter.valBits.Value(); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := uint64(0), counter.valInt; expected != got {
+	if expected, got := int64(0), counter.valInt.Value(); expected != got {
 		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 


### PR DESCRIPTION
Summary

  This replaces the atomic uint64 fields backing the plain prometheus.Counter with sharded per-P counters from argc.dev/goexp/sync. Under concurrent writers, a single atomic counter
  becomes a cache-coherency hotspot: every Inc()/Add() contends on the same cache line. The sharded counter stripes writes across per-P shards so increments stay contention-free, summing
  the shards only at read (collection) time.

  Counter is the ideal — and essentially only — good fit for this in the repository:

  - Inc/Add are on the hottest write paths in instrumented code, while reads happen only at scrape time (seconds apart). The counter is monotonic and never needs a consistent snapshot or
  a reset — a textbook match for a write-optimized, approximate-read sharded counter.
  - Histograms and summaries are intentionally not changed. They depend on exact atomic hot/cold index swaps and consistent-snapshot draining of cold buckets; the sharded counter's
  approximate Value() and lack of atomic-swap semantics would break that logic.
  - Gauges are intentionally not changed. They decrease as well as increase and need Set plus exact reads, which a sharded counter does not provide.

  Changes

  - counter.valBits/counter.valInt change from uint64 atomics to *xsync.Counter[float64] / *xsync.Counter[int64], initialized in both the NewCounter and NewCounterVec factories.
  - Add, Inc, and get delegate to the sharded counter's Add() / Value(). The existing integer/float split is preserved, so the exact-integer fast path and float precision are retained.
  (int64 replaces uint64 because the package is generic over int64 | float64; this only differs in the astronomical 9.2e18–1.8e19 range, far beyond any realistic counter.)
  - Removed the now-obsolete struct-alignment comment and the unused math import.
  - Updated the white-box assertions in counter_test.go to read via .Value().
  - go mod tidy adds a single require line; module-graph pruning keeps goexp's unrelated dependencies out of go.mod since only the sync subpackage is imported.

  Behavioral note for reviewers

  Value() is approximate under concurrent writers — it sums shards without a global lock, so a scrape taken mid-write may read shards from slightly different instants. For a monotonic
  counter scraped every ~15s this is harmless and is the intended trade for contention-free writes, but it is a genuine semantic change from the old strictly-atomic read and is called
  out here deliberately.

  Validation

  - go build ./... — clean
  - go vet ./prometheus/ — clean
  - go test -race ./prometheus/ — PASS (127s)

Validation                                                                                                                                                                       [0/843]

  - go build ./... — clean
  - go vet ./prometheus/ — clean
  - go test -race ./prometheus/ — PASS (127s)

  Benchmarks

  go test -bench=... -benchmem -cpu=8 -count=3 (Apple Silicon, darwin):

   | Benchmark | Before (atomic) | After (sharded) | Change |
  |---|---|---|---|
  | `BenchmarkParallelCounter` (contended `Inc`) | ~48.1 ns/op | ~0.81 ns/op | ~59× faster |
  | `BenchmarkCounterNoLabels` (uncontended) | ~6.95 ns/op | ~6.00 ns/op | ~14% faster |

  Zero allocations before and after in both benchmarks.

  <details>
  <summary>Raw benchmark output</summary>

  === OLD (atomic) ===
  BenchmarkCounterNoLabels-8    170848102                6.965 ns/op           0 B/op          0 allocs/op
  BenchmarkCounterNoLabels-8    173221360                6.946 ns/op           0 B/op          0 allocs/op
  BenchmarkCounterNoLabels-8    172775521                6.945 ns/op           0 B/op          0 allocs/op
  BenchmarkParallelCounter-8    26206380                48.18 ns/op            0 B/op          0 allocs/op
  BenchmarkParallelCounter-8    26129320                47.30 ns/op            0 B/op          0 allocs/op
  BenchmarkParallelCounter-8    29907597                48.78 ns/op            0 B/op          0 allocs/op

  === NEW (sharded) ===
  BenchmarkCounterNoLabels-8    196301019                6.003 ns/op           0 B/op          0 allocs/op
  BenchmarkCounterNoLabels-8    200686598                6.007 ns/op           0 B/op          0 allocs/op
  BenchmarkCounterNoLabels-8    200671132                5.996 ns/op           0 B/op          0 allocs/op
  BenchmarkParallelCounter-8    1000000000               0.8075 ns/op          0 B/op          0 allocs/op
  BenchmarkParallelCounter-8    1000000000               0.8266 ns/op          0 B/op          0 allocs/op
  BenchmarkParallelCounter-8    1000000000               0.8082 ns/op          0 B/op          0 allocs/op
  </details>