### PR TITLE
promhttp: fix panic on requests with nil URL

### DIFF
--- a/prometheus/promhttp/http.go
+++ b/prometheus/promhttp/http.go
@@ -372,12 +372,15 @@ func HandlerForTransactional(reg prometheus.TransactionalGatherer, opts HandlerO
 			return false
 		}
 
-		// Build metric name filter set from query params (if any)
+		// Build metric name filter set from query params (if any). The URL
+		// can be nil on hand-constructed requests.
 		var metricFilter map[string]struct{}
-		if metricNames := req.URL.Query()["name[]"]; len(metricNames) > 0 {
-			metricFilter = make(map[string]struct{}, len(metricNames))
-			for _, name := range metricNames {
-				metricFilter[name] = struct{}{}
+		if req.URL != nil {
+			if metricNames := req.URL.Query()["name[]"]; len(metricNames) > 0 {
+				metricFilter = make(map[string]struct{}, len(metricNames))
+				for _, name := range metricNames {
+					metricFilter[name] = struct{}{}
+				}
 			}
 		}
 

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -879,6 +879,28 @@ func TestHandlerWithMetricFilter(t *testing.T) {
 	}
 }
 
+func TestHandlerWithNilRequestURL(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_counter",
+		Help: "A test counter.",
+	})
+	reg.MustRegister(counter)
+	counter.Inc()
+
+	writer := httptest.NewRecorder()
+	handler := HandlerFor(reg, HandlerOpts{ErrorHandling: ContinueOnError})
+	handler.ServeHTTP(writer, &http.Request{})
+
+	if got, want := writer.Code, http.StatusOK; got != want {
+		t.Errorf("got HTTP status code %d, want %d", got, want)
+	}
+	if body := writer.Body.String(); !strings.Contains(body, "test_counter") {
+		t.Errorf("expected body to contain test_counter, got: %s", body)
+	}
+}
+
 // syncGatherCounter is a thread-safe TransactionalGatherer wrapper that counts
 // Gather and done invocations. Safe for concurrent use from multiple goroutines,
 // unlike mockTransactionGatherer whose counters are not race-safe.


### PR DESCRIPTION
Fixes #2064. The name[] filtering added in #1925 reads req.URL.Query() unconditionally, so serving a hand-constructed `&http.Request{}` (common in handler tests, worked fine before 1.24) now panics with a nil pointer dereference. Guard the URL before reading query params and add a regression test.