### PR TITLE
testutil: add GatherAndFormat helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* [FEATURE] testutil: Add GatherAndFormat to encode a subset of metrics from a Gatherer. #2079
+* [FEATURE] testutil: Add GatherAndFormat to encode a subset of metrics from a Gatherer. #2091
 
 ## 1.24.1 / 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [FEATURE] testutil: Add GatherAndFormat to encode a subset of metrics from a Gatherer. #2079
+
 ## 1.24.1 / 2026-07-23
 
 * [BUGFIX] promhttp: Fix panic on requests with nil URL. #2065

--- a/prometheus/testutil/testutil.go
+++ b/prometheus/testutil/testutil.go
@@ -30,7 +30,9 @@
 // most appropriate use is not so much testing instrumentation of your code, but
 // testing custom prometheus.Collector implementations and in particular whole
 // exporters, i.e. programs that retrieve telemetry data from a 3rd party source
-// and convert it into Prometheus metrics.
+// and convert it into Prometheus metrics. CollectAndFormat and GatherAndFormat
+// return the same exposition bytes when you need to inspect a subset without a
+// full expected fixture.
 //
 // In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
 // metrics that have issues with their name, type, or metadata without being
@@ -240,8 +242,17 @@ func CollectAndFormat(c prometheus.Collector, format expfmt.FormatType, metricNa
 	if err := reg.Register(c); err != nil {
 		return nil, fmt.Errorf("registering collector failed: %w", err)
 	}
+	return GatherAndFormat(reg, format, metricNames...)
+}
 
-	gotFiltered, err := reg.Gather()
+// GatherAndFormat gathers metrics from the provided Gatherer, optionally
+// filtered to metricNames, and returns them encoded in the given format.
+//
+// Unlike CollectAndFormat, this works with any Gatherer, so tests can inspect
+// metrics that were registered elsewhere (for example prometheus.DefaultGatherer)
+// without holding a reference to the Collector.
+func GatherAndFormat(g prometheus.Gatherer, format expfmt.FormatType, metricNames ...string) ([]byte, error) {
+	gotFiltered, err := g.Gather()
 	if err != nil {
 		return nil, fmt.Errorf("gathering metrics failed: %w", err)
 	}

--- a/prometheus/testutil/testutil_test.go
+++ b/prometheus/testutil/testutil_test.go
@@ -462,3 +462,42 @@ foo_bar{fizz="bang"} 1
 		t.Errorf("unexpected metric output, got %q, expected %q", gotS, expected)
 	}
 }
+
+func TestGatherAndFormat(t *testing.T) {
+	const expected = `# HELP foo_bar A value that represents the number of bars in foo.
+# TYPE foo_bar counter
+foo_bar{fizz="bang"} 1
+`
+	reg := prometheus.NewPedanticRegistry()
+	want := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "foo_bar",
+			Help: "A value that represents the number of bars in foo.",
+		},
+		[]string{"fizz"},
+	)
+	other := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "other_total",
+		Help: "A metric that should be filtered out.",
+	})
+	if err := reg.Register(want); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register(other); err != nil {
+		t.Fatal(err)
+	}
+	want.WithLabelValues("bang").Inc()
+	other.Inc()
+
+	got, err := GatherAndFormat(reg, expfmt.TypeTextPlain, "foo_bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	gotS := string(got)
+	if gotS != expected {
+		t.Errorf("unexpected metric output, got %q, expected %q", gotS, expected)
+	}
+	if strings.Contains(gotS, "other_total") {
+		t.Errorf("filtered gather included unexpected metric: %q", gotS)
+	}
+}


### PR DESCRIPTION
## What

Add `testutil.GatherAndFormat`, the Gatherer counterpart of `CollectAndFormat`.

When metrics live on a registry you do not own (or you only have a `Gatherer`), there was no helper to encode a named subset. `GatherAndCompare` needs a full fixture; `GatherAndCount` drops the values.

`CollectAndFormat` now calls `GatherAndFormat`.

```go
bb, err := testutil.GatherAndFormat(prometheus.DefaultGatherer, expfmt.TypeOpenMetrics, "errors_caught_panics_total")
```

## Why

Requested in https://github.com/prometheus/client_golang/issues/2079

## How to verify

```bash
go test ./prometheus/testutil/ -count=1
```

cc @bwplotka

This PR was written in part with the assistance of generative AI.