### PR TITLE
exp/api/remote: dont panic on malformed remote-write label refs

### DIFF
--- a/exp/api/remote/genproto/v2/symbols.go
+++ b/exp/api/remote/genproto/v2/symbols.go
@@ -30,6 +30,8 @@
 
 package writev2
 
+import "fmt"
+
 // SymbolsTable implements table for easy symbol use.
 type SymbolsTable struct {
 	strings    []string
@@ -88,10 +90,21 @@ func (t *SymbolsTable) Reset() {
 }
 
 // DesymbolizeLabels decodes label references, with given symbols to labels.
-func DesymbolizeLabels(labelRefs []uint32, symbols, buf []string) []string {
+//
+// The references are decoded from a remote-write request, so they are not
+// trusted: an odd number of references, or a reference outside the symbols
+// table, is reported as an error rather than panicking.
+func DesymbolizeLabels(labelRefs []uint32, symbols, buf []string) ([]string, error) {
+	if len(labelRefs)%2 != 0 {
+		return nil, fmt.Errorf("invalid labelRefs length %v, must be even", len(labelRefs))
+	}
 	result := buf[:0]
 	for i := 0; i < len(labelRefs); i += 2 {
-		result = append(result, symbols[labelRefs[i]], symbols[labelRefs[i+1]])
+		nameRef, valueRef := labelRefs[i], labelRefs[i+1]
+		if int(nameRef) >= len(symbols) || int(valueRef) >= len(symbols) {
+			return nil, fmt.Errorf("labelRefs %v (name), %v (value) outside of symbols table (size %v)", nameRef, valueRef, len(symbols))
+		}
+		result = append(result, symbols[nameRef], symbols[valueRef])
 	}
-	return result
+	return result, nil
 }

--- a/exp/api/remote/genproto/v2/symbols_test.go
+++ b/exp/api/remote/genproto/v2/symbols_test.go
@@ -70,11 +70,41 @@ func TestSymbolsTable(t *testing.T) {
 	ls := []string{"__name__", "qwer", "zxcv", "1234"}
 	encoded := s.SymbolizeLabels(ls, nil)
 	requireEqual(t, []uint32{1, 3, 4, 5}, encoded)
-	decoded := DesymbolizeLabels(encoded, s.Symbols(), nil)
+	decoded, err := DesymbolizeLabels(encoded, s.Symbols(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	requireEqual(t, ls, decoded)
 
 	// Different buf.
 	ls = []string{"__name__", "qwer", "zxcv2222", "1234"}
 	encoded = s.SymbolizeLabels(ls, []uint32{1, 3, 4, 5})
 	requireEqual(t, []uint32{1, 3, 6, 5}, encoded)
+}
+
+func TestDesymbolizeLabelsInvalidInput(t *testing.T) {
+	// Label references come from a remote-write request, so malformed input has
+	// to be reported as an error rather than panicking the receiver.
+	for _, tcase := range []struct {
+		name      string
+		labelRefs []uint32
+		symbols   []string
+	}{
+		{name: "odd number of refs", labelRefs: []uint32{1}, symbols: []string{"", "a"}},
+		{name: "odd number of refs, longer", labelRefs: []uint32{1, 1, 1}, symbols: []string{"", "a"}},
+		{name: "name ref out of range", labelRefs: []uint32{9, 1}, symbols: []string{"", "a"}},
+		{name: "value ref out of range", labelRefs: []uint32{1, 9}, symbols: []string{"", "a"}},
+		{name: "refs against empty symbols", labelRefs: []uint32{0, 0}, symbols: nil},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("unexpected panic: %v", r)
+				}
+			}()
+			if _, err := DesymbolizeLabels(tcase.labelRefs, tcase.symbols, nil); err == nil {
+				t.Fatal("expected an error, got none")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`DesymbolizeLabels` walks `labelRefs` two entries at a time and indexes into `symbols` directly, with no validation of either:

```go
func DesymbolizeLabels(labelRefs []uint32, symbols, buf []string) []string {
	result := buf[:0]
	for i := 0; i < len(labelRefs); i += 2 {
		result = append(result, symbols[labelRefs[i]], symbols[labelRefs[i+1]])
	}
	return result
}
```

Both inputs come off the wire. `NewWriteHandler` accepts remote-write v2 requests and hands them to a `writeStorage` implementation, and this is the helper that implementation uses to turn `TimeSeries.LabelsRefs` into labels. A sender that emits an odd number of references, or a reference past the end of the symbols table, panics the decoding goroutine:

```
DesymbolizeLabels([]uint32{1}, []string{"", "a"}, nil)
// panic: runtime error: index out of range [1] with length 1

DesymbolizeLabels([]uint32{5, 6}, []string{"", "a"}, nil)
// panic: runtime error: index out of range [5] with length 2
```

Neither condition is checked anywhere before this point, so a malformed or malicious request reaches it unfiltered.

## Fix

Return an error for both cases. This matches the reference implementation of the same spec in `prometheus/prometheus` ([`prompb/io/prometheus/write/v2/symbols.go`](https://github.com/prometheus/prometheus/blob/main/prompb/io/prometheus/write/v2/symbols.go)), which already guards exactly these two conditions:

```go
func desymbolizeLabels(b *labels.ScratchBuilder, labelRefs []uint32, symbols []string) (labels.Labels, error) {
	if len(labelRefs)%2 != 0 {
		return labels.EmptyLabels(), fmt.Errorf("invalid labelRefs length %d", len(labelRefs))
	}
	...
	if int(nameRef) >= len(symbols) || int(valueRef) >= len(symbols) {
		return labels.EmptyLabels(), fmt.Errorf("labelRefs %d (name) = %d (value) outside of symbols table (size %d)", ...)
	}
```

Prometheus's own `appendV2` treats this as a fallible operation and turns a failure into a bad-request error rather than a crash, which seems like the behaviour a receiver built on this package would want too.

This does change the signature to return an error. That is a breaking change, which I took to be acceptable here because the module documents itself as experimental ("This package is experimental and may contain breaking changes or be removed in the future"), and because silently dropping the malformed pairs would discard metric data without telling the caller. Happy to take a non-breaking variant instead if you would rather not change the signature in this module yet.

I left `SymbolizeLabels` alone. It has the same `i += 2` shape, but its input is the caller's own label slice rather than wire data, so an odd length there is a programming error in the caller and out of scope for this change. Glad to include it if you would prefer them consistent.

## Testing

Added `TestDesymbolizeLabelsInvalidInput`, covering an odd reference count (two lengths), an out-of-range name reference, an out-of-range value reference, and references against an empty symbols table. It fails on current `main` with the panics above and passes with the fix.

The existing `TestSymbolsTable` round trip is updated for the new signature and still passes. Full `exp` module suite is green (`go test ./...`), and `gofmt` and `go vet` are clean.
