### PR TITLE
Use stdlib to decode apiResult envelope

### DIFF
--- a/api/prometheus/v1/api.go
+++ b/api/prometheus/v1/api.go
@@ -1454,12 +1454,12 @@ type apiClientImpl struct {
 }
 
 type apiResponse struct {
-	Status    string          `json:"status"`
-	Data      json.RawMessage `json:"data"`
-	ErrorType ErrorType       `json:"errorType"`
-	Error     string          `json:"error"`
-	Warnings  []string        `json:"warnings,omitempty"`
-	Infos     []string        `json:"infos,omitempty"`
+	Status    string            `json:"status"`
+	Data      gojson.RawMessage `json:"data"`
+	ErrorType ErrorType         `json:"errorType"`
+	Error     string            `json:"error"`
+	Warnings  []string          `json:"warnings,omitempty"`
+	Infos     []string          `json:"infos,omitempty"`
 }
 
 func apiError(code int) bool {
@@ -1501,7 +1501,7 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 	var result apiResponse
 
 	if http.StatusNoContent != code {
-		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
+		if jsonErr := gojson.Unmarshal(body, &result); jsonErr != nil {
 			return resp, body, nil, nil, &Error{
 				Type: ErrBadResponse,
 				Msg:  jsonErr.Error(),

--- a/api/prometheus/v1/api_bench_test.go
+++ b/api/prometheus/v1/api_bench_test.go
@@ -15,6 +15,7 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -245,6 +246,134 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 						})
 					})
 				})
+			}
+		})
+	}
+}
+
+func BenchmarkAPIResponse(b *testing.B) {
+	type apiResponseTest struct {
+		name string
+		data []byte
+	}
+
+	var testcases []apiResponseTest
+	addTestcase := func(name string, v any) {
+		data, err := json.Marshal(v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		testcases = append(testcases, apiResponseTest{
+			name: name,
+			data: data,
+		})
+	}
+
+	addTestcase("AlertsResult", AlertsResult{Alerts: []Alert{{
+		ActiveAt:    time.Unix(1, 0),
+		Annotations: model.LabelSet{"key": "value"},
+		Labels:      model.LabelSet{"key": "value"},
+		State:       AlertStateFiring,
+		Value:       "somevalue",
+	}}})
+	addTestcase("AlertManagersResult", AlertManagersResult{
+		Active:  []AlertManager{{URL: "https://example.com"}},
+		Dropped: []AlertManager{{URL: "https://example.com"}},
+	})
+	addTestcase("ConfigResult", ConfigResult{
+		YAML: "somekey: somevalue",
+	})
+	addTestcase("FlagsResult", FlagsResult{"key": "value"})
+	addTestcase("BuildinfoResult", BuildinfoResult{
+		Version:   "1.0.0",
+		Revision:  "v12",
+		Branch:    "dev",
+		BuildUser: "default",
+		BuildDate: "2026-01-02",
+		GoVersion: "1.26.6",
+	})
+	addTestcase("RuntimeinfoResult", RuntimeinfoResult{})
+	addTestcase("model.LabelValues", model.LabelValues{"value1", "value2"})
+	addTestcase("SnapshotResult", SnapshotResult{Name: "name"})
+	addTestcase("TargetsResult", TargetsResult{
+		Active:  []ActiveTarget{},
+		Dropped: []DroppedTarget{},
+	})
+	addTestcase("[]MetricMetadata", []MetricMetadata{{
+		Target: map[string]string{"key": "value"},
+		Metric: "mymetric",
+		Type:   MetricTypeGauge,
+		Help:   "help text",
+		Unit:   "unit",
+	}})
+	addTestcase("map[string][]Metadata", map[string][]Metadata{
+		"default": {{
+			Type: "default",
+			Help: "help text",
+			Unit: "unit",
+		}},
+	})
+	addTestcase("TSDBResult", TSDBResult{
+		HeadStats: TSDBHeadStats{
+			NumSeries:     1000,
+			NumLabelPairs: 1000,
+			ChunkCount:    10,
+			MinTime:       1,
+			MaxTime:       1000,
+		},
+		SeriesCountByMetricName:     []Stat{{Name: "statname", Value: 12345}},
+		LabelValueCountByLabelName:  []Stat{{Name: "statname", Value: 12345}},
+		MemoryInBytesByLabelName:    []Stat{{Name: "statname", Value: 12345}},
+		SeriesCountByLabelValuePair: []Stat{{Name: "statname", Value: 12345}},
+	})
+	addTestcase("TSDBBlocksResult", TSDBBlocksResult{
+		Status: "ok",
+		Data: TSDBBlocksData{
+			Blocks: []TSDBBlocksBlockMetadata{{
+				Ulid:    "ulid",
+				MinTime: 1,
+				MaxTime: 1000,
+				Stats: TSDBBlocksStats{
+					NumSamples: 1000,
+					NumSeries:  1000,
+					NumChunks:  1000,
+				},
+				Compaction: TSDBBlocksCompaction{
+					Level:   1234,
+					Sources: []string{"sourcea"},
+				},
+				Version: 1,
+			}},
+		},
+	})
+	addTestcase("WalReplayStatus", WalReplayStatus{Min: 1, Max: 1000, Current: 500})
+	addTestcase("[]ExemplarQueryResult", []ExemplarQueryResult{{
+		SeriesLabels: model.LabelSet{"key": "value"},
+		Exemplars: []Exemplar{{
+			Labels:    model.LabelSet{"key": "value"},
+			Value:     model.SampleValue(1234.567),
+			Timestamp: model.Time(1234),
+		}},
+	}})
+
+	for _, size := range []int{10, 100, 1000} {
+		floats, histograms := generateData(size, size)
+		addTestcase(fmt.Sprintf("floats-%d", size), floats)
+		addTestcase(fmt.Sprintf("histograms-%d", size), histograms)
+	}
+
+	for _, tc := range testcases {
+		data, err := json.Marshal(apiResponse{Status: "ok", Data: tc.data})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Log(string(data))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				var r apiResponse
+				if err := json.Unmarshal(data, &r); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/api/prometheus/v1/api_test.go
+++ b/api/prometheus/v1/api_test.go
@@ -15,6 +15,7 @@ package v1
 
 import (
 	"context"
+	gojson "encoding/json"
 	"errors"
 	"io"
 	"math"
@@ -1425,7 +1426,7 @@ func (c *testClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 	case string:
 		b = []byte(v)
 	default:
-		b, err = json.Marshal(v)
+		b, err = gojson.Marshal(v)
 		if err != nil {
 			c.Fatal(err)
 		}
@@ -1444,7 +1445,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusUnprocessableEntity,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`null`),
+				Data:      gojson.RawMessage(`null`),
 				ErrorType: ErrBadData,
 				Error:     "failed",
 			},
@@ -1458,7 +1459,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusUnprocessableEntity,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`"test"`),
+				Data:      gojson.RawMessage(`"test"`),
 				ErrorType: ErrTimeout,
 				Error:     "timed out",
 			},
@@ -1490,7 +1491,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusBadRequest,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`null`),
+				Data:      gojson.RawMessage(`null`),
 				ErrorType: ErrBadData,
 				Error:     "end timestamp must not be before start time",
 			},
@@ -1504,14 +1505,14 @@ func TestAPIClientDo(t *testing.T) {
 			response: "bad json",
 			expectedErr: &Error{
 				Type: ErrBadResponse,
-				Msg:  "readObjectStart: expect { or n, but found b, error found in #1 byte of ...|bad json|..., bigger context ...|bad json|...",
+				Msg:  "invalid character 'b' looking for beginning of value",
 			},
 		},
 		{
 			code: http.StatusUnprocessableEntity,
 			response: &apiResponse{
 				Status: "success",
-				Data:   json.RawMessage(`"test"`),
+				Data:   gojson.RawMessage(`"test"`),
 			},
 			expectedErr: &Error{
 				Type: ErrBadResponse,
@@ -1522,7 +1523,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusUnprocessableEntity,
 			response: &apiResponse{
 				Status:    "success",
-				Data:      json.RawMessage(`"test"`),
+				Data:      gojson.RawMessage(`"test"`),
 				ErrorType: ErrTimeout,
 				Error:     "timed out",
 			},
@@ -1535,7 +1536,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusOK,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`"test"`),
+				Data:      gojson.RawMessage(`"test"`),
 				ErrorType: ErrTimeout,
 				Error:     "timed out",
 			},
@@ -1548,7 +1549,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusOK,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`"test"`),
+				Data:      gojson.RawMessage(`"test"`),
 				ErrorType: ErrTimeout,
 				Error:     "timed out",
 				Warnings:  []string{"a"},
@@ -1563,7 +1564,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusOK,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`"test"`),
+				Data:      gojson.RawMessage(`"test"`),
 				ErrorType: ErrTimeout,
 				Error:     "timed out",
 				Infos:     []string{"b"},
@@ -1578,7 +1579,7 @@ func TestAPIClientDo(t *testing.T) {
 			code: http.StatusOK,
 			response: &apiResponse{
 				Status:    "error",
-				Data:      json.RawMessage(`"test"`),
+				Data:      gojson.RawMessage(`"test"`),
 				ErrorType: ErrTimeout,
 				Error:     "timed out",
 				Warnings:  []string{"a"},
@@ -1958,7 +1959,7 @@ func TestDoGetFallback(t *testing.T) {
 	// Start a local HTTP server.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		req.ParseForm()
-		testResp, _ := json.Marshal(&testResponse{
+		testResp, _ := gojson.Marshal(&testResponse{
 			Values: req.Form.Encode(),
 			Method: req.Method,
 		})
@@ -1967,7 +1968,7 @@ func TestDoGetFallback(t *testing.T) {
 			Data: testResp,
 		}
 
-		body, _ := json.Marshal(apiResp)
+		body, _ := gojson.Marshal(apiResp)
 
 		if req.Method == http.MethodPost {
 			if req.URL.Path == "/blockPost403" {


### PR DESCRIPTION
cc @bwplotka 

part of https://github.com/prometheus/client_golang/issues/2105

1. Adds a benchmark for apiResult decoding
2. Switches to stdlib for the envelope decoding

Benchmark results of switching the envelope decode to stdlib:

On Go 1.26:
* CPU is about 180% slower than json-iter
* Bytes range from ~flat (on larger complex responses) to ~2x json-iter
* Allocs are consistently better, and *way* better than json-iter on large complex responses

On Go 1.27:
* CPU is about 35% slower than json-iter
* Bytes are improved 0-38% compared with json-iter
* Allocs are improved 70-100% (!) over json-iter

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/client_golang/api/prometheus/v1
cpu: Apple M4 Pro
                                     │    main     │               go1.26.6               │              go1.27.1               │
                                     │   sec/op    │    sec/op     vs base                │    sec/op     vs base               │
APIResponse/AlertsResult-14            364.8n ± 1%   1054.0n ± 1%  +188.93% (p=0.002 n=6)   470.2n ±  1%  +28.88% (p=0.002 n=6)
APIResponse/AlertManagersResult-14     307.2n ± 1%    931.8n ± 1%  +203.34% (p=0.002 n=6)   408.9n ±  2%  +33.11% (p=0.002 n=6)
APIResponse/ConfigResult-14            191.0n ± 0%    577.6n ± 1%  +202.30% (p=0.002 n=6)   303.3n ±  2%  +58.75% (p=0.002 n=6)
APIResponse/FlagsResult-14             187.5n ± 1%    523.5n ± 0%  +179.13% (p=0.002 n=6)   297.6n ±  1%  +58.68% (p=0.002 n=6)
APIResponse/BuildinfoResult-14         311.1n ± 3%    904.2n ± 1%  +190.65% (p=0.002 n=6)   422.6n ±  2%  +35.84% (p=0.002 n=6)
APIResponse/RuntimeinfoResult-14       436.3n ± 2%   1258.0n ± 1%  +188.30% (p=0.002 n=6)   523.2n ±  1%  +19.90% (p=0.002 n=6)
APIResponse/model.LabelValues-14       189.3n ± 1%    546.9n ± 0%  +188.80% (p=0.002 n=6)   300.2n ±  1%  +58.54% (p=0.002 n=6)
APIResponse/SnapshotResult-14          191.6n ± 2%    535.3n ± 1%  +179.38% (p=0.002 n=6)   299.2n ±  1%  +56.18% (p=0.002 n=6)
APIResponse/TargetsResult-14           234.8n ± 1%    644.1n ± 1%  +174.32% (p=0.002 n=6)   331.9n ±  1%  +41.35% (p=0.002 n=6)
APIResponse/[]MetricMetadata-14        310.4n ± 1%    856.9n ± 0%  +176.05% (p=0.002 n=6)   422.1n ±  1%  +35.97% (p=0.002 n=6)
APIResponse/map[string][]Metadata-14   281.9n ± 1%    744.9n ± 1%  +164.29% (p=0.002 n=6)   379.6n ±  1%  +34.66% (p=0.002 n=6)
APIResponse/TSDBResult-14              676.0n ± 1%   1869.5n ± 1%  +176.55% (p=0.002 n=6)   792.2n ±  1%  +17.19% (p=0.002 n=6)
APIResponse/TSDBBlocksResult-14        518.7n ± 1%   1328.0n ± 0%  +156.02% (p=0.002 n=6)   597.2n ±  1%  +15.12% (p=0.002 n=6)
APIResponse/WalReplayStatus-14         247.3n ± 1%    615.8n ± 1%  +148.99% (p=0.002 n=6)   338.6n ± 14%  +36.92% (p=0.002 n=6)
APIResponse/[]ExemplarQueryResult-14   351.7n ± 1%    955.2n ± 1%  +171.65% (p=0.002 n=6)   450.0n ±  1%  +27.97% (p=0.002 n=6)
APIResponse/floats-10-14               3.875µ ± 2%   10.806µ ± 1%  +178.90% (p=0.002 n=6)   5.447µ ±  4%  +40.59% (p=0.002 n=6)
APIResponse/histograms-10-14           41.61µ ± 3%   143.34µ ± 0%  +244.52% (p=0.002 n=6)   49.72µ ±  1%  +19.50% (p=0.002 n=6)
APIResponse/floats-100-14              280.0µ ± 2%    790.3µ ± 1%  +182.22% (p=0.002 n=6)   423.2µ ±  2%  +51.14% (p=0.002 n=6)
APIResponse/histograms-100-14          4.000m ± 1%   14.083m ± 1%  +252.05% (p=0.002 n=6)   4.805m ±  2%  +20.12% (p=0.002 n=6)
APIResponse/floats-1000-14             27.73m ± 2%    77.84m ± 1%  +180.70% (p=0.002 n=6)   41.97m ±  3%  +51.34% (p=0.002 n=6)
APIResponse/histograms-1000-14         399.9m ± 2%   1424.6m ± 1%  +256.21% (p=0.002 n=6)   485.5m ±  4%  +21.39% (p=0.002 n=6)
geomean                                3.126µ         9.016µ       +188.41%                 4.238µ        +35.58%

                                     │     main     │               go1.26.6               │              go1.27.1               │
                                     │     B/op     │     B/op      vs base                │     B/op      vs base               │
APIResponse/AlertsResult-14              416.0 ± 0%     624.0 ± 0%   +50.00% (p=0.002 n=6)     288.0 ± 0%  -30.77% (p=0.002 n=6)
APIResponse/AlertManagersResult-14       360.0 ± 0%     512.0 ± 0%   +42.22% (p=0.002 n=6)     240.0 ± 0%  -33.33% (p=0.002 n=6)
APIResponse/ConfigResult-14              192.0 ± 0%     400.0 ± 0%  +108.33% (p=0.002 n=6)     160.0 ± 0%  -16.67% (p=0.002 n=6)
APIResponse/FlagsResult-14               192.0 ± 0%     384.0 ± 0%  +100.00% (p=0.002 n=6)     144.0 ± 0%  -25.00% (p=0.002 n=6)
APIResponse/BuildinfoResult-14           384.0 ± 0%     496.0 ± 0%   +29.17% (p=0.002 n=6)     256.0 ± 0%  -33.33% (p=0.002 n=6)
APIResponse/RuntimeinfoResult-14         536.0 ± 0%     592.0 ± 0%   +10.45% (p=0.002 n=6)     352.0 ± 0%  -34.33% (p=0.002 n=6)
APIResponse/model.LabelValues-14         192.0 ± 0%     392.0 ± 0%  +104.17% (p=0.002 n=6)     152.0 ± 0%  -20.83% (p=0.002 n=6)
APIResponse/SnapshotResult-14            192.0 ± 0%     384.0 ± 0%  +100.00% (p=0.002 n=6)     144.0 ± 0%  -25.00% (p=0.002 n=6)
APIResponse/TargetsResult-14             288.0 ± 0%     448.0 ± 0%   +55.56% (p=0.002 n=6)     176.0 ± 0%  -38.89% (p=0.002 n=6)
APIResponse/[]MetricMetadata-14          320.0 ± 0%     496.0 ± 0%   +55.00% (p=0.002 n=6)     224.0 ± 0%  -30.00% (p=0.002 n=6)
APIResponse/map[string][]Metadata-14     296.0 ± 0%     480.0 ± 0%   +62.16% (p=0.002 n=6)     208.0 ± 0%  -29.73% (p=0.002 n=6)
APIResponse/TSDBResult-14                784.0 ± 0%     752.0 ± 0%    -4.08% (p=0.002 n=6)     480.0 ± 0%  -38.78% (p=0.002 n=6)
APIResponse/TSDBBlocksResult-14          528.0 ± 0%     672.0 ± 0%   +27.27% (p=0.002 n=6)     336.0 ± 0%  -36.36% (p=0.002 n=6)
APIResponse/WalReplayStatus-14           272.0 ± 0%     416.0 ± 0%   +52.94% (p=0.002 n=6)     176.0 ± 0%  -35.29% (p=0.002 n=6)
APIResponse/[]ExemplarQueryResult-14     368.0 ± 0%     576.0 ± 0%   +56.52% (p=0.002 n=6)     240.0 ± 0%  -34.78% (p=0.002 n=6)
APIResponse/floats-10-14               3.500Ki ± 0%   3.453Ki ± 0%    -1.34% (p=0.002 n=6)   3.125Ki ± 0%  -10.71% (p=0.002 n=6)
APIResponse/histograms-10-14           42.06Ki ± 0%   40.45Ki ± 0%    -3.83% (p=0.002 n=6)   40.12Ki ± 0%   -4.61% (p=0.002 n=6)
APIResponse/floats-100-14              227.3Ki ± 0%   224.5Ki ± 0%    -1.26% (p=0.002 n=6)   224.1Ki ± 0%   -1.40% (p=0.002 n=6)
APIResponse/histograms-100-14          3.476Mi ± 0%   3.321Mi ± 0%    -4.47% (p=0.002 n=6)   3.320Mi ± 0%   -4.48% (p=0.002 n=6)
APIResponse/floats-1000-14             21.93Mi ± 0%   21.90Mi ± 0%    -0.14% (p=0.002 n=6)   21.90Mi ± 0%   -0.14% (p=0.002 n=6)
APIResponse/histograms-1000-14         353.1Mi ± 0%   337.9Mi ± 0%    -4.33% (p=0.002 n=6)   337.9Mi ± 0%   -4.33% (p=0.002 n=6)
geomean                                3.164Ki        4.257Ki        +34.51%                 2.394Ki       -24.36%

                                     │       main       │               go1.26.6                │              go1.27.1               │
                                     │    allocs/op     │  allocs/op   vs base                  │  allocs/op   vs base                │
APIResponse/AlertsResult-14                 16.000 ± 0%   10.000 ± 0%   -37.50% (p=0.002 n=6)     2.000 ±  0%   -87.50% (p=0.002 n=6)
APIResponse/AlertManagersResult-14          12.000 ± 0%    9.000 ± 0%   -25.00% (p=0.002 n=6)     2.000 ±  0%   -83.33% (p=0.002 n=6)
APIResponse/ConfigResult-14                  8.000 ± 0%    8.000 ± 0%         ~ (p=1.000 n=6) ¹   2.000 ±  0%   -75.00% (p=0.002 n=6)
APIResponse/FlagsResult-14                   8.000 ± 0%    8.000 ± 0%         ~ (p=1.000 n=6) ¹   2.000 ±  0%   -75.00% (p=0.002 n=6)
APIResponse/BuildinfoResult-14              14.000 ± 0%    8.000 ± 0%   -42.86% (p=0.002 n=6)     2.000 ±  0%   -85.71% (p=0.002 n=6)
APIResponse/RuntimeinfoResult-14            18.000 ± 0%    8.000 ± 0%   -55.56% (p=0.002 n=6)     2.000 ±  0%   -88.89% (p=0.002 n=6)
APIResponse/model.LabelValues-14             7.000 ± 0%    8.000 ± 0%   +14.29% (p=0.002 n=6)     2.000 ±  0%   -71.43% (p=0.002 n=6)
APIResponse/SnapshotResult-14                8.000 ± 0%    8.000 ± 0%         ~ (p=1.000 n=6) ¹   2.000 ±  0%   -75.00% (p=0.002 n=6)
APIResponse/TargetsResult-14                10.000 ± 0%    9.000 ± 0%   -10.00% (p=0.002 n=6)     2.000 ±  0%   -80.00% (p=0.002 n=6)
APIResponse/[]MetricMetadata-14             14.000 ± 0%    9.000 ± 0%   -35.71% (p=0.002 n=6)     2.000 ±  0%   -85.71% (p=0.002 n=6)
APIResponse/map[string][]Metadata-14        12.000 ± 0%    9.000 ± 0%   -25.00% (p=0.002 n=6)     2.000 ±  0%   -83.33% (p=0.002 n=6)
APIResponse/TSDBResult-14                   26.000 ± 0%    9.000 ± 0%   -65.38% (p=0.002 n=6)     2.000 ±  0%   -92.31% (p=0.002 n=6)
APIResponse/TSDBBlocksResult-14             22.000 ± 0%   10.000 ± 0%   -54.55% (p=0.002 n=6)     2.000 ±  0%   -90.91% (p=0.002 n=6)
APIResponse/WalReplayStatus-14              11.000 ± 0%    8.000 ± 0%   -27.27% (p=0.002 n=6)     2.000 ±  0%   -81.82% (p=0.002 n=6)
APIResponse/[]ExemplarQueryResult-14        15.000 ± 0%   10.000 ± 0%   -33.33% (p=0.002 n=6)     2.000 ±  0%   -86.67% (p=0.002 n=6)
APIResponse/floats-10-14                    48.000 ± 0%   10.000 ± 0%   -79.17% (p=0.002 n=6)     2.000 ±  0%   -95.83% (p=0.002 n=6)
APIResponse/histograms-10-14               348.000 ± 0%   10.000 ± 0%   -97.13% (p=0.002 n=6)     2.000 ±  0%   -99.43% (p=0.002 n=6)
APIResponse/floats-100-14                  408.000 ± 0%   10.000 ± 0%   -97.55% (p=0.002 n=6)     2.000 ±  0%   -99.51% (p=0.002 n=6)
APIResponse/histograms-100-14            30408.000 ± 0%   10.000 ± 0%   -99.97% (p=0.002 n=6)     2.000 ±  0%   -99.99% (p=0.002 n=6)
APIResponse/floats-1000-14                4008.000 ± 0%   10.000 ± 0%   -99.75% (p=0.002 n=6)     2.000 ±  0%   -99.95% (p=0.002 n=6)
APIResponse/histograms-1000-14         3004009.000 ± 0%   10.000 ± 0%  -100.00% (p=0.002 n=6)     4.000 ± 50%  -100.00% (p=0.002 n=6)
geomean                                      63.35         9.053        -85.71%                   2.067         -96.74%
¹ all samples are equal
```