### PR TITLE
api: return HTTP status on non-JSON API error bodies

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1521,6 +1521,16 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 
 	if http.StatusNoContent != code {
 		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
+			// Non-2xx API error codes (400/422) with a non-JSON body (e.g. HTML from a
+			// proxy) should surface the HTTP status instead of a confusing unmarshal error.
+			if code/100 != 2 {
+				errorType, errorMsg := errorTypeAndMsgFor(resp)
+				return resp, body, nil, &Error{
+					Type:   errorType,
+					Msg:    errorMsg,
+					Detail: string(body),
+				}
+			}
 			return resp, body, nil, &Error{
 				Type: ErrBadResponse,
 				Msg:  jsonErr.Error(),

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -1497,8 +1497,28 @@ func TestAPIClientDo(t *testing.T) {
 			code:     http.StatusUnprocessableEntity,
 			response: "bad json",
 			expectedErr: &Error{
-				Type: ErrBadResponse,
-				Msg:  "readObjectStart: expect { or n, but found b, error found in #1 byte of ...|bad json|..., bigger context ...|bad json|...",
+				Type:   ErrClient,
+				Msg:    "client error: 422",
+				Detail: "bad json",
+			},
+		},
+		{
+			// Proxy-style HTML body on a Prometheus API error status must not yield a JSON unmarshal error.
+			code:     http.StatusBadRequest,
+			response: "<html>400 Bad Request</html>",
+			expectedErr: &Error{
+				Type:   ErrClient,
+				Msg:    "client error: 400",
+				Detail: "<html>400 Bad Request</html>",
+			},
+		},
+		{
+			code:     http.StatusForbidden,
+			response: "<html>403 Forbidden</html>",
+			expectedErr: &Error{
+				Type:   ErrClient,
+				Msg:    "client error: 403",
+				Detail: "<html>403 Forbidden</html>",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
* When HTTP 400/422 responses carry a non-JSON body (common via proxies), `apiClientImpl.Do` now returns a status-based error with the body as `Detail` instead of a confusing JSON unmarshal failure.
* Existing 404/5xx paths already skipped unmarshalling; this closes the remaining gap for Prometheus API error statuses that previously tried to decode a JSON API envelope first.

Addresses prometheus/client_golang#763 (status-before-unmarshal for proxy/non-JSON error bodies). Body close/exhaust is already handled by the lower HTTP client and is out of scope here.

## Test plan
- [x] `go test ./api/prometheus/v1/ -run TestAPIClientDo`
- [x] `go test ./api/prometheus/v1/ -run TestAPIs`