### PR TITLE
go.mod: remove obsolete exclude rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,5 +30,3 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )
-
-exclude github.com/prometheus/client_golang v1.12.1


### PR DESCRIPTION
relates to;

- https://github.com/prometheus/client_golang/pull/1027
- https://github.com/prometheus/client_golang/issues/1012#issuecomment-1090482644

The exclude was originally added in 02fec464ad5c015332dcbd4db0cf53b96967e3f2 to prevent traversing client_golang v1.12.1. No current dependency requires that version, making the exclude obsolete.

To verify;

    go list -m all

which produced no changes.

Also verified that:

    go mod tidy
    go test ./...

produce no changes and all tests pass.