### PR TITLE
RuleGroup: use stdlib for json decoding, optimize decoding

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -761,36 +761,57 @@ func (rg *RuleGroup) UnmarshalJSON(b []byte) error {
 	rg.Interval = v.Interval
 
 	for _, rule := range v.Rules {
-		alertingRule := AlertingRule{}
-		if err := gojson.Unmarshal(rule, &alertingRule); err == nil {
+		ruleType, err := unmarshalRuleType(rule)
+		if err != nil {
+			return err
+		}
+		switch ruleType {
+		case RuleTypeAlerting:
+			alertingRule := AlertingRule{}
+			if err := alertingRule.unmarshalTypeCheckedJSON(rule); err != nil {
+				return err
+			}
 			rg.Rules = append(rg.Rules, alertingRule)
-			continue
-		}
-		recordingRule := RecordingRule{}
-		if err := gojson.Unmarshal(rule, &recordingRule); err == nil {
+		case RuleTypeRecording:
+			recordingRule := RecordingRule{}
+			if err := recordingRule.unmarshalTypeCheckedJSON(rule); err != nil {
+				return err
+			}
 			rg.Rules = append(rg.Rules, recordingRule)
-			continue
+		default:
+			return errors.New("failed to decode JSON into an alerting or recording rule")
 		}
-		return errors.New("failed to decode JSON into an alerting or recording rule")
 	}
 
 	return nil
 }
 
-func (r *AlertingRule) UnmarshalJSON(b []byte) error {
+func unmarshalRuleType(b []byte) (RuleType, error) {
 	v := struct {
 		Type string `json:"type"`
 	}{}
 	if err := gojson.Unmarshal(b, &v); err != nil {
-		return err
+		return RuleType(""), err
 	}
 	if v.Type == "" {
-		return errors.New("type field not present in rule")
+		return RuleType(""), errors.New("type field not present in rule")
 	}
-	if v.Type != string(RuleTypeAlerting) {
-		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeAlerting), v.Type)
-	}
+	return RuleType(v.Type), nil
+}
 
+func (r *AlertingRule) UnmarshalJSON(b []byte) error {
+	ruleType, err := unmarshalRuleType(b)
+	if err != nil {
+		return err
+	}
+	if ruleType != RuleTypeAlerting {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeAlerting), ruleType)
+	}
+	return r.unmarshalTypeCheckedJSON(b)
+}
+
+// unmarshalTypeCheckedJSON unmarshals json with the type field already verified to be RuleTypeAlerting
+func (r *AlertingRule) unmarshalTypeCheckedJSON(b []byte) error {
 	rule := struct {
 		Name           string         `json:"name"`
 		Query          string         `json:"query"`
@@ -823,19 +844,18 @@ func (r *AlertingRule) UnmarshalJSON(b []byte) error {
 }
 
 func (r *RecordingRule) UnmarshalJSON(b []byte) error {
-	v := struct {
-		Type string `json:"type"`
-	}{}
-	if err := gojson.Unmarshal(b, &v); err != nil {
+	ruleType, err := unmarshalRuleType(b)
+	if err != nil {
 		return err
 	}
-	if v.Type == "" {
-		return errors.New("type field not present in rule")
+	if ruleType != RuleTypeRecording {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeRecording), ruleType)
 	}
-	if v.Type != string(RuleTypeRecording) {
-		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeRecording), v.Type)
-	}
+	return r.unmarshalTypeCheckedJSON(b)
+}
 
+// unmarshalTypeCheckedJSON unmarshals json with the type field already verified to be RuleTypeRecording
+func (r *RecordingRule) unmarshalTypeCheckedJSON(b []byte) error {
 	rule := struct {
 		Name           string         `json:"name"`
 		Query          string         `json:"query"`

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -810,37 +810,11 @@ func (r *AlertingRule) UnmarshalJSON(b []byte) error {
 	return r.unmarshalTypeCheckedJSON(b)
 }
 
+type alertingRuleInternal AlertingRule
+
 // unmarshalTypeCheckedJSON unmarshals json with the type field already verified to be RuleTypeAlerting
 func (r *AlertingRule) unmarshalTypeCheckedJSON(b []byte) error {
-	rule := struct {
-		Name           string         `json:"name"`
-		Query          string         `json:"query"`
-		Duration       float64        `json:"duration"`
-		Labels         model.LabelSet `json:"labels"`
-		Annotations    model.LabelSet `json:"annotations"`
-		Alerts         []*Alert       `json:"alerts"`
-		Health         RuleHealth     `json:"health"`
-		LastError      string         `json:"lastError,omitempty"`
-		EvaluationTime float64        `json:"evaluationTime"`
-		LastEvaluation time.Time      `json:"lastEvaluation"`
-		State          string         `json:"state"`
-	}{}
-	if err := gojson.Unmarshal(b, &rule); err != nil {
-		return err
-	}
-	r.Health = rule.Health
-	r.Annotations = rule.Annotations
-	r.Name = rule.Name
-	r.Query = rule.Query
-	r.Alerts = rule.Alerts
-	r.Duration = rule.Duration
-	r.Labels = rule.Labels
-	r.LastError = rule.LastError
-	r.EvaluationTime = rule.EvaluationTime
-	r.LastEvaluation = rule.LastEvaluation
-	r.State = rule.State
-
-	return nil
+	return gojson.Unmarshal(b, (*alertingRuleInternal)(r))
 }
 
 func (r *RecordingRule) UnmarshalJSON(b []byte) error {
@@ -854,29 +828,11 @@ func (r *RecordingRule) UnmarshalJSON(b []byte) error {
 	return r.unmarshalTypeCheckedJSON(b)
 }
 
+type recordingRuleInternal RecordingRule
+
 // unmarshalTypeCheckedJSON unmarshals json with the type field already verified to be RuleTypeRecording
 func (r *RecordingRule) unmarshalTypeCheckedJSON(b []byte) error {
-	rule := struct {
-		Name           string         `json:"name"`
-		Query          string         `json:"query"`
-		Labels         model.LabelSet `json:"labels,omitempty"`
-		Health         RuleHealth     `json:"health"`
-		LastError      string         `json:"lastError,omitempty"`
-		EvaluationTime float64        `json:"evaluationTime"`
-		LastEvaluation time.Time      `json:"lastEvaluation"`
-	}{}
-	if err := gojson.Unmarshal(b, &rule); err != nil {
-		return err
-	}
-	r.Health = rule.Health
-	r.Labels = rule.Labels
-	r.Name = rule.Name
-	r.LastError = rule.LastError
-	r.Query = rule.Query
-	r.EvaluationTime = rule.EvaluationTime
-	r.LastEvaluation = rule.LastEvaluation
-
-	return nil
+	return gojson.Unmarshal(b, (*recordingRuleInternal)(r))
 }
 
 func (qr *queryResult) UnmarshalJSON(b []byte) error {

--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -17,6 +17,7 @@ package v1
 
 import (
 	"context"
+	gojson "encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -745,13 +746,13 @@ type Stat struct {
 
 func (rg *RuleGroup) UnmarshalJSON(b []byte) error {
 	v := struct {
-		Name     string            `json:"name"`
-		File     string            `json:"file"`
-		Interval float64           `json:"interval"`
-		Rules    []json.RawMessage `json:"rules"`
+		Name     string              `json:"name"`
+		File     string              `json:"file"`
+		Interval float64             `json:"interval"`
+		Rules    []gojson.RawMessage `json:"rules"`
 	}{}
 
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := gojson.Unmarshal(b, &v); err != nil {
 		return err
 	}
 
@@ -761,12 +762,12 @@ func (rg *RuleGroup) UnmarshalJSON(b []byte) error {
 
 	for _, rule := range v.Rules {
 		alertingRule := AlertingRule{}
-		if err := json.Unmarshal(rule, &alertingRule); err == nil {
+		if err := gojson.Unmarshal(rule, &alertingRule); err == nil {
 			rg.Rules = append(rg.Rules, alertingRule)
 			continue
 		}
 		recordingRule := RecordingRule{}
-		if err := json.Unmarshal(rule, &recordingRule); err == nil {
+		if err := gojson.Unmarshal(rule, &recordingRule); err == nil {
 			rg.Rules = append(rg.Rules, recordingRule)
 			continue
 		}
@@ -780,7 +781,7 @@ func (r *AlertingRule) UnmarshalJSON(b []byte) error {
 	v := struct {
 		Type string `json:"type"`
 	}{}
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := gojson.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	if v.Type == "" {
@@ -803,7 +804,7 @@ func (r *AlertingRule) UnmarshalJSON(b []byte) error {
 		LastEvaluation time.Time      `json:"lastEvaluation"`
 		State          string         `json:"state"`
 	}{}
-	if err := json.Unmarshal(b, &rule); err != nil {
+	if err := gojson.Unmarshal(b, &rule); err != nil {
 		return err
 	}
 	r.Health = rule.Health
@@ -825,7 +826,7 @@ func (r *RecordingRule) UnmarshalJSON(b []byte) error {
 	v := struct {
 		Type string `json:"type"`
 	}{}
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := gojson.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	if v.Type == "" {
@@ -844,7 +845,7 @@ func (r *RecordingRule) UnmarshalJSON(b []byte) error {
 		EvaluationTime float64        `json:"evaluationTime"`
 		LastEvaluation time.Time      `json:"lastEvaluation"`
 	}{}
-	if err := json.Unmarshal(b, &rule); err != nil {
+	if err := gojson.Unmarshal(b, &rule); err != nil {
 		return err
 	}
 	r.Health = rule.Health
@@ -1296,7 +1297,7 @@ func (h *httpAPI) Rules(ctx context.Context, matches []string) (RulesResult, err
 	}
 
 	var res RulesResult
-	err = json.Unmarshal(body, &res)
+	err = gojson.Unmarshal(body, &res)
 	return res, err
 }
 

--- a/api/prometheus/v1/api_bench_test.go
+++ b/api/prometheus/v1/api_bench_test.go
@@ -258,14 +258,14 @@ func BenchmarkRuleGroup(b *testing.B) {
 
 	b.Run("streaming", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if err := jsoniter.NewDecoder(bytes.NewReader(data)).Decode(&RuleGroup{}); err != nil {
+			if err := json.NewDecoder(bytes.NewReader(data)).Decode(&RuleGroup{}); err != nil {
 				b.Fatal(err)
 			}
 		}
 	})
 	b.Run("unmarshal", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if err := jsoniter.Unmarshal(data, &RuleGroup{}); err != nil {
+			if err := json.Unmarshal(data, &RuleGroup{}); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/api/prometheus/v1/api_bench_test.go
+++ b/api/prometheus/v1/api_bench_test.go
@@ -13,8 +13,10 @@
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -196,4 +198,76 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkRuleGroup(b *testing.B) {
+	alertingRuleJSON, err := json.Marshal(struct {
+		Type         RuleType `json:"type"`
+		AlertingRule `json:""`
+	}{
+		Type: RuleTypeAlerting,
+		AlertingRule: AlertingRule{
+			Name:        "HighRequestLatency",
+			Query:       "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5",
+			Duration:    600,
+			Labels:      model.LabelSet{"severity": "page"},
+			Annotations: model.LabelSet{"summary": "High request latency"},
+			Alerts: []*Alert{{
+				ActiveAt:    time.Now().UTC(),
+				Annotations: model.LabelSet{"summary": "High request latency"},
+				Labels:      model.LabelSet{"alertname": "HighRequestLatency", "severity": "page"},
+				State:       AlertStateFiring,
+				Value:       "1e+00",
+			}},
+			Health:         RuleHealthGood,
+			LastError:      "Unknown",
+			EvaluationTime: 1,
+			LastEvaluation: time.Now().Round(time.Millisecond).UTC(),
+			State:          "state",
+		},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Log("alerting:", string(alertingRuleJSON))
+
+	recordingRuleJSON, err := json.Marshal(struct {
+		Type          RuleType `json:"type"`
+		RecordingRule `json:""`
+	}{
+		Type: RuleTypeRecording,
+		RecordingRule: RecordingRule{
+			Name:           "job:http_inprogress_requests:sum",
+			Query:          "sum(http_inprogress_requests) by (job)",
+			Labels:         model.LabelSet{"severity": "page"},
+			Health:         RuleHealthGood,
+			LastError:      "Unknown",
+			EvaluationTime: 1,
+			LastEvaluation: time.Now().Round(time.Millisecond).UTC(),
+		},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Log("recording:", string(recordingRuleJSON))
+
+	data := []byte(`{
+"name":"myname","file":"myfile","interval":0.0000005,"rules":[` +
+		string(alertingRuleJSON) + strings.Repeat(","+string(alertingRuleJSON), 100) + strings.Repeat(","+string(recordingRuleJSON), 100) +
+		`]}`)
+
+	b.Run("streaming", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := jsoniter.NewDecoder(bytes.NewReader(data)).Decode(&RuleGroup{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("unmarshal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := jsoniter.Unmarshal(data, &RuleGroup{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
cc @bwplotka 

part of https://github.com/prometheus/client_golang/issues/2105

1. Adds a benchmark for RuleGroup decoding
2. Switches to stdlib
3. Avoids decoding rule bytes multiple times
4. Avoids struct copies

Allocs and bytes consumed are significantly better than json-iter on both Go 1.26 and 1.27

CPU is worse on Go 1.26, better on Go 1.27.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/client_golang/api/prometheus/v1
cpu: Apple M4 Pro
                       │    main     │              go1.26.6               │              go1.27.1              │
                       │   sec/op    │    sec/op     vs base               │   sec/op     vs base               │
RuleGroup/streaming-14   944.5µ ± 1%   1551.7µ ± 0%  +64.28% (p=0.002 n=6)   787.3µ ± 3%  -16.64% (p=0.002 n=6)
RuleGroup/unmarshal-14   885.9µ ± 1%   1521.7µ ± 1%  +71.76% (p=0.002 n=6)   722.0µ ± 2%  -18.50% (p=0.002 n=6)
geomean                  914.7µ         1.537m       +67.98%                 754.0µ       -17.58%

                       │     main      │              go1.26.6               │              go1.27.1               │
                       │     B/op      │     B/op      vs base               │     B/op      vs base               │
RuleGroup/streaming-14   1293.9Ki ± 0%   832.7Ki ± 0%  -35.64% (p=0.002 n=6)   620.5Ki ± 0%  -52.04% (p=0.002 n=6)
RuleGroup/unmarshal-14    998.0Ki ± 0%   578.3Ki ± 0%  -42.05% (p=0.002 n=6)   363.5Ki ± 0%  -63.57% (p=0.002 n=6)
geomean                   1.110Mi        693.9Ki       -38.93%                 475.0Ki       -58.20%

                       │     main     │              go1.26.6              │              go1.27.1              │
                       │  allocs/op   │  allocs/op   vs base               │  allocs/op   vs base               │
RuleGroup/streaming-14   27.396k ± 0%   9.614k ± 0%  -64.91% (p=0.002 n=6)   3.868k ± 0%  -85.88% (p=0.002 n=6)
RuleGroup/unmarshal-14   27.314k ± 0%   9.601k ± 0%  -64.85% (p=0.002 n=6)   3.850k ± 0%  -85.90% (p=0.002 n=6)
geomean                   27.35k        9.607k       -64.88%                 3.859k       -85.89%
```