### PR TITLE
Modernize micro benchmarks: b.Loop and key=value case names

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -229,7 +229,7 @@ func BenchmarkClient(b *testing.B) {
 	ctx := context.Background()
 
 	for _, sizeKB := range []int{4, 50, 1000, 2000} {
-		b.Run(fmt.Sprintf("%dKB", sizeKB), func(b *testing.B) {
+		b.Run(fmt.Sprintf("size=%dKB", sizeKB), func(b *testing.B) {
 			testServer := httptest.NewServer(serveSpaces{sizeKB})
 			defer testServer.Close()
 
@@ -246,14 +246,12 @@ func BenchmarkClient(b *testing.B) {
 			req := &http.Request{
 				URL: url,
 			}
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, _, err := client.Do(ctx, req)
 				if err != nil {
 					b.Fatalf("Query failed: %v", err)
 				}
 			}
-			b.StopTimer()
 		})
 	}
 }

--- a/api/prometheus/v1/api_bench_test.go
+++ b/api/prometheus/v1/api_bench_test.go
@@ -105,9 +105,9 @@ func generateData(timeseries, datapoints int) (floatMatrix, histogramMatrix mode
 
 func BenchmarkSamplesJsonSerialization(b *testing.B) {
 	for _, timeseriesCount := range []int{10, 100, 1000} {
-		b.Run(strconv.Itoa(timeseriesCount), func(b *testing.B) {
+		b.Run("series="+strconv.Itoa(timeseriesCount), func(b *testing.B) {
 			for _, datapointCount := range []int{10, 100, 1000} {
-				b.Run(strconv.Itoa(datapointCount), func(b *testing.B) {
+				b.Run("dp="+strconv.Itoa(datapointCount), func(b *testing.B) {
 					floats, histograms := generateData(timeseriesCount, datapointCount)
 
 					floatBytes, err := json.Marshal(floats)
@@ -119,57 +119,57 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 						b.Fatalf("Error marshaling: %v", err)
 					}
 
-					b.Run("marshal", func(b *testing.B) {
-						b.Run("floats", func(b *testing.B) {
-							b.Run("json", func(b *testing.B) {
+					b.Run("op=marshal", func(b *testing.B) {
+						b.Run("type=floats", func(b *testing.B) {
+							b.Run("encoder=json", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									if _, err := json.Marshal(floats); err != nil {
 										b.Fatal(err)
 									}
 								}
 							})
 							if supportsJSONv2 {
-								b.Run("jsonv2", func(b *testing.B) {
+								b.Run("encoder=jsonv2", func(b *testing.B) {
 									b.ReportAllocs()
-									for i := 0; i < b.N; i++ {
+									for b.Loop() {
 										if _, err := jsonv2Marshal(floats); err != nil {
 											b.Fatal(err)
 										}
 									}
 								})
 							}
-							b.Run("jsoniter", func(b *testing.B) {
+							b.Run("encoder=jsoniter", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									if _, err := jsoniter.Marshal(floats); err != nil {
 										b.Fatal(err)
 									}
 								}
 							})
 						})
-						b.Run("histograms", func(b *testing.B) {
-							b.Run("json", func(b *testing.B) {
+						b.Run("type=histograms", func(b *testing.B) {
+							b.Run("encoder=json", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									if _, err := json.Marshal(histograms); err != nil {
 										b.Fatal(err)
 									}
 								}
 							})
 							if supportsJSONv2 {
-								b.Run("jsonv2", func(b *testing.B) {
+								b.Run("encoder=jsonv2", func(b *testing.B) {
 									b.ReportAllocs()
-									for i := 0; i < b.N; i++ {
+									for b.Loop() {
 										if _, err := jsonv2Marshal(histograms); err != nil {
 											b.Fatal(err)
 										}
 									}
 								})
 							}
-							b.Run("jsoniter", func(b *testing.B) {
+							b.Run("encoder=jsoniter", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									if _, err := jsoniter.Marshal(histograms); err != nil {
 										b.Fatal(err)
 									}
@@ -178,11 +178,11 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 						})
 					})
 
-					b.Run("unmarshal", func(b *testing.B) {
-						b.Run("floats", func(b *testing.B) {
-							b.Run("json", func(b *testing.B) {
+					b.Run("op=unmarshal", func(b *testing.B) {
+						b.Run("type=floats", func(b *testing.B) {
+							b.Run("encoder=json", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									var m model.Matrix
 									if err := json.Unmarshal(floatBytes, &m); err != nil {
 										b.Fatal(err)
@@ -190,9 +190,9 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 								}
 							})
 							if supportsJSONv2 {
-								b.Run("jsonv2", func(b *testing.B) {
+								b.Run("encoder=jsonv2", func(b *testing.B) {
 									b.ReportAllocs()
-									for i := 0; i < b.N; i++ {
+									for b.Loop() {
 										var m model.Matrix
 										if err := jsonv2Unmarshal(floatBytes, &m); err != nil {
 											b.Fatal(err)
@@ -200,9 +200,9 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 									}
 								})
 							}
-							b.Run("jsoniter", func(b *testing.B) {
+							b.Run("encoder=jsoniter", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									var m model.Matrix
 									if err := jsoniter.Unmarshal(floatBytes, &m); err != nil {
 										b.Fatal(err)
@@ -210,10 +210,10 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 								}
 							})
 						})
-						b.Run("histograms", func(b *testing.B) {
-							b.Run("json", func(b *testing.B) {
+						b.Run("type=histograms", func(b *testing.B) {
+							b.Run("encoder=json", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									var m model.Matrix
 									if err := json.Unmarshal(histogramBytes, &m); err != nil {
 										b.Fatal(err)
@@ -221,9 +221,9 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 								}
 							})
 							if supportsJSONv2 {
-								b.Run("jsonv2", func(b *testing.B) {
+								b.Run("encoder=jsonv2", func(b *testing.B) {
 									b.ReportAllocs()
-									for i := 0; i < b.N; i++ {
+									for b.Loop() {
 										var m model.Matrix
 										if err := jsonv2Unmarshal(histogramBytes, &m); err != nil {
 											b.Fatal(err)
@@ -231,9 +231,9 @@ func BenchmarkSamplesJsonSerialization(b *testing.B) {
 									}
 								})
 							}
-							b.Run("jsoniter", func(b *testing.B) {
+							b.Run("encoder=jsoniter", func(b *testing.B) {
 								b.ReportAllocs()
-								for i := 0; i < b.N; i++ {
+								for b.Loop() {
 									var m model.Matrix
 									if err := jsoniter.Unmarshal(histogramBytes, &m); err != nil {
 										b.Fatal(err)

--- a/prometheus/benchmark_test.go
+++ b/prometheus/benchmark_test.go
@@ -63,24 +63,24 @@ func BenchmarkCounter(b *testing.B) {
 		constraint LabelConstraint
 		counters   fns
 	}{
-		{"With Label Values", nil, fns{deLV}},
-		{"With Label Values and Constraint", twoConstraint, fns{deLV}},
-		{"With triple Label Values", nil, fns{deLV, frLV, nlLV}},
-		{"With triple Label Values and Constraint", twoConstraint, fns{deLV, frLV, nlLV}},
-		{"With repeated Label Values", nil, fns{deLV, deLV}},
-		{"With repeated Label Values and Constraint", twoConstraint, fns{deLV, deLV}},
-		{"With Mapped Labels", nil, fns{deML}},
-		{"With Mapped Labels and Constraint", twoConstraint, fns{deML}},
-		{"With triple Mapped Labels", nil, fns{deML, frML, nlML}},
-		{"With triple Mapped Labels and Constraint", twoConstraint, fns{deML, frML, nlML}},
-		{"With repeated Mapped Labels", nil, fns{deML, deML}},
-		{"With repeated Mapped Labels and Constraint", twoConstraint, fns{deML, deML}},
-		{"With Prepared Mapped Labels", nil, fns{dePML}},
-		{"With Prepared Mapped Labels and Constraint", twoConstraint, fns{dePML}},
-		{"With triple Prepared Mapped Labels", nil, fns{dePML, frPML, nlPML}},
-		{"With triple Prepared Mapped Labels and Constraint", twoConstraint, fns{dePML, frPML, nlPML}},
-		{"With repeated Prepared Mapped Labels", nil, fns{dePML, dePML}},
-		{"With repeated Prepared Mapped Labels and Constraint", twoConstraint, fns{dePML, dePML}},
+		{"labels=values,constraint=no", nil, fns{deLV}},
+		{"labels=values,constraint=yes", twoConstraint, fns{deLV}},
+		{"labels=values-triple,constraint=no", nil, fns{deLV, frLV, nlLV}},
+		{"labels=values-triple,constraint=yes", twoConstraint, fns{deLV, frLV, nlLV}},
+		{"labels=values-repeated,constraint=no", nil, fns{deLV, deLV}},
+		{"labels=values-repeated,constraint=yes", twoConstraint, fns{deLV, deLV}},
+		{"labels=mapped,constraint=no", nil, fns{deML}},
+		{"labels=mapped,constraint=yes", twoConstraint, fns{deML}},
+		{"labels=mapped-triple,constraint=no", nil, fns{deML, frML, nlML}},
+		{"labels=mapped-triple,constraint=yes", twoConstraint, fns{deML, frML, nlML}},
+		{"labels=mapped-repeated,constraint=no", nil, fns{deML, deML}},
+		{"labels=mapped-repeated,constraint=yes", twoConstraint, fns{deML, deML}},
+		{"labels=mapped-prepared,constraint=no", nil, fns{dePML}},
+		{"labels=mapped-prepared,constraint=yes", twoConstraint, fns{dePML}},
+		{"labels=mapped-prepared-triple,constraint=no", nil, fns{dePML, frPML, nlPML}},
+		{"labels=mapped-prepared-triple,constraint=yes", twoConstraint, fns{dePML, frPML, nlPML}},
+		{"labels=mapped-prepared-repeated,constraint=no", nil, fns{dePML, dePML}},
+		{"labels=mapped-prepared-repeated,constraint=yes", twoConstraint, fns{dePML, dePML}},
 	}
 
 	for _, t := range table {
@@ -99,8 +99,7 @@ func BenchmarkCounter(b *testing.B) {
 				},
 			)
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				for _, fn := range t.counters {
 					fn(m).Inc()
 				}
@@ -138,8 +137,7 @@ func BenchmarkCounterNoLabels(b *testing.B) {
 		Help: "A counter to benchmark it.",
 	})
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.Inc()
 	}
 }
@@ -153,8 +151,7 @@ func BenchmarkGaugeWithLabelValues(b *testing.B) {
 		[]string{"one", "two", "three"},
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.WithLabelValues("eins", "zwei", "drei").Set(3.1415)
 	}
 }
@@ -165,8 +162,7 @@ func BenchmarkGaugeNoLabels(b *testing.B) {
 		Help: "A gauge to benchmark it.",
 	})
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.Set(3.1415)
 	}
 }
@@ -181,8 +177,7 @@ func BenchmarkSummaryWithLabelValues(b *testing.B) {
 		[]string{"one", "two", "three"},
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.WithLabelValues("eins", "zwei", "drei").Observe(3.1415)
 	}
 }
@@ -195,8 +190,7 @@ func BenchmarkSummaryNoLabels(b *testing.B) {
 	},
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.Observe(3.1415)
 	}
 }
@@ -210,8 +204,7 @@ func BenchmarkHistogramWithLabelValues(b *testing.B) {
 		[]string{"one", "two", "three"},
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.WithLabelValues("eins", "zwei", "drei").Observe(3.1415)
 	}
 }
@@ -223,8 +216,7 @@ func BenchmarkHistogramNoLabels(b *testing.B) {
 	},
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m.Observe(3.1415)
 	}
 }

--- a/prometheus/go_collector_test.go
+++ b/prometheus/go_collector_test.go
@@ -158,8 +158,7 @@ func TestGoCollectorGC(t *testing.T) {
 func BenchmarkGoCollector(b *testing.B) {
 	c := NewGoCollector().(*goCollector)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ch := make(chan Metric, 8)
 		go func() {
 			// Drain all metrics received until the

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -1486,8 +1486,7 @@ func benchmarkFindBucket(b *testing.B, l int) {
 	}
 	v := float64(l / 2)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		resultFindBucket = h.findBucket(v)
 	}
 }
@@ -1515,8 +1514,7 @@ func BenchmarkFindBucketInf(b *testing.B) {
 	}
 	v := 1000.5
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		resultFindBucket = h.findBucket(v)
 	}
 }
@@ -1528,8 +1526,7 @@ func BenchmarkFindBucketLow(b *testing.B) {
 	}
 	v := -1.1
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		resultFindBucket = h.findBucket(v)
 	}
 }

--- a/prometheus/internal/difflib_test.go
+++ b/prometheus/internal/difflib_test.go
@@ -249,10 +249,8 @@ func TestSplitLines(t *testing.T) {
 func benchmarkSplitLines(b *testing.B, count int) {
 	str := strings.Repeat("foo\n", count)
 
-	b.ResetTimer()
-
 	n := 0
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		n += len(SplitLines(str))
 	}
 }

--- a/prometheus/promhttp/http_test.go
+++ b/prometheus/promhttp/http_test.go
@@ -760,8 +760,8 @@ func BenchmarkCompression(b *testing.B) {
 		}
 
 		for _, benchmark := range benchmarks {
-			b.Run(benchmark.name+"_"+size.name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+			b.Run("op="+benchmark.name+",size="+size.name, func(b *testing.B) {
+				for b.Loop() {
 					writer := httptest.NewRecorder()
 					request, _ := http.NewRequest(http.MethodGet, "/", nil)
 					request.Header.Add(acceptEncodingHeader, benchmark.compressionType)

--- a/prometheus/registry_test.go
+++ b/prometheus/registry_test.go
@@ -749,7 +749,7 @@ func TestHandler(t *testing.T) {
 }
 
 func BenchmarkHandler(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		testHandler(b)
 	}
 }

--- a/prometheus/vec_test.go
+++ b/prometheus/vec_test.go
@@ -971,8 +971,7 @@ func benchmarkMetricVecWith(b *testing.B, labels map[string]string) {
 	)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		vec.With(labels)
 	}
 }
@@ -993,8 +992,8 @@ func benchmarkMetricVecWithLabelValues(b *testing.B, labels map[string][]string)
 	)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		// Varies input across provide map entries based on key size.
 		for j, k := range keys {
 			candidates := labels[k]
@@ -1002,5 +1001,6 @@ func benchmarkMetricVecWithLabelValues(b *testing.B, labels map[string][]string)
 		}
 
 		vec.WithLabelValues(values...)
+		i++
 	}
 }


### PR DESCRIPTION
Migrates the sequential micro benchmarks to `b.Loop` and normalizes `b.Run` case names to the key=value format so benchstat can project on them (following #2107 and [the linked benchmarks guide](https://www.bwplotka.dev/2024/go-microbenchmarks-benchstat/)).

**`b.Loop` migrations** — benchmarks whose bodies are sequential: v1 API JSON serialization (all 12 leaf benchmarks), counter/gauge/summary/histogram vec+scalar benchmarks, GoCollector, Handler, SplitLines, promhttp compression handler, and the API client query benchmark. Redundant `ResetTimer`/`StopTimer` around setup are removed, since `b.Loop` manages the timer and excludes setup automatically.

**Kept on `b.N`** — benchmarks that fan work out across goroutines sized by `b.N` (`benchmarkHistogramObserve/Write`, `benchmarkSummaryObserve/Write`, `BenchmarkCounterWithLabelValuesConcurrent`) and `b.RunParallel` (`BenchmarkParallelCounter`): `b.Loop` covers single-goroutine iteration only. `benchmarkMetricVecWithLabelValues` rotates its label-value input with an explicit counter since `Loop` exposes no index.

**Case renames**:
- v1 API benchmarks: `series=N`, `dp=N`, `op=marshal|unmarshal`, `type=floats|histograms`, `encoder=json|jsonv2|jsoniter`
- API client: `size=NKB`
- promhttp: `op=<name>,size=<name>`
- counter vec table: `labels=<shape>,constraint=<yes|no>`

Verification: `go vet ./api/... ./prometheus/...` clean; smoke runs of the migrated benchmarks (`-benchtime=50x`) and the full `go test ./api/... ./prometheus/ ... ./prometheus/promhttp/...` pass. The two runtime-metrics collector tests (`TestGoCollector_ExposedMetrics`, `TestExpectedRuntimeMetrics`) fail identically on an unmodified checkout with local Go 1.26 — a toolchain-version snapshot mismatch unrelated to this change.

Fixes #2113