### PR TITLE
Benchmark json-iter, stdlib json and json/v2

### DIFF
--- a/api/prometheus/v1/api_bench_test.go
+++ b/api/prometheus/v1/api_bench_test.go
@@ -120,76 +120,126 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 					}
 
 					b.Run("marshal", func(b *testing.B) {
-						b.Run("encoding/json/floats", func(b *testing.B) {
-							b.ReportAllocs()
-							for i := 0; i < b.N; i++ {
-								if _, err := json.Marshal(floats); err != nil {
-									b.Fatal(err)
+						b.Run("floats", func(b *testing.B) {
+							b.Run("json", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									if _, err := json.Marshal(floats); err != nil {
+										b.Fatal(err)
+									}
 								}
+							})
+							if supportsJSONv2 {
+								b.Run("jsonv2", func(b *testing.B) {
+									b.ReportAllocs()
+									for i := 0; i < b.N; i++ {
+										if _, err := jsonv2Marshal(floats); err != nil {
+											b.Fatal(err)
+										}
+									}
+								})
 							}
+							b.Run("jsoniter", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									if _, err := jsoniter.Marshal(floats); err != nil {
+										b.Fatal(err)
+									}
+								}
+							})
 						})
-						b.Run("jsoniter/floats", func(b *testing.B) {
-							b.ReportAllocs()
-							for i := 0; i < b.N; i++ {
-								if _, err := jsoniter.Marshal(floats); err != nil {
-									b.Fatal(err)
+						b.Run("histograms", func(b *testing.B) {
+							b.Run("json", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									if _, err := json.Marshal(histograms); err != nil {
+										b.Fatal(err)
+									}
 								}
+							})
+							if supportsJSONv2 {
+								b.Run("jsonv2", func(b *testing.B) {
+									b.ReportAllocs()
+									for i := 0; i < b.N; i++ {
+										if _, err := jsonv2Marshal(histograms); err != nil {
+											b.Fatal(err)
+										}
+									}
+								})
 							}
-						})
-						b.Run("encoding/json/histograms", func(b *testing.B) {
-							b.ReportAllocs()
-							for i := 0; i < b.N; i++ {
-								if _, err := json.Marshal(histograms); err != nil {
-									b.Fatal(err)
+							b.Run("jsoniter", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									if _, err := jsoniter.Marshal(histograms); err != nil {
+										b.Fatal(err)
+									}
 								}
-							}
-						})
-						b.Run("jsoniter/histograms", func(b *testing.B) {
-							b.ReportAllocs()
-							for i := 0; i < b.N; i++ {
-								if _, err := jsoniter.Marshal(histograms); err != nil {
-									b.Fatal(err)
-								}
-							}
+							})
 						})
 					})
 
 					b.Run("unmarshal", func(b *testing.B) {
-						b.Run("encoding/json/floats", func(b *testing.B) {
-							b.ReportAllocs()
-							var m model.Matrix
-							for i := 0; i < b.N; i++ {
-								if err := json.Unmarshal(floatBytes, &m); err != nil {
-									b.Fatal(err)
+						b.Run("floats", func(b *testing.B) {
+							b.Run("json", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									var m model.Matrix
+									if err := json.Unmarshal(floatBytes, &m); err != nil {
+										b.Fatal(err)
+									}
 								}
+							})
+							if supportsJSONv2 {
+								b.Run("jsonv2", func(b *testing.B) {
+									b.ReportAllocs()
+									for i := 0; i < b.N; i++ {
+										var m model.Matrix
+										if err := jsonv2Unmarshal(floatBytes, &m); err != nil {
+											b.Fatal(err)
+										}
+									}
+								})
 							}
+							b.Run("jsoniter", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									var m model.Matrix
+									if err := jsoniter.Unmarshal(floatBytes, &m); err != nil {
+										b.Fatal(err)
+									}
+								}
+							})
 						})
-						b.Run("jsoniter/floats", func(b *testing.B) {
-							b.ReportAllocs()
-							var m model.Matrix
-							for i := 0; i < b.N; i++ {
-								if err := jsoniter.Unmarshal(floatBytes, &m); err != nil {
-									b.Fatal(err)
+						b.Run("histograms", func(b *testing.B) {
+							b.Run("json", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									var m model.Matrix
+									if err := json.Unmarshal(histogramBytes, &m); err != nil {
+										b.Fatal(err)
+									}
 								}
+							})
+							if supportsJSONv2 {
+								b.Run("jsonv2", func(b *testing.B) {
+									b.ReportAllocs()
+									for i := 0; i < b.N; i++ {
+										var m model.Matrix
+										if err := jsonv2Unmarshal(histogramBytes, &m); err != nil {
+											b.Fatal(err)
+										}
+									}
+								})
 							}
-						})
-						b.Run("encoding/json/histograms", func(b *testing.B) {
-							b.ReportAllocs()
-							var m model.Matrix
-							for i := 0; i < b.N; i++ {
-								if err := json.Unmarshal(histogramBytes, &m); err != nil {
-									b.Fatal(err)
+							b.Run("jsoniter", func(b *testing.B) {
+								b.ReportAllocs()
+								for i := 0; i < b.N; i++ {
+									var m model.Matrix
+									if err := jsoniter.Unmarshal(histogramBytes, &m); err != nil {
+										b.Fatal(err)
+									}
 								}
-							}
-						})
-						b.Run("jsoniter/histograms", func(b *testing.B) {
-							b.ReportAllocs()
-							var m model.Matrix
-							for i := 0; i < b.N; i++ {
-								if err := jsoniter.Unmarshal(histogramBytes, &m); err != nil {
-									b.Fatal(err)
-								}
-							}
+							})
 						})
 					})
 				})

--- a/api/prometheus/v1/api_bench_test_127.go
+++ b/api/prometheus/v1/api_bench_test_127.go
@@ -1,0 +1,26 @@
+//go:build go1.27
+
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	jsonv2 "encoding/json/v2"
+)
+
+const supportsJSONv2 = true
+
+var jsonv2Marshal = jsonv2.Marshal
+
+var jsonv2Unmarshal = jsonv2.Unmarshal

--- a/api/prometheus/v1/api_bench_test_pre127.go
+++ b/api/prometheus/v1/api_bench_test_pre127.go
@@ -1,0 +1,28 @@
+//go:build !go1.27
+
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "errors"
+
+const supportsJSONv2 = false
+
+func jsonv2Marshal(v any) ([]byte, error) {
+	return nil, errors.New("unsupported")
+}
+
+func jsonv2Unmarshal(data []byte, v any) error {
+	return errors.New("unsupported")
+}


### PR DESCRIPTION
Conditionally benchmarks Go 1.27 stdlib json/v2 when run with Go 1.27 (skips json/v2 when not run on Go 1.27). Part of gathering test data for https://github.com/prometheus/client_golang/issues/2105

Reformats the benchmark names to group what is being tested with the different encoder/decoder as the last test name segment

Best reviewed ignoring whitespace - https://github.com/prometheus/client_golang/pull/2107/changes?w=1

cc @bwplotka 